### PR TITLE
Move some parts of protoc-gen-haskell to visible modules for use by plugins.

### DIFF
--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -4,6 +4,9 @@ synopsis:            Protocol buffer compiler for the proto-lens library.
 description:
   Turn protocol buffer files (.proto) into Haskell files (.hs) which
   can be used with the proto-lens package.
+
+  The library component of this package contains compiler code that is not
+  guaranteed to have stable APIs.
 license:             BSD3
 license-file:        LICENSE
 author:              Judah Jacobson
@@ -14,7 +17,12 @@ build-type:          Simple
 cabal-version:       >=1.21
 
 library
-  exposed-modules:   Data.ProtoLens.Setup
+  exposed-modules:
+      Data.ProtoLens.Setup
+      Data.ProtoLens.Compiler.Combinators
+      Data.ProtoLens.Compiler.Definitions
+      Data.ProtoLens.Compiler.Generate
+      Data.ProtoLens.Compiler.Plugin
   default-language:  Haskell2010
   hs-source-dirs:    src
   build-depends:
@@ -25,6 +33,7 @@ library
       , data-default-class == 0.0.*
       , directory == 1.2.*
       , filepath == 1.4.*
+      , haskell-src-exts == 1.17.*
       , lens-family == 1.2.*
       , process >= 1.2 && < 1.5
       , proto-lens == 0.1.0.1
@@ -48,9 +57,6 @@ executable proto-lens-protoc
   other-modules:
       Bootstrap.Proto.Google.Protobuf.Compiler.Plugin
       Bootstrap.Proto.Google.Protobuf.Descriptor
-      Combinators
-      Definitions
-      Generate
 
   build-depends:
         base >= 4.8 && < 4.10

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -5,8 +5,8 @@ description:
   Turn protocol buffer files (.proto) into Haskell files (.hs) which
   can be used with the proto-lens package.
 
-  The library component of this package contains compiler code that is not
-  guaranteed to have stable APIs.
+  The library component of this package contains compiler code (namely
+  Data.ProtoLens.Compiler.*) that is not guaranteed to have stable APIs.
 license:             BSD3
 license-file:        LICENSE
 author:              Judah Jacobson

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -23,6 +23,8 @@ library
       Data.ProtoLens.Compiler.Definitions
       Data.ProtoLens.Compiler.Generate
       Data.ProtoLens.Compiler.Plugin
+      Bootstrap.Proto.Google.Protobuf.Compiler.Plugin
+      Bootstrap.Proto.Google.Protobuf.Descriptor
   default-language:  Haskell2010
   hs-source-dirs:    src
   build-depends:
@@ -54,9 +56,6 @@ library
 
 executable proto-lens-protoc
   main-is:  protoc-gen-haskell.hs
-  other-modules:
-      Bootstrap.Proto.Google.Protobuf.Compiler.Plugin
-      Bootstrap.Proto.Google.Protobuf.Descriptor
 
   build-depends:
         base >= 4.8 && < 4.10

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
@@ -12,7 +12,7 @@
 -- datatypes, with some intelligence about Haskell names.  For example, @"foo"
 -- :: Exp@ is treated as a variable and @"Foo" :: Exp@ is treated as a
 -- constructor.
-module Combinators where
+module Data.ProtoLens.Compiler.Combinators where
 
 import Data.Char (isAlphaNum, isUpper)
 import Data.String (IsString(..))

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -8,7 +8,7 @@
 -- and assigning Haskell names to all of the defined things (messages, enums
 -- and field names).
 {-# LANGUAGE DeriveFunctor, OverloadedStrings #-}
-module Definitions
+module Data.ProtoLens.Compiler.Definitions
     ( Env
     , Definition(..)
     , MessageInfo(..)

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -7,7 +7,7 @@
 -- | This module builds the actual, generated Haskell file
 -- for a given input .proto file.
 {-# LANGUAGE OverloadedStrings #-}
-module Generate(
+module Data.ProtoLens.Compiler.Generate(
     generateModule,
     fileSyntaxType,
     ) where
@@ -45,11 +45,10 @@ import Bootstrap.Proto.Google.Protobuf.Descriptor
     , syntax
     , type'
     , typeName
-    , value
     )
 
-import Combinators
-import Definitions
+import Data.ProtoLens.Compiler.Combinators
+import Data.ProtoLens.Compiler.Definitions
 
 data SyntaxType = Proto2 | Proto3
     deriving Eq

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
@@ -11,7 +11,7 @@ module Data.ProtoLens.Compiler.Plugin
     ( ProtoFileName
     , ProtoFile(..)
     , analyzeProtoFiles
-    , buildEnv
+    , collectEnvFromDeps
     , outputFilePath
     , moduleName
     , moduleNameStr

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
@@ -1,0 +1,125 @@
+-- Copyright 2016 Google Inc. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+--
+-- Code for writing protocol compiler plugins.
+
+{-# LANGUAGE OverloadedStrings #-}
+module Data.ProtoLens.Compiler.Plugin
+    ( ProtoFileName
+    , ProtoFile(..)
+    , analyzeProtoFiles
+    , buildEnv
+    , outputFilePath
+    , moduleName
+    , moduleNameStr
+    ) where
+
+import Data.Char (toUpper)
+import Data.List (foldl', intercalate)
+import qualified Data.Map.Strict as Map
+import Data.Map.Strict (Map, unions, (!))
+import Data.Monoid ((<>))
+import qualified Data.Text as T
+import Data.Text (Text)
+import Language.Haskell.Exts.Syntax (ModuleName(..), Name(..), QName(..))
+import Lens.Family2
+import Bootstrap.Proto.Google.Protobuf.Descriptor
+    (FileDescriptorProto, name, dependency, publicDependency)
+import System.FilePath (dropExtension, splitDirectories)
+
+
+import Data.ProtoLens.Compiler.Definitions
+
+-- | The filename of an input .proto file.
+type ProtoFileName = Text
+
+data ProtoFile = ProtoFile
+  { descriptor :: FileDescriptorProto
+  , haskellModule :: ModuleName
+  , definitions :: Env Name
+  , exports :: [ProtoFileName]
+  , exportedEnv :: Env QName
+  }
+
+-- Given a list of FileDescriptorProtos, collect information about each file
+-- into a map of 'ProtoFile's keyed by 'ProtoFileName'.
+analyzeProtoFiles :: Text -> [FileDescriptorProto] -> Map ProtoFileName ProtoFile
+analyzeProtoFiles modulePrefix files =
+    Map.fromList [ (f ^. name, ingestFile f) | f <- files ]
+  where
+    filesByName = Map.fromList [(f ^. name, f) | f <- files]
+    moduleNames = fmap (moduleName modulePrefix) filesByName
+    -- The definitions in each input proto file, indexed by filename.
+    definitionsByName = fmap collectDefinitions filesByName
+    -- The exports from each .proto file (including any "public import"
+    -- dependencies), as they appear to other modules that are importing them;
+    -- i.e., qualified by module name.
+    exportsByName = transitiveExports files
+    localExports = Map.intersectionWith qualifyEnv moduleNames definitionsByName
+    exportedEnvs = fmap (\es -> unions [localExports ! e | e <- es]) exportsByName
+
+    ingestFile f = ProtoFile
+        { descriptor = f
+        , haskellModule = moduleNames ! n
+        , definitions = definitionsByName ! n
+        , exports = exportsByName ! n
+        , exportedEnv = exportedEnvs ! n
+        }
+      where
+        n = f ^. name
+
+buildEnv :: [Text] -> Map ProtoFileName ProtoFile -> Env QName
+buildEnv deps filesByName = unions $ fmap (exportedEnv . (filesByName !)) deps
+
+-- | Get the output file path (for CodeGeneratorResponse.File) for a Haskell
+-- ModuleName.
+outputFilePath :: String -> Text
+outputFilePath n = T.replace "." "/" (T.pack n) <> ".hs"
+
+-- | Get the Haskell 'ModuleName' corresponding to a given .proto file.
+moduleName :: Text -> FileDescriptorProto -> ModuleName
+moduleName modulePrefix fd = ModuleName (moduleNameStr modulePrefix fd)
+
+-- | Get the Haskell module name corresponding to a given .proto file.
+moduleNameStr :: Text -> FileDescriptorProto -> String
+moduleNameStr modulePrefix fd = fixModuleName rawModuleName
+  where
+    path = fd ^. name
+    prefix
+        | T.null modulePrefix = "Proto"
+        | otherwise = modulePrefix
+    fixModuleName "" = ""
+    -- Characters allowed in Bazel filenames but not in module names:
+    fixModuleName ('.':c:cs) = '.' : toUpper c : fixModuleName cs
+    fixModuleName ('_':c:cs) = toUpper c : fixModuleName cs
+    fixModuleName ('-':c:cs) = toUpper c : fixModuleName cs
+    fixModuleName (c:cs) = c : fixModuleName cs
+    rawModuleName = intercalate "." $ (T.unpack prefix :)
+                        $ splitDirectories $ dropExtension
+                        $ T.unpack path
+
+-- | Given a list of .proto files (topologically sorted), determine which
+-- files' definitions are exported by which files.
+--
+-- Files only export their own definitions, along with the definitions exported
+-- by any "import public" declarations.
+transitiveExports :: [FileDescriptorProto] -> Map ProtoFileName [ProtoFileName]
+-- Accumulate the transitive dependencies by folding over the files in
+-- topological order.
+transitiveExports = foldl' setExportsFromFile Map.empty
+  where
+    setExportsFromFile :: Map ProtoFileName [ProtoFileName]
+                       -> FileDescriptorProto
+                       -> Map ProtoFileName [ProtoFileName]
+    setExportsFromFile prevExports fd
+        = flip (Map.insert n) prevExports $
+            n : concat [ prevExports ! ((fd ^. dependency) !! fromIntegral i)
+                       -- Note that publicDependency is a list of indices into
+                       -- the dependency list.
+                       | i <- fd ^. publicDependency
+                       ]
+      where n = fd ^. name
+

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
@@ -40,6 +40,8 @@ data ProtoFile = ProtoFile
   { descriptor :: FileDescriptorProto
   , haskellModule :: ModuleName
   , definitions :: Env Name
+  -- | The names of proto files exported (transitively, via "import public"
+  -- decl) by this file.
   , exports :: [ProtoFileName]
   , exportedEnv :: Env QName
   }
@@ -71,8 +73,9 @@ analyzeProtoFiles modulePrefix files =
       where
         n = f ^. name
 
-buildEnv :: [Text] -> Map ProtoFileName ProtoFile -> Env QName
-buildEnv deps filesByName = unions $ fmap (exportedEnv . (filesByName !)) deps
+collectEnvFromDeps :: [ProtoFileName] -> Map ProtoFileName ProtoFile -> Env QName
+collectEnvFromDeps deps filesByName =
+    unions $ fmap (exportedEnv . (filesByName !)) deps
 
 -- | Get the output file path (for CodeGeneratorResponse.File) for a Haskell
 -- ModuleName.

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
@@ -37,14 +37,14 @@ import Data.ProtoLens.Compiler.Definitions
 type ProtoFileName = Text
 
 data ProtoFile = ProtoFile
-  { descriptor :: FileDescriptorProto
-  , haskellModule :: ModuleName
-  , definitions :: Env Name
-  -- | The names of proto files exported (transitively, via "import public"
-  -- decl) by this file.
-  , exports :: [ProtoFileName]
-  , exportedEnv :: Env QName
-  }
+    { descriptor :: FileDescriptorProto
+    , haskellModule :: ModuleName
+    , definitions :: Env Name
+    -- | The names of proto files exported (transitively, via "import public"
+    -- decl) by this file.
+    , exports :: [ProtoFileName]
+    , exportedEnv :: Env QName
+    }
 
 -- Given a list of FileDescriptorProtos, collect information about each file
 -- into a map of 'ProtoFile's keyed by 'ProtoFileName'.

--- a/proto-lens-protoc/src/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/src/protoc-gen-haskell.hs
@@ -78,7 +78,7 @@ generateFiles modulePrefix header files toGenerate = let
       in generateModule (haskellModule file) imports
              (fileSyntaxType (descriptor file))
              (definitions file)
-             (buildEnv deps filesByName)
+             (collectEnvFromDeps deps filesByName)
   in [ ( outputFilePath . (\(ModuleName n) -> n) . haskellModule $ file
        , header (descriptor file) <> pack (prettyPrint $ buildFile file)
        )

--- a/proto-lens-protoc/src/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/src/protoc-gen-haskell.hs
@@ -18,7 +18,7 @@ import qualified Data.Text as T
 import Data.Text (Text, pack)
 import Data.ProtoLens (decodeMessage, def, encodeMessage)
 import Language.Haskell.Exts.Pretty (prettyPrint)
-import Language.Haskell.Exts.Syntax (ModuleName(..))
+import Language.Haskell.Exts.Syntax (ModuleName(..), Name(..), QName(..))
 import Lens.Family2
 import Bootstrap.Proto.Google.Protobuf.Compiler.Plugin
     ( CodeGeneratorRequest
@@ -37,8 +37,9 @@ import System.IO as IO
 import System.FilePath (dropExtension, replaceExtension, splitDirectories)
 
 
-import Definitions
-import Generate
+import Data.ProtoLens.Compiler.Definitions
+import Data.ProtoLens.Compiler.Generate
+import Data.ProtoLens.Compiler.Plugin
 
 main = do
     contents <- B.getContents
@@ -61,82 +62,27 @@ makeResponse prog request = let
                      | (outputName, outputContent) <- outputFiles
                      ]
 
--- | The filename of an input .proto file.
-type ProtoFileName = Text
 
 generateFiles :: Text -> (FileDescriptorProto -> Text) -> [FileDescriptorProto]
               -> [ProtoFileName] -> [(Text, Text)]
 generateFiles modulePrefix header files toGenerate = let
-  filesByName = Map.fromList [(f ^. name, f) | f <- files]
-  moduleNames = fmap (moduleName modulePrefix) filesByName
-  -- The definitions in each input proto file, indexed by filename.
-  definitions = fmap collectDefinitions filesByName
-  -- The exports from each .proto file (including any "public import"
-  -- dependencies), as they appear to other modules that are importing them;
-  -- i.e., qualified by module name.
-  exports = transitiveExports files
-  localExports = Map.intersectionWith qualifyEnv moduleNames definitions
-  exportedEnvs = fmap (\es -> unions [localExports ! e | e <- es]) exports
+  filesByName = analyzeProtoFiles modulePrefix files
   -- The contents of the generated Haskell file for a given .proto file.
-  buildFile fileName = let
-      f = filesByName ! fileName
-      deps = f ^. dependency
-      env = unions $ fmap (exportedEnvs !) deps
+  buildFile file = let
+      deps = descriptor file ^. dependency
       imports = Set.toAscList $ Set.fromList
-                  [ moduleNames ! exportName
+                  [ haskellModule (filesByName ! exportName)
                   | dep <- deps
-                  , exportName <- exports ! dep
+                  , exportName <- exports (filesByName ! dep)
                   ]
-      in generateModule (moduleNames ! fileName) imports (fileSyntaxType f)
-              (definitions ! fileName) env
-  in [ ( outputFilePath (moduleNames ! f)
-       , header fd <> pack (prettyPrint $ buildFile f)
+      in generateModule (haskellModule file) imports
+             (fileSyntaxType (descriptor file))
+             (definitions file)
+             (buildEnv deps filesByName)
+  in [ ( outputFilePath . (\(ModuleName n) -> n) . haskellModule $ file
+       , header (descriptor file) <> pack (prettyPrint $ buildFile file)
        )
-     | f <- toGenerate
-     , let fd = filesByName ! f
+     | fileName <- toGenerate
+     , let file = filesByName ! fileName
      ]
-
--- | Given a list of .proto files (topologically sorted), determine which
--- files' definitions are exported by which files.
---
--- Files only export their own definitions, along with the definitions exported
--- by any "import public" declarations.
-transitiveExports :: [FileDescriptorProto] -> Map ProtoFileName [ProtoFileName]
--- Accumulate the transitive dependencies by folding over the files in
--- topological order.
-transitiveExports = foldl' setExportsFromFile Map.empty
-  where
-    setExportsFromFile :: Map ProtoFileName [ProtoFileName]
-                       -> FileDescriptorProto
-                       -> Map ProtoFileName [ProtoFileName]
-    setExportsFromFile prevExports fd
-        = flip (Map.insert n) prevExports $
-            n : concat [ prevExports ! ((fd ^. dependency) !! fromIntegral i)
-                       -- Note that publicDependency is a list of indices into
-                       -- the dependency list.
-                       | i <- fd ^. publicDependency
-                       ]
-      where n = fd ^. name
-
-outputFilePath :: ModuleName -> Text
-outputFilePath (ModuleName n) = T.replace "." "/" (T.pack n) <> ".hs"
-
--- | Get the module name of a .proto file.
-moduleName :: Text -> FileDescriptorProto -> ModuleName
-moduleName modulePrefix fd = ModuleName $ fixModuleName rawModuleName
-  where
-    path = fd ^. name
-    prefix
-        | T.null modulePrefix = "Proto"
-        | otherwise = modulePrefix
-    fixModuleName "" = ""
-    -- Characters allowed in Bazel filenames but not in module names:
-    fixModuleName ('.':c:cs) = '.' : toUpper c : fixModuleName cs
-    fixModuleName ('_':c:cs) = toUpper c : fixModuleName cs
-    fixModuleName ('-':c:cs) = toUpper c : fixModuleName cs
-    fixModuleName (c:cs) = c : fixModuleName cs
-    rawModuleName = intercalate "." $ (T.unpack prefix :)
-                        $ splitDirectories $ dropExtension
-                        $ T.unpack path
-
 


### PR DESCRIPTION
This also refactors the main environment analysis a bit so it can be reused, and changes a few functions to accept/return String rather than ModuleName since the un-annotated haskell-src-exts API is on the way out.