### PR TITLE
Reexport modules with new names from proto-lens-protoc.

### DIFF
--- a/proto-lens-combinators/proto-lens-combinators.cabal
+++ b/proto-lens-combinators/proto-lens-combinators.cabal
@@ -36,6 +36,7 @@ Test-Suite combinators_test
   build-depends: HUnit
                , base
                , lens-family
+               , proto-lens
                , proto-lens-combinators
                , proto-lens-protoc
                , test-framework

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -30,15 +30,18 @@ library
       , proto-lens == 0.1.0.1
       , text == 1.2.*
   reexported-modules:
-      -- Modules that are needed by the generated Haskell files:
-        Data.ByteString
-      , Data.Default.Class
-      , Data.Map
-      , Data.ProtoLens
-      , Data.ProtoLens.Message.Enum
-      , Data.Text
-      , Lens.Family2
-      , Lens.Family2.Unchecked
+      -- Modules that are needed by the generated Haskell files.
+      -- For forwards compatibility, reexport them as new module names so that
+      -- other packages don't accidentally write non-generated code that
+      -- relies on these modules being reexported by proto-lens-protoc.
+        Data.ByteString as Data.ProtoLens.Reexport.Data.ByteString
+      , Data.Default.Class as Data.ProtoLens.Reexport.Data.Default.Class
+      , Data.Map as Data.ProtoLens.Reexport.Data.Map
+      , Data.ProtoLens as Data.ProtoLens.Reexport.Data.ProtoLens
+      , Data.ProtoLens.Message.Enum as Data.ProtoLens.Reexport.Data.ProtoLens.Message.Enum
+      , Data.Text as Data.ProtoLens.Reexport.Data.Text
+      , Lens.Family2 as Data.ProtoLens.Reexport.Lens.Family2
+      , Lens.Family2.Unchecked as Data.ProtoLens.Reexport.Lens.Family2.Unchecked
 
 executable proto-lens-protoc
   main-is:  protoc-gen-haskell.hs

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -19,6 +19,7 @@ library
   exposed-modules:     Data.ProtoLens.TestUtil
   default-language: Haskell2010
   build-depends: proto-lens-arbitrary == 0.1.*
+               , proto-lens == 0.1.*
                , proto-lens-protoc == 0.1.*
                , base >= 4.8 && < 4.10
                , bytestring == 0.10.*
@@ -40,6 +41,8 @@ Test-Suite canonical_test
   other-modules: Proto.Canonical
   build-depends: base
                , bytestring
+               , lens-family
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -51,7 +54,8 @@ Test-Suite group_test
   hs-source-dirs: tests
   other-modules: Proto.Group
   build-depends: base
-               , bytestring
+               , lens-family
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -64,6 +68,8 @@ Test-Suite map_test
   other-modules: Proto.Map
   build-depends: base
                , bytestring
+               , lens-family
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -76,7 +82,8 @@ Test-Suite optional_test
   other-modules: Proto.Optional
   build-depends: HUnit
                , base
-               , bytestring
+               , lens-family
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -91,6 +98,8 @@ Test-Suite proto3_test
   build-depends: HUnit
                , base
                , bytestring
+               , lens-family
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -104,6 +113,8 @@ Test-Suite repeated_test
   other-modules: Proto.Repeated
   build-depends: base
                , bytestring
+               , lens-family
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -116,8 +127,9 @@ Test-Suite text_format_test
   hs-source-dirs: tests
   build-depends: HUnit
                , base
-               , bytestring
+               , lens-family
                , pretty
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -131,8 +143,9 @@ Test-Suite enum_test
   other-modules: Proto.Enum
   build-depends: HUnit
                , base
-               , bytestring
+               , lens-family
                , pretty
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -146,7 +159,8 @@ Test-Suite names_test
   other-modules: Proto.Names
   build-depends: HUnit
                , base
-               , bytestring
+               , lens-family
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -159,7 +173,8 @@ Test-Suite no_package_test
   hs-source-dirs: tests
   other-modules: Proto.NoPackage
   build-depends: base
-               , bytestring
+               , lens-family
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -173,7 +188,8 @@ Test-Suite packed_test
   hs-source-dirs: tests
   other-modules: Proto.Packed
   build-depends: base
-               , bytestring
+               , lens-family
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -187,6 +203,8 @@ Test-Suite raw_fields_test
   other-modules: Proto.RawFields
   build-depends: base
                , bytestring
+               , lens-family
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
@@ -199,7 +217,9 @@ Test-Suite required_test
   hs-source-dirs: tests
   other-modules: Proto.Required
   build-depends: base
-               , bytestring
+               , data-default-class
+               , lens-family
+               , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework


### PR DESCRIPTION
This should prevent user packages from accidentally depending on
the particular set of modules that we reexport.  For example,
previously they could get the module 'Data.ByteString' from
proto-lens-protoc.  After this change, they'll need to explicitly
list 'bytestring' in their 'build-depends' to get that.