### PR TITLE
Fix sdist by pointing it to the generated files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 
 before_install:
   - mkdir -p $HOME/.local/bin
-  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$PATH
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$HOME/.cabal/bin:$PATH
   - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.0.4.3/stack-1.0.4.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'
   - curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-2/protoc-3.0.0-beta-2-linux-x86_64.zip > protoc-release.zip
   - unzip -p protoc-release.zip protoc > $HOME/.local/bin/protoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
 
 before_install:
   - mkdir -p $HOME/.local/bin
-  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$HOME/.cabal/bin:$PATH
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$PATH
   - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.0.4.3/stack-1.0.4.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'
   - curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-2/protoc-3.0.0-beta-2-linux-x86_64.zip > protoc-release.zip
   - unzip -p protoc-release.zip protoc > $HOME/.local/bin/protoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 # Use a lightweight base image; we provide our own build tools.
 language: c
 
-# Use Travis containers to enable caching.
-sudo: false
+sudo: true
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ cache:
   directories:
   - $HOME/.ghc
   - $HOME/.stack
+  - $HOME/.cabal
 
 matrix:
   include:
@@ -16,7 +17,7 @@ matrix:
 
 before_install:
   - mkdir -p $HOME/.local/bin
-  - export PATH=$HOME/.local/bin:$PATH
+  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$HOME/.cabal/bin:$PATH
   - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.0.4.3/stack-1.0.4.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'
   - curl -L https://github.com/google/protobuf/releases/download/v3.0.0-beta-2/protoc-3.0.0-beta-2-linux-x86_64.zip > protoc-release.zip
   - unzip -p protoc-release.zip protoc > $HOME/.local/bin/protoc
@@ -26,9 +27,12 @@ before_install:
 install:
   - stack setup --no-terminal
   - stack build --only-snapshot --no-terminal
+  - cabal --version
+  - cabal update
 
 script:
   # Separate build from test, since build by itself hits some edge cases around
   # custom Setup.hs script dependencies.
   - stack build --haddock --no-haddock-deps
   - stack test --haddock --no-haddock-deps
+  - ./travis-cabal.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 # Use a lightweight base image; we provide our own build tools.
 language: c
 
+# Docker builds make GHC much slower for some reason:
+# https://github.com/travis-ci/travis-ci/issues/5623
 sudo: true
 
 cache:
@@ -28,9 +30,10 @@ before_install:
 install:
   - case "$BUILD" in
       stack)
-        stack setup --no-terminal && stack build --only-snapshot --no-terminal
+        stack setup --no-terminal;
+        stack build --only-snapshot --no-terminal;;
       cabal)
-        cabal update
+        cabal update;;
     esac
 
 script:
@@ -38,7 +41,7 @@ script:
   # custom Setup.hs script dependencies.
   - case "$BUILD" in
       stack)
-        stack build --haddock --no-haddock-deps && stack test --haddock --no-haddock-deps
+        stack build --haddock --no-haddock-deps && stack test --haddock --no-haddock-deps;;
       cabal)
-        ./travis-cabal.sh
+        ./travis-cabal.sh;;
     esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ cache:
 
 matrix:
   include:
-  - env: GHCVER=7.10.3 CABALVER=1.22
+  - env: BUILD=cabal GHCVER=7.10.3 CABALVER=1.22
+    addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+  - env: BUILD=stack GHCVER=7.10.3 CABALVER=1.22
     addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
 
 before_install:
@@ -24,14 +26,19 @@ before_install:
   - rm protoc-release.zip
 
 install:
-  - stack setup --no-terminal
-  - stack build --only-snapshot --no-terminal
-  - cabal --version
-  - cabal update
+  - case "$BUILD" in
+      stack)
+        stack setup --no-terminal && stack build --only-snapshot --no-terminal
+      cabal)
+        cabal update
+    esac
 
 script:
   # Separate build from test, since build by itself hits some edge cases around
   # custom Setup.hs script dependencies.
-  - stack build --haddock --no-haddock-deps
-  - stack test --haddock --no-haddock-deps
-  - ./travis-cabal.sh
+  - case "$BUILD" in
+      stack)
+        stack build --haddock --no-haddock-deps && stack test --haddock --no-haddock-deps
+      cabal)
+        ./travis-cabal.sh
+    esac

--- a/travis-cabal.sh
+++ b/travis-cabal.sh
@@ -40,7 +40,7 @@ do
         date
         cabal configure --enable-tests
         date
-        cabal build -v3
+        cabal build -v
         date
         cabal sdist
         date

--- a/travis-cabal.sh
+++ b/travis-cabal.sh
@@ -29,15 +29,22 @@ for p in $PACKAGES
 do
     echo "Cabal building $p"
     (cd $p &&
+        date
         cabal clean
+        date
         cabal install --enable-tests --only-dependencies
+        date
         cabal configure --enable-tests
+        date
         cabal build
+        date
         cabal sdist
+        date
         SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}')
         cd dist
         if [ -f "$SRC_TGZ" ]; then
             cabal install --force-reinstalls "$SRC_TGZ"
+        date
         else
             echo "expected '$SRC_TGZ' not found"
             exit 1

--- a/travis-cabal.sh
+++ b/travis-cabal.sh
@@ -25,6 +25,10 @@ do
   ghc-pkg unregister --force $p || true
 done
 
+which ghc
+ghc --info
+ghc +RTS --info
+
 for p in $PACKAGES
 do
     echo "Cabal building $p"
@@ -36,7 +40,7 @@ do
         date
         cabal configure --enable-tests
         date
-        cabal build
+        cabal build -v3
         date
         cabal sdist
         date

--- a/travis-cabal.sh
+++ b/travis-cabal.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# A script for running Cabal on all the individual packages in this project.
+
+set -eu
+
+# List all the packages in this repo.  Put proto-lens[-protoc] first since
+# they're dependencies of the others.  (Unfortunately, "stack query" doesn't
+# give them to us in the right order.)
+BASE_PACKAGES="proto-lens proto-lens-protoc"
+OTHER_PACKAGES=$(stack query | sed -n 's/  \(.*\):$/\1/p' | sed '/^proto-lens$/d' | sed '/^proto-lens-protoc$/d')
+PACKAGES=$(echo $BASE_PACKAGES $OTHER_PACKAGES)
+
+echo Building: $PACKAGES
+
+# Needed by haskell-src-exts which is a dependency of proto-lens-protoc.
+# Sadly, Cabal won't install such build-tools automatically.
+cabal install happy
+
+# Unregister the already-installed packages, since otherwise they may
+# propagate between builds.
+# TODO: use a Cabal sandbox for this.
+for p in $PACKAGES
+do
+  echo "Unregistering $p"
+  ghc-pkg unregister --force $p || true
+done
+
+for p in $PACKAGES
+do
+    echo "Cabal building $p"
+    (cd $p &&
+        cabal clean
+        cabal install --enable-tests --only-dependencies
+        cabal configure --enable-tests
+        cabal build
+        cabal sdist
+        SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}')
+        cd dist
+        if [ -f "$SRC_TGZ" ]; then
+            cabal install --force-reinstalls "$SRC_TGZ"
+        else
+            echo "expected '$SRC_TGZ' not found"
+            exit 1
+        fi
+    )
+done


### PR DESCRIPTION
The generated files will get included in the output tarball.  However,
'cabal install' will still regenerate them and so require the `protoc`
executable to be installed.