### PR TITLE
Add proto-lens-benchmarks package with a small set of Criterion benchmarks

### DIFF
--- a/proto-lens-benchmarks/LICENSE
+++ b/proto-lens-benchmarks/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2016, Google Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Google Inc. nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/proto-lens-benchmarks/Setup.hs
+++ b/proto-lens-benchmarks/Setup.hs
@@ -1,0 +1,9 @@
+-- Copyright 2016 Google Inc. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+import Data.ProtoLens.Setup
+
+main = defaultMainGeneratingProtos "benchmarks"

--- a/proto-lens-benchmarks/benchmarks/IntPacking.hs
+++ b/proto-lens-benchmarks/benchmarks/IntPacking.hs
@@ -42,6 +42,7 @@ populatePacked n k = def & num .~ replicate n k
 benchmaker :: Int -> [Benchmark]
 benchmaker size =
     [ protoBenchmark "int32-unpacked" (populateUnpacked size 5 :: FooUnpacked)
-    , protoBenchmark "int32-packed" (populatePacked size 5 :: FooPacked)]
+    , protoBenchmark "int32-packed" (populatePacked size 5 :: FooPacked)
+    ]
 
 main = benchmarkMain defaultNumInt32s benchmaker

--- a/proto-lens-benchmarks/benchmarks/IntPacking.hs
+++ b/proto-lens-benchmarks/benchmarks/IntPacking.hs
@@ -1,0 +1,47 @@
+-- Copyright 2016 Google Inc. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+
+-- | A benchmark to measure the performance difference between packed and
+-- unpacked integer data.
+module Main where
+
+import Data.ProtoLens.BenchmarkUtil (protoBenchmark, benchmarkMain)
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import Criterion.Main (Benchmark)
+import Lens.Family2 ((&), (.~))
+import Data.Int (Int32)
+import Data.ProtoLens.Field (HasField)
+import Data.ProtoLens.Message (Message, def)
+import Proto.IntPacking
+
+-- These instances are required by Criterion to benchmark proto decoding.
+deriving instance Generic FooUnpacked
+
+deriving instance Generic FooPacked
+
+deriving instance NFData FooUnpacked
+
+deriving instance NFData FooPacked
+
+defaultNumInt32s :: Int
+defaultNumInt32s = 10000
+
+populateUnpacked :: Int -> Int32 -> FooUnpacked
+populateUnpacked n k = def & num .~ replicate n k
+
+populatePacked :: Int -> Int32 -> FooPacked
+populatePacked n k = def & num .~ replicate n k
+
+benchmaker :: Int -> [Benchmark]
+benchmaker size =
+    [ protoBenchmark "int32-unpacked" (populateUnpacked size 5 :: FooUnpacked)
+    , protoBenchmark "int32-packed" (populatePacked size 5 :: FooPacked)]
+
+main = benchmarkMain defaultNumInt32s benchmaker

--- a/proto-lens-benchmarks/benchmarks/Nested.hs
+++ b/proto-lens-benchmarks/benchmarks/Nested.hs
@@ -1,0 +1,58 @@
+-- Copyright 2016 Google Inc. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | A benchmark to measure the difference between nesting fields in a repeated
+-- submessage vs. putting repeated fields directly in the top-level message.
+module Main where
+
+import Data.ProtoLens.BenchmarkUtil (protoBenchmark, benchmarkMain)
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import Criterion.Main (Benchmark)
+import Lens.Family2 ((&), (.~))
+import Data.ProtoLens.Message (def)
+import Proto.Nested
+
+-- These instances are required by Criterion to benchmark proto decoding.
+deriving instance Generic FooFlat
+
+deriving instance Generic FooNested
+
+deriving instance Generic FooNested'Sub
+
+deriving instance NFData FooFlat
+
+deriving instance NFData FooNested
+
+deriving instance NFData FooNested'Sub
+
+defaultNumValues :: Int
+defaultNumValues = 10000
+
+intValue = 5
+
+strValue = "foo"
+
+populateFlat :: Int -> FooFlat
+populateFlat n =
+    def & (intField .~ replicate n intValue) .
+    (strField .~ replicate n strValue)
+
+populateNested :: Int -> FooNested
+populateNested n = def & sub .~ replicate n subMessage
+  where
+    subMessage = def & (intField .~ intValue) . (strField .~ strValue)
+
+benchmaker :: Int -> [Benchmark]
+benchmaker size =
+    [ protoBenchmark "flat" (populateFlat size)
+    , protoBenchmark "nested" (populateNested size)]
+
+main = benchmarkMain defaultNumValues benchmaker

--- a/proto-lens-benchmarks/benchmarks/Nested.hs
+++ b/proto-lens-benchmarks/benchmarks/Nested.hs
@@ -53,6 +53,7 @@ populateNested n = def & sub .~ replicate n subMessage
 benchmaker :: Int -> [Benchmark]
 benchmaker size =
     [ protoBenchmark "flat" (populateFlat size)
-    , protoBenchmark "nested" (populateNested size)]
+    , protoBenchmark "nested" (populateNested size)
+    ]
 
 main = benchmarkMain defaultNumValues benchmaker

--- a/proto-lens-benchmarks/benchmarks/UnusedFields.hs
+++ b/proto-lens-benchmarks/benchmarks/UnusedFields.hs
@@ -1,0 +1,49 @@
+-- Copyright 2016 Google Inc. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+
+-- | A benchmark to measure the overhead of including a lot of unused fields
+-- in a proto message. Because protos are modeled as Haskell records, decoding
+-- will involve repeatedly updating a record, which will require copying all
+-- the fields that remain unchanged. Extra fields in the proto will also
+-- produce more overhead when looking up fields in the descriptor.
+module Main where
+
+import Data.ProtoLens.BenchmarkUtil (protoBenchmark, benchmarkMain)
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import Criterion.Main (Benchmark)
+import Lens.Family2 ((&), (.~))
+import Data.Int (Int32)
+import Data.ProtoLens.Message (def)
+import Proto.UnusedFields
+
+-- These instances are required by Criterion to benchmark proto decoding.
+deriving instance Generic Foo
+
+deriving instance Generic FooWithUnusedFields
+
+deriving instance NFData Foo
+
+deriving instance NFData FooWithUnusedFields
+
+defaultNumInt32s :: Int
+defaultNumInt32s = 10000
+
+populateFoo :: Int -> Int32 -> Foo
+populateFoo n k = def & field .~ replicate n k
+
+populateFooWithUnusedFields :: Int -> Int32 -> FooWithUnusedFields
+populateFooWithUnusedFields n k = def & field .~ replicate n k
+
+benchmaker :: Int -> [Benchmark]
+benchmaker size =
+        [ protoBenchmark "no-unused" (populateFoo size 5)
+        , protoBenchmark "with-unused" (populateFooWithUnusedFields size 5)]
+
+main = benchmarkMain defaultNumInt32s benchmaker

--- a/proto-lens-benchmarks/benchmarks/UnusedFields.hs
+++ b/proto-lens-benchmarks/benchmarks/UnusedFields.hs
@@ -43,7 +43,8 @@ populateFooWithUnusedFields n k = def & field .~ replicate n k
 
 benchmaker :: Int -> [Benchmark]
 benchmaker size =
-        [ protoBenchmark "no-unused" (populateFoo size 5)
-        , protoBenchmark "with-unused" (populateFooWithUnusedFields size 5)]
+    [ protoBenchmark "no-unused" (populateFoo size 5)
+    , protoBenchmark "with-unused" (populateFooWithUnusedFields size 5)
+    ]
 
 main = benchmarkMain defaultNumInt32s benchmaker

--- a/proto-lens-benchmarks/benchmarks/int_packing.proto
+++ b/proto-lens-benchmarks/benchmarks/int_packing.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package int_packing;
+
+message FooUnpacked {
+  repeated int32 num = 1 [packed=false];
+}
+
+message FooPacked {
+  repeated int32 num = 1 [packed=true];
+}
+

--- a/proto-lens-benchmarks/benchmarks/nested.proto
+++ b/proto-lens-benchmarks/benchmarks/nested.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package nested;
+
+message FooFlat {
+  repeated int32 int_field = 1;
+  repeated string str_field = 2;
+}
+
+message FooNested {
+  message Sub {
+    int32 int_field = 1;
+    string str_field = 2;
+  }
+
+  repeated Sub sub = 1;
+}
+

--- a/proto-lens-benchmarks/benchmarks/unused_fields.proto
+++ b/proto-lens-benchmarks/benchmarks/unused_fields.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package unused_fields;
+
+message Foo {
+  repeated int32 field = 1;
+}
+
+message FooWithUnusedFields {
+  repeated int32 field = 1;
+  int32 unused_02 = 2;
+  int32 unused_03 = 3;
+  int32 unused_04 = 4;
+  int32 unused_05 = 5;
+  int32 unused_06 = 6;
+  int32 unused_07 = 7;
+  int32 unused_08 = 8;
+  int32 unused_09 = 9;
+  int32 unused_10 = 10;
+  int32 unused_11 = 11;
+  int32 unused_12 = 12;
+  int32 unused_13 = 13;
+  int32 unused_14 = 14;
+  int32 unused_15 = 15;
+  int32 unused_16 = 16;
+  int32 unused_17 = 17;
+  int32 unused_18 = 18;
+  int32 unused_19 = 19;
+  int32 unused_20 = 20;
+  int32 unused_21 = 21;
+  int32 unused_22 = 22;
+  int32 unused_23 = 23;
+  int32 unused_24 = 24;
+  int32 unused_25 = 25;
+  int32 unused_26 = 26;
+  int32 unused_27 = 27;
+  int32 unused_28 = 28;
+  int32 unused_29 = 29;
+  int32 unused_30 = 30;
+  int32 unused_31 = 31;
+  int32 unused_32 = 32;
+}
+

--- a/proto-lens-benchmarks/proto-lens-benchmarks.cabal
+++ b/proto-lens-benchmarks/proto-lens-benchmarks.cabal
@@ -58,3 +58,18 @@ Benchmark nested
                  , proto-lens
                  , proto-lens-benchmarks
                  , proto-lens-protoc
+
+Benchmark unused-fields
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    main-is:          UnusedFields.hs
+    hs-source-dirs:   benchmarks
+    other-modules:    Proto.UnusedFields
+    ghc-options:      -O2 -rtsopts
+    build-depends: base
+                 , criterion
+                 , deepseq
+                 , lens-family
+                 , proto-lens
+                 , proto-lens-benchmarks
+                 , proto-lens-protoc

--- a/proto-lens-benchmarks/proto-lens-benchmarks.cabal
+++ b/proto-lens-benchmarks/proto-lens-benchmarks.cabal
@@ -25,3 +25,21 @@ library
                , criterion == 1.1.*
                , deepseq == 1.4.*
                , optparse-applicative == 0.12.*
+
+-- The build-depends in the benchmarks don't specify version bounds, since
+-- those are already constrained by the library rule.
+
+Benchmark int-packing
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    main-is:          IntPacking.hs
+    hs-source-dirs:   benchmarks
+    other-modules:    Proto.IntPacking
+    ghc-options:      -O2 -rtsopts
+    build-depends: base
+                 , criterion
+                 , deepseq
+                 , lens-family
+                 , proto-lens
+                 , proto-lens-benchmarks
+                 , proto-lens-protoc

--- a/proto-lens-benchmarks/proto-lens-benchmarks.cabal
+++ b/proto-lens-benchmarks/proto-lens-benchmarks.cabal
@@ -1,0 +1,27 @@
+name:                proto-lens-benchmarks
+version:             0.1.0.0
+synopsis:            Benchmarks for proto-lens
+description:
+    This package contains a set of benchmarks for proto-lens.
+homepage:            https://github.com/google/proto-lens
+license:             BSD3
+license-file:        LICENSE
+author:              Aden Grue
+maintainer:          agrue+protolens@google.com
+copyright:           Google Inc.
+category:            Data
+build-type:          Custom
+cabal-version:       >=1.10
+extra-source-files:  benchmarks/*.proto
+
+library
+  hs-source-dirs: src
+  exposed-modules:     Data.ProtoLens.BenchmarkUtil
+  default-language: Haskell2010
+  build-depends: proto-lens == 0.1.*
+               , proto-lens-protoc == 0.1.*
+               , base >= 4.8 && < 4.10
+               , bytestring == 0.10.*
+               , criterion == 1.1.*
+               , deepseq == 1.4.*
+               , optparse-applicative == 0.12.*

--- a/proto-lens-benchmarks/proto-lens-benchmarks.cabal
+++ b/proto-lens-benchmarks/proto-lens-benchmarks.cabal
@@ -43,3 +43,18 @@ Benchmark int-packing
                  , proto-lens
                  , proto-lens-benchmarks
                  , proto-lens-protoc
+
+Benchmark nested
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+    main-is:          Nested.hs
+    hs-source-dirs:   benchmarks
+    other-modules:    Proto.Nested
+    ghc-options:      -O2 -rtsopts
+    build-depends: base
+                 , criterion
+                 , deepseq
+                 , lens-family
+                 , proto-lens
+                 , proto-lens-benchmarks
+                 , proto-lens-protoc

--- a/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
+++ b/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
@@ -1,0 +1,77 @@
+-- Copyright 2016 Google Inc. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | A utility library for writing proto-lens benchmarks.
+module Data.ProtoLens.BenchmarkUtil (protoBenchmark, benchmarkMain) where
+
+import Control.DeepSeq (NFData)
+import Criterion.Main
+import qualified Criterion.Main.Options as Criterion
+import qualified Data.ByteString as BS (length)
+import Data.Maybe (fromMaybe)
+import Data.ProtoLens
+import Options.Applicative
+
+-- | Generate a group of benchmarks for encoding and decoding the given proto
+-- message. Includes benchmarks for decoding to both weak head normal form and
+-- normal form (i.e. all fields fully forced.) There is only one encoding
+-- benchmark because protos are encoded as strict ByteStrings, so there is no
+-- difference between normal form and weak head normal form.
+protoBenchmark
+    :: forall a.
+       (NFData a, Message a)
+    => String
+    -- ^ Benchmark name.
+    -> a
+    -- ^ Protocol buffer message to encode/decode.
+    -> Benchmark
+protoBenchmark groupName proto =
+    bgroup
+        fullGroupName
+        [ bench "encode" $ nf encodeMessage proto
+        , bgroup
+              "decode"
+              [ bench "whnf" $ whnf decodeMessage' encodedProto
+              , bench "nf" $ nf decodeMessage' encodedProto]]
+  where
+    -- We must indicate to the compiler that we want to decode to the same
+    -- message type as the input proto.
+    decodeMessage' bytes = (decodeMessage bytes :: Either String a)
+    encodedProto = encodeMessage proto
+    fullGroupName =
+        groupName ++ "(" ++ prettySize (BS.length encodedProto) ++ ")"
+
+prettySize :: Int -> String
+prettySize b
+  | b < 10240 = show b ++ "B"
+  | k < 10240 = show k ++ "kB"
+  | otherwise = show m ++ "MB"
+  where
+    k = b `div` 1024
+    m = k `div` 1024
+
+-- | Main function for a benchmark suite with an optional 'size' parameter.
+benchmarkMain
+    :: Int
+    -- ^ Default benchmark size if one is not provided.
+    -> (Int -> [Benchmark])
+    -- ^ Function to generate a set of benchmarks from a provided 'size'.
+    -> IO ()
+benchmarkMain defaultSize benchmaker = do
+    (maybeSize, criterionMode) <- execParser $ info (helper <*> options) mempty
+    runMode criterionMode $ benchmaker (fromMaybe defaultSize maybeSize)
+
+options :: Parser (Maybe Int, Criterion.Mode)
+options =
+    (,) <$>
+    optional
+        (option
+             auto
+             (help "Benchmark data size" <> metavar "N" <> short 's' <>
+              long "size")) <*>
+    Criterion.parseWith Criterion.defaultConfig

--- a/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
+++ b/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
@@ -37,7 +37,9 @@ protoBenchmark groupName proto =
         , bgroup
               "decode"
               [ bench "whnf" $ whnf decodeMessage' encodedProto
-              , bench "nf" $ nf decodeMessage' encodedProto]]
+              , bench "nf" $ nf decodeMessage' encodedProto
+              ]
+        ]
   where
     -- We must indicate to the compiler that we want to decode to the same
     -- message type as the input proto.

--- a/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
+++ b/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
@@ -36,14 +36,18 @@ protoBenchmark groupName proto =
         [ bench "encode" $ nf encodeMessage proto
         , bgroup
               "decode"
-              [ bench "whnf" $ whnf decodeMessage' encodedProto
-              , bench "nf" $ nf decodeMessage' encodedProto
+              [ bench "whnf" $ whnf decodeMessageOrDie' encodedProto
+              , bench "nf" $ nf decodeMessageOrDie' encodedProto
               ]
         ]
   where
     -- We must indicate to the compiler that we want to decode to the same
     -- message type as the input proto.
-    decodeMessage' bytes = (decodeMessage bytes :: Either String a)
+    -- We use decodeMessageOrDie here (instead of decodeMessage) so that if
+    -- a bug is introduced that causes decoding to fail, the benchmark will
+    -- fail with an error, instead of silently reporting a misleading value
+    -- (the amount of time required to determine that proto decoding failed).
+    decodeMessageOrDie' bytes = (decodeMessageOrDie bytes :: a)
     encodedProto = encodeMessage proto
     fullGroupName =
         groupName ++ "(" ++ prettySize (BS.length encodedProto) ++ ")"

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -6,6 +6,7 @@ packages:
 - proto-lens-combinators
 - proto-lens-optparse
 - proto-lens-tests
+- proto-lens-benchmarks
 
 # Allow our custom Setup.hs scripts to import Data.ProtoLens.Setup from the version of
 # `proto-lens-protoc` in stack's local DB.  This makes things simpler when developing

--- a/stack.yaml
+++ b/stack.yaml
@@ -6,6 +6,7 @@ packages:
 - proto-lens-combinators
 - proto-lens-optparse
 - proto-lens-tests
+- proto-lens-benchmarks
 
 # Allow our custom Setup.hs scripts to import Data.ProtoLens.Setup from the version of
 # `proto-lens-protoc` in stack's local DB.  This makes things simpler when developing

--- a/travis-cabal.sh
+++ b/travis-cabal.sh
@@ -13,6 +13,7 @@ PACKAGES="
     proto-lens-combinators
     proto-lens-optparse
     proto-lens-tests
+    proto-lens-benchmarks
 "
 echo Building: $PACKAGES
 


### PR DESCRIPTION
This begins to address #24. I didn't really know which benchmarks were important, so I included a small set of benchmarks that were interesting to me. It should be easy for others to add their own based on these examples and using the small BenchmarkUtil library I included. Or I am always happy to add additional benchmarks to this pull request based on review comments.
