### PR TITLE
Fix Issue #45 by using \x escapes for non-printing characters.

### DIFF
--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -127,6 +127,7 @@ Test-Suite text_format_test
   hs-source-dirs: tests
   build-depends: HUnit
                , base
+               , bytestring
                , lens-family
                , pretty
                , proto-lens
@@ -134,6 +135,7 @@ Test-Suite text_format_test
                , proto-lens-tests
                , test-framework
                , test-framework-hunit
+               , text
 
 Test-Suite enum_test
   default-language: Haskell2010

--- a/proto-lens-tests/tests/canonical.proto
+++ b/proto-lens-tests/tests/canonical.proto
@@ -19,3 +19,8 @@ message Test3 {
 message Test4 {
     repeated int32 d = 4 [packed=true];
 }
+
+message Test5 {
+    required bytes e = 1;
+}
+


### PR DESCRIPTION
Add tests.