### PR TITLE
Support enum aliases using PatternSynonyms.

### DIFF
--- a/proto-lens-protoc/src/Definitions.hs
+++ b/proto-lens-protoc/src/Definitions.hs
@@ -232,7 +232,7 @@ enumDef protoPrefix hsPrefix d = let
             })
 
 -- | Generate the definitions for each enum value.  In particular, decide
--- whether it's a true constructor or a PatternSynonym' to another
+-- whether it's a true constructor or a PatternSynonym to another
 -- constructor.
 --
 -- Like Java, we treat the first case of each numeric value as the "real"

--- a/proto-lens-protoc/src/Definitions.hs
+++ b/proto-lens-protoc/src/Definitions.hs
@@ -14,6 +14,7 @@ module Definitions
     , MessageInfo(..)
     , FieldInfo(..)
     , EnumInfo(..)
+    , EnumValueInfo(..)
     , qualifyEnv
     , unqualifyEnv
     , collectDefinitions
@@ -21,6 +22,8 @@ module Definitions
     ) where
 
 import Data.Char (toUpper)
+import Data.Int (Int32)
+import Data.List (mapAccumL)
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
 import Data.Monoid
@@ -32,6 +35,7 @@ import Lens.Family2 ((^.))
 import Bootstrap.Proto.Google.Protobuf.Descriptor
     ( DescriptorProto
     , EnumDescriptorProto
+    , EnumValueDescriptorProto
     , FieldDescriptorProto
     , FileDescriptorProto
     , enumType
@@ -39,6 +43,7 @@ import Bootstrap.Proto.Google.Protobuf.Descriptor
     , messageType
     , name
     , nestedType
+    , number
     , package
     , typeName
     , value
@@ -81,9 +86,18 @@ data FieldInfo = FieldInfo
 data EnumInfo n = EnumInfo
     { enumName :: n
     , enumDescriptor :: EnumDescriptorProto
-    , enumValueNames :: [n]
-      -- ^ The Haskell name of each enum value.
-      -- This corresponds 1-1 with "value" in EnumDescriptorProto.
+    , enumValues :: [EnumValueInfo n]
+    } deriving Functor
+
+-- | Information about a single value case of a proto enum.
+data EnumValueInfo n = EnumValueInfo
+    { enumValueName :: n
+    , enumValueDescriptor :: EnumValueDescriptorProto
+    , enumAliasOf :: Maybe Name
+        -- ^ If 'Nothing', we turn value into a normal constructor of the enum.
+        -- If @'Just' n@, we're treating it as an alias of the constructor @n@
+        -- (a PatternSynonym in Haskell).  This mirrors the behavior of the
+        -- Java API.
     } deriving Functor
 
 mapEnv :: (n -> n') -> Env n -> Env n'
@@ -200,6 +214,7 @@ reservedKeywords = Set.fromList $
     ++  -- Nonstandard extensions
     [ "mdo"   -- RecursiveDo
     , "rec"   -- Arrows, RecursiveDo
+    , "pattern"  -- PatternSynonyms
     , "proc"  -- Arrows
     ]
 
@@ -213,8 +228,29 @@ enumDef protoPrefix hsPrefix d = let
        , Enum EnumInfo
             { enumName = mkHsName (d ^. name)
             , enumDescriptor = d
-            , enumValueNames = fmap (mkHsName . (^. name)) (d ^. value)
+            , enumValues = collectEnumValues mkHsName $ d ^. value
             })
+
+-- | Generate the definitions for each enum value.  In particular, decide
+-- whether it's a true constructor or a PatternSynonym' to another
+-- constructor.
+--
+-- Like Java, we treat the first case of each numeric value as the "real"
+-- constructor, and subsequent cases as synonyms.
+collectEnumValues :: (Text -> Name) -> [EnumValueDescriptorProto]
+                  -> [EnumValueInfo Name]
+collectEnumValues mkHsName = snd . mapAccumL helper Map.empty
+  where
+    helper :: Map.Map Int32 Name -> EnumValueDescriptorProto
+           -> (Map.Map Int32 Name, EnumValueInfo Name)
+    helper seenNames v
+        | Just n' <- Map.lookup k seenNames = (seenNames, mkValue (Just n'))
+        | otherwise = (Map.insert k hsName seenNames, mkValue Nothing)
+      where
+        mkValue = EnumValueInfo hsName v
+        hsName = mkHsName n
+        n = v ^. name
+        k = v ^. number
 
 -- Haskell types must start with an uppercase letter, so we capitalize message
 -- and enum names.

--- a/proto-lens-protoc/src/Generate.hs
+++ b/proto-lens-protoc/src/Generate.hs
@@ -29,7 +29,8 @@ import Language.Haskell.Exts.Syntax as Syntax
 import Language.Haskell.Exts.SrcLoc (noLoc)
 import Lens.Family2 ((^.))
 import Bootstrap.Proto.Google.Protobuf.Descriptor
-    ( FieldDescriptorProto
+    ( EnumValueDescriptorProto
+    , FieldDescriptorProto
     , FieldDescriptorProto'Label(..)
     , FieldDescriptorProto'Type(..)
     , FileDescriptorProto
@@ -72,7 +73,8 @@ generateModule modName imports syntaxType definitions importedEnv
     = Module noLoc modName
           [ LanguagePragma noLoc $ map Ident
               ["ScopedTypeVariables", "DataKinds", "TypeFamilies",
-               "MultiParamTypeClasses", "FlexibleContexts", "FlexibleInstances"]
+               "MultiParamTypeClasses", "FlexibleContexts", "FlexibleInstances",
+               "PatternSynonyms"]
               -- Allow unused imports in case we don't import anything from
               -- Data.Text, Data.Int, etc.
           , OptionsPragma noLoc (Just GHC) "-fno-warn-unused-imports"
@@ -173,7 +175,7 @@ generateMessageDecls syntaxType env info =
 generateEnumDecls :: EnumInfo Name -> [Decl]
 generateEnumDecls info =
     [ DataDecl noLoc DataType [] dataName []
-        [QualConDecl noLoc [] [] $ ConDecl n [] | (n, _) <- values]
+        [QualConDecl noLoc [] [] $ ConDecl n [] | n <- constructorNames]
         [(c, []) | c <- ["Prelude.Show", "Prelude.Eq"]]
     -- instance Data.Default.Class.Default Foo where
     --   def = FirstEnumValue
@@ -199,21 +201,22 @@ generateEnumDecls info =
     --    readEnum _ = Nothing
     , InstDecl noLoc Nothing [] [] "Data.ProtoLens.MessageEnum" [dataType]
         [ InsDecl $ FunBind $
-            [ match "maybeToEnum" [pLitInt k] $ "Prelude.Just" @@ Con (UnQual n)
-            | (n, k) <- values
+            [ match "maybeToEnum" [pLitInt k]
+                $ "Prelude.Just" @@ Con (UnQual n)
+            | (n, k) <- constructorNumbers
             ]
             ++
             [ match "maybeToEnum" [PWildCard] "Prelude.Nothing"
             ]
             ++
-            [ match "showEnum" [PVar n] $ Lit $ Syntax.String $ T.unpack ev
-            | (n, ev) <- names
+            [ match "showEnum" [PVar n] $ Lit $ Syntax.String $ T.unpack pn
+            | (n, pn) <- constructorProtoNames
             ]
             ++
             [ match "readEnum"
-                [PLit Signless . Syntax.String $ T.unpack ev]
+                [PLit Signless . Syntax.String $ T.unpack pn]
                 $ "Prelude.Just" @@ Con (UnQual n)
-            | (n, ev) <- names
+            | (n, pn) <- constructorProtoNames
             ]
             ++
             [ match "readEnum" [PWildCard] "Prelude.Nothing"
@@ -246,7 +249,7 @@ generateEnumDecls info =
             ]
         , InsDecl $ FunBind
             [ match "fromEnum" [PApp (UnQual c) []] $ litInt k
-            | (c, k) <- values
+            | (c, k) <- constructorNumbers
             ]
         , succDecl "succ" maxBoundName succPairs
         , succDecl "pred" minBoundName $ map swap succPairs
@@ -266,24 +269,41 @@ generateEnumDecls info =
             ]
         ]
     ]
+    ++
+    -- pattern FooAlias :: Foo
+    -- pattern FooAlias = FooConstructor
+    concat
+        [ [ PatSynSig noLoc aliasName Nothing [] [] dataType
+          , PatSyn noLoc (PVar aliasName) (PVar originalName)
+                ImplicitBidirectional
+          ]
+        | EnumValueInfo
+            { enumValueName = aliasName
+            , enumAliasOf = Just originalName
+            } <- enumValues info
+        ]
   where
     dataType = TyCon $ UnQual dataName
-    EnumInfo
-        { enumName = dataName
-        , enumValueNames = valueNames
-        , enumDescriptor = ed
-        } = info
-    namesAndValues = zip valueNames (ed ^. value)
-    names = map (second (^. name)) namesAndValues
-    values = List.sortBy (comparing snd) $
-        map (second (fromIntegral . (^. number))) namesAndValues
-    minBoundName = fst $ head values
-    maxBoundName = fst $ last values
+    EnumInfo { enumName = dataName, enumDescriptor = ed } = info
+    constructors :: [(Name, EnumValueDescriptorProto)]
+    constructors = List.sortBy (comparing ((^. number) . snd))
+                            [(n, d) | EnumValueInfo
+                                { enumValueName = n
+                                , enumValueDescriptor = d
+                                , enumAliasOf = Nothing
+                                } <- enumValues info
+                            ]
+    constructorNames = map fst constructors
+    minBoundName = head constructorNames
+    maxBoundName = last constructorNames
 
-    succPairs = zip ctorNames $ tail ctorNames
-      where ctorNames = map fst values
+    constructorProtoNames = map (second (^. name)) constructors
+    constructorNumbers = map (second (fromIntegral . (^. number)))
+                          constructors
+
+    succPairs = zip constructorNames $ tail constructorNames
     succDecl funName boundName thePairs = InsDecl $ FunBind $
-        match funName [PApp (UnQual boundName) []] (
+        match funName [PVar boundName] (
             "Prelude.error" @@ Lit (Syntax.String $ concat
                 [ show dataName, ".", show funName, ": bad argument "
                 , show boundName, ". This value would be out of bounds."
@@ -294,7 +314,7 @@ generateEnumDecls info =
         ]
     alias funName implName = InsDecl $ FunBind [match funName [] implName]
 
-    defaultCon = Con $ UnQual $ fst $ head names
+    defaultCon = Con $ UnQual $ head constructorNames
     errorMessageExpr = "Prelude.error"
                           @@ ("Prelude.++" @@ Lit (Syntax.String errorMessage)
                               @@ ("Prelude.show" @@ "k__"))
@@ -469,9 +489,8 @@ hsFieldValueDefault env fd = case fd ^. type' of
     FieldDescriptorProto'TYPE_ENUM
         | T.null def -> "Data.Default.Class.def"
         | Enum e <- definedFieldType fd env
-        , Just v <- List.lookup def [ (vd ^. name, n)
-                                    | (vd, n) <- zip (enumDescriptor e ^. value)
-                                                     (enumValueNames e)
+        , Just v <- List.lookup def [ (enumValueDescriptor v ^. name, enumValueName v)
+                                    | v <- enumValues e
                                     ]
             -> Con v
         | otherwise -> errorMessage "enum"

--- a/proto-lens-protoc/src/Generate.hs
+++ b/proto-lens-protoc/src/Generate.hs
@@ -309,7 +309,7 @@ generateEnumDecls info =
 
     succPairs = zip constructorNames $ tail constructorNames
     succDecl funName boundName thePairs = InsDecl $ FunBind $
-        match funName [PVar boundName] (
+        match funName [PApp (UnQual boundName) []] (
             "Prelude.error" @@ Lit (Syntax.String $ concat
                 [ show dataName, ".", show funName, ": bad argument "
                 , show boundName, ". This value would be out of bounds."

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -129,6 +129,9 @@ Test-Suite enum_test
   main-is: enum_test.hs
   hs-source-dirs: tests
   other-modules: Proto.Enum
+  -- Check that the code generated for enum aliases and the pattern-match in the
+  -- test (aliasTest) are both warning-clean.
+  ghc-options: -fwarn-overlapping-patterns -fwarn-incomplete-patterns -Werror
   build-depends: HUnit
                , base
                , bytestring

--- a/proto-lens-tests/tests/enum.proto
+++ b/proto-lens-tests/tests/enum.proto
@@ -34,3 +34,11 @@ message Foo {
   optional bool true_defaulted = 5 [default = true];
   optional bool false_defaulted = 6 [default = false];
 }
+
+enum Alias {
+  option allow_alias = true;
+  Alias1 = 1;
+  Alias2 = 2;
+  Alias2a = 2;
+  Alias3 = 3;
+}

--- a/proto-lens-tests/tests/enum_test.hs
+++ b/proto-lens-tests/tests/enum_test.hs
@@ -33,6 +33,7 @@ main = testMain
     , testBounded
     , testMaybeSuccAndPred
     , testEnumFromThenTo
+    , testAliases
     ]
 
 testExternalEnum = testGroup "external"
@@ -116,3 +117,13 @@ testEnumFromThenTo = plusTestOptions testOptions $ testGroup "enumFromThenTo"
         -- Note that there are only 10 values, so this should happen rarely.
         testCase name $ take 10 actual @?= expected
 
+testAliases = testCase "alias" $ do
+    map fromEnum [Alias1, Alias2, Alias2a, Alias3] @?= [1,2,2,3]
+    Alias2 @?= Alias2a
+    Alias2 @?= case Alias2 of
+        -- Check that this explicit list (which doesn't include Alias2) covers
+        -- all the constructor cases for this type.
+        -- We turn on warnings and -Werror for this test in the .cabal file.
+        Alias1 -> Alias1
+        Alias2 -> Alias2
+        Alias3 -> Alias3


### PR DESCRIPTION
The first case listed in the proto for each int value is the "real" enum
constructor, and subsequent ones are synonyms.  This is the same approach as
Java:
https://developers.google.com/protocol-buffers/docs/reference/java-generated#enum