### PR TITLE
Fix package description markup.

### DIFF
--- a/proto-lens/proto-lens.cabal
+++ b/proto-lens/proto-lens.cabal
@@ -4,8 +4,11 @@ synopsis:            A lens-based implementation of protocol buffers in Haskell.
 description:
   The proto-lens library provides to protocol buffers using modern
   Haskell language and library patterns.  Specifically, it provides:
+  .
   * Composable field accessors via lenses
+  .
   * Simple field name resolution/overloading via type-level literals
+  .
   * Type-safe reflection and encoding/decoding of messages via GADTs
 
 homepage:            https://github.com/google/proto-lens


### PR DESCRIPTION
You need to use "." to get a line break in the package description field.