### PR TITLE
Fix Issues #20, #40, and #45 by using the same escaping as Protobuf d…

### DIFF
--- a/proto-lens-protoc/src/Data/ProtoLens/Setup.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Setup.hs
@@ -13,11 +13,16 @@
 -- `build-dependencies`.
 --
 -- See @README.md@ for instructions on how to use proto-lens with Cabal.
+{-# LANGUAGE CPP #-}
 module Data.ProtoLens.Setup
     ( defaultMainGeneratingProtos
     , generatingProtos
     , generateProtos
     ) where
+
+#if __GLASGOW_HASKELL__ < 709
+import Data.Functor ((<$>))
+#endif
 
 import Distribution.PackageDescription
     ( PackageDescription(..)
@@ -30,8 +35,6 @@ import Distribution.PackageDescription
     )
 import Distribution.Simple.BuildPaths (autogenModulesDir)
 import Distribution.Simple.LocalBuildInfo (LocalBuildInfo)
-import Distribution.Simple.Program (knownPrograms, ConfiguredProgram(..))
-import Distribution.Simple.Program.Types (simpleProgram)
 import Distribution.Simple.Utils (matchFileGlob)
 import Distribution.Simple
     ( defaultMainWithHooks

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -127,6 +127,7 @@ Test-Suite text_format_test
   hs-source-dirs: tests
   build-depends: HUnit
                , base
+               , bytestring
                , lens-family
                , pretty
                , proto-lens
@@ -134,6 +135,7 @@ Test-Suite text_format_test
                , proto-lens-tests
                , test-framework
                , test-framework-hunit
+               , text
 
 Test-Suite enum_test
   default-language: Haskell2010

--- a/proto-lens-tests/tests/canonical.proto
+++ b/proto-lens-tests/tests/canonical.proto
@@ -19,3 +19,8 @@ message Test3 {
 message Test4 {
     repeated int32 d = 4 [packed=true];
 }
+
+message Test5 {
+    required bytes e = 1;
+}
+

--- a/proto-lens-tests/tests/proto3_test.hs
+++ b/proto-lens-tests/tests/proto3_test.hs
@@ -55,7 +55,7 @@ main = testMain
             $ tagged 3 $ Fixed32 0x40d55555
         , serializeTo "bytes"
             (def & d .~ "a\0b" :: Foo)
-            "d: \"a\\NULb\""
+            "d: \"a\\000b\""
             $ tagged 4 $ Lengthy "a\0b"
         -- Scalar "oneof" fields should have a "maybe" selector.
         , testCase "maybe" $ do

--- a/proto-lens-tests/tests/text_format_test.hs
+++ b/proto-lens-tests/tests/text_format_test.hs
@@ -7,6 +7,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
+import qualified Data.ByteString
+import Data.Char (ord)
+import Data.Monoid ((<>))
+import qualified Data.Text.Lazy
+import Data.Word (Word8)
 import Data.ProtoLens (
     def, Message, showMessage, showMessageShort, pprintMessage)
 import Lens.Family2 ((&), (.~))
@@ -28,6 +33,9 @@ def3 = def
 
 def4 :: Test4
 def4 = def
+
+def5 :: Test5
+def5 = def
 
 failed1 :: Maybe Test1
 failed1 = Nothing
@@ -57,8 +65,40 @@ main = testMain
     , testCase "Render multiple lines" $
         "d: 1\nd: 2\nd: 3" @=?
             showMessageWithLineLength 3 (def4 & d .~ [1, 2, 3])
+    , readFrom
+         "Parse string with escape sequences"
+          -- '\o172' == '\x7a' == 'z'
+         (Just $ def2 & b .~ "\o1\o12\o123\x2\o172z3z3")
+         (Data.Text.Lazy.pack "b: \"\\001\\012\\123\\002\\172\\x7a3\\1723\"")
+    , testCase "Render string with escape sequences" $
+        escapeRendered @=? showMessageShort escapeMessage
+    , readFrom "Parse rendered string with escape sequences"
+               (Just escapeMessage) (Data.Text.Lazy.pack escapeRendered)
+    , testCase "Render bytes" $
+         invalidUTF8BytesRendered @=? showMessage invalidUTF8BytesMessage
+    , readFrom "Parse single-quote-delimited string"
+         (Just $ def2 & b .~ "ab\o2") "b: \'ab\2\'"
+    , readFrom "Non-UTF8 bytes"
+         (Just invalidUTF8BytesMessage)
+         (Data.Text.Lazy.pack invalidUTF8BytesRendered)
     , let kNums = [0..99]  -- The default line limit is 100 so we exceed it.
           kExpected = unwords $ map (("d: " ++) . show) kNums
       in testCase "Render single line for debugString" $
           kExpected @=? showMessageShort (def4 & d .~ kNums)
     ]
+  where
+    escapeMessage  = def2 & b
+        .~ ("a\r\n\t\"\'\\" <> "bc\o030" <> "1" <> "\o109" <> "¢" <> "\o1")
+    escapeRendered =
+        -- All the special escapes:
+        "b: \"a\\r\\n\\t\\\"\\\'\\\\"
+        ++ "bc\\0301"      -- The last digit is a separate character, not part
+                           -- of the escape.
+        ++ "\\010" ++ "9"  -- Note that the 9 is a separate character
+        ++ "\\302\\242"    -- UTF-8 for the cent symbol, '¢'.
+        ++ "\\001"         -- Works fine at EOL.
+        ++ "\""
+    invalidUTF8BytesMessage =
+        def5 & e .~ Data.ByteString.pack (map (fromIntegral . ord) "abc"
+            ++ [0xC0, 0xC0, 0x0])  -- Invalid UTF8.
+    invalidUTF8BytesRendered = "e: \"abc\\300\\300\\000\""

--- a/proto-lens-tests/tests/text_format_test.hs
+++ b/proto-lens-tests/tests/text_format_test.hs
@@ -96,7 +96,7 @@ main = testMain
     escapeMessage  = def2 & b
         .~ ("a\r\n\t\"\'\\" <> "bc\o030" <> "1" <> "\o109" <> "¢" <> "\o1")
     escapeRendered =
-        -- 'a' followed by all the non-numerica escapes we emit:
+        -- 'a' followed by all the non-numeric escapes we emit:
         "b: \"a\\r\\n\\t\\\"\\\'\\\\"
         ++ "bc\\0301"      -- The last digit is a separate character, not part
                            -- of the escape.

--- a/proto-lens-tests/tests/text_format_test.hs
+++ b/proto-lens-tests/tests/text_format_test.hs
@@ -66,10 +66,16 @@ main = testMain
         "d: 1\nd: 2\nd: 3" @=?
             showMessageWithLineLength 3 (def4 & d .~ [1, 2, 3])
     , readFrom
-         "Parse string with escape sequences"
+         ("Parse string with numeric escape sequences"
+             ++ " (including ones we do not emit)")
           -- '\o172' == '\x7a' == 'z'
          (Just $ def2 & b .~ "\o1\o12\o123\x2\o172z3z3")
          (Data.Text.Lazy.pack "b: \"\\001\\012\\123\\002\\172\\x7a3\\1723\"")
+    , readFrom
+         ("Parse string with non-numeric escape sequences"
+             ++ " (including ones we do not emit)")
+         (Just $ def2 & b .~ "\a\b\f\n\r\t\v\\\'\"")
+         (Data.Text.Lazy.pack "b: \"\a\b\f\n\r\t\v\\\\\\\'\\\"\"")
     , testCase "Render string with escape sequences" $
         escapeRendered @=? showMessageShort escapeMessage
     , readFrom "Parse rendered string with escape sequences"
@@ -90,7 +96,7 @@ main = testMain
     escapeMessage  = def2 & b
         .~ ("a\r\n\t\"\'\\" <> "bc\o030" <> "1" <> "\o109" <> "¢" <> "\o1")
     escapeRendered =
-        -- All the special escapes:
+        -- 'a' followed by all the non-numerica escapes we emit:
         "b: \"a\\r\\n\\t\\\"\\\'\\\\"
         ++ "bc\\0301"      -- The last digit is a separate character, not part
                            -- of the escape.

--- a/proto-lens/src/Data/ProtoLens/Encoding.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding.hs
@@ -223,4 +223,3 @@ integralFieldWireType w = simpleFieldWireType w fromIntegral fromIntegral
 stringizeError :: Either UnicodeException a -> Either String a
 stringizeError (Left e) = Left (show e)
 stringizeError (Right a) = Right a
-

--- a/proto-lens/src/Data/ProtoLens/TextFormat/Parser.hs
+++ b/proto-lens/src/Data/ProtoLens/TextFormat/Parser.hs
@@ -14,13 +14,19 @@ module Data.ProtoLens.TextFormat.Parser
     , parser
     ) where
 
-import Data.List (intercalate)
+import Data.ByteString (ByteString, pack)
+import Data.Char (ord)
 import Data.Functor.Identity (Identity)
+import Data.List (intercalate)
+import Data.Maybe (catMaybes)
 import Data.Text.Lazy (Text)
-import Text.Parsec.Char (alphaNum, char, letter, oneOf)
+import Data.Word (Word8)
+import Numeric (readOct, readHex)
+import Text.Parsec.Char
+  (alphaNum, char, hexDigit, letter, octDigit, oneOf, satisfy)
 import Text.Parsec.Text.Lazy (Parser)
-import Text.Parsec.Combinator (eof, sepBy1, many1, choice)
-import Text.Parsec.Token
+import Text.Parsec.Combinator (choice, eof, many1, optionMaybe, sepBy1)
+import Text.Parsec.Token hiding (octal)
 import Control.Applicative ((<*), (<|>), (*>), many)
 import Control.Monad (liftM, liftM2, mzero)
 
@@ -60,7 +66,7 @@ data Key = Key String  -- ^ A standard key that is just a string.
 
 data Value = IntValue Integer  -- ^ An integer
   | DoubleValue Double  -- ^ Any floating point number
-  | StringValue String  -- ^ A string literal
+  | ByteStringValue ByteString    -- ^ A string or bytes literal
   | MessageValue Message  -- ^ A sub message
   | EnumValue String  -- ^ Any undelimited string (including false & true)
   deriving (Show,Ord,Eq)
@@ -91,7 +97,8 @@ parser = whiteSpace ptp *> parseMessage <* eof
         negative <- (symbol ptp "-" >> return True) <|> return False
         value <- naturalOrFloat ptp
         return $ makeNumberValue negative value
-    parseString = liftM (StringValue . concat) . many1 $ stringLiteral ptp
+    parseString = liftM (ByteStringValue . mconcat)
+        $ many1 $ lexeme ptp $ protoStringLiteral
     parseEnumValue = liftM EnumValue (identifier ptp)
     parseMessageValue = liftM MessageValue
         (braces ptp parseMessage <|> angles ptp parseMessage)
@@ -101,3 +108,50 @@ parser = whiteSpace ptp *> parseMessage <* eof
     makeNumberValue False (Left intValue) = IntValue intValue
     makeNumberValue True (Right doubleValue) = DoubleValue (negate doubleValue)
     makeNumberValue False (Right doubleValue) = DoubleValue doubleValue
+
+-- | Reads a literal string the way the Protocol Buffer distribution's
+-- tokenizer.cc does.  This differs from Haskell string literals in treating,
+-- e.g. "\11" as octal instead of decimal, so reading as 9 instead of 11.  Also,
+-- like tokenizer.cc we assume octal and hex escapes can have at most three and
+-- two digits, respectively.
+--
+-- TODO: implement reading of Unicode escapes.
+protoStringLiteral :: Parser ByteString
+protoStringLiteral = do
+    initialQuoteChar <- char '\'' <|> char '\"'
+    word8s <- many stringChar
+    _ <- char initialQuoteChar
+    return $ pack word8s
+  where
+    stringChar :: Parser Word8
+    stringChar = nonEscape <|> stringEscape
+    nonEscape  = fmap (fromIntegral . ord)
+        $ satisfy (\c -> c `notElem` "\\\'\"" && ord c < 256)
+    stringEscape = char '\\' >> (octal <|> hex <|> unicode <|> simple)
+    octal = do d0 <- octDigit
+               d1 <- optionMaybe octDigit
+               d2 <- optionMaybe octDigit
+               readMaybeDigits readOct [Just d0, d1, d2]
+    readMaybeDigits :: ReadS Word8 -> [Maybe Char] -> Parser Word8
+    readMaybeDigits reader
+        = return . (\str -> let [(v, "")] = reader str in v) . catMaybes
+    hex = do _ <- oneOf "xX"
+             d0 <- hexDigit
+             d1 <- optionMaybe hexDigit
+             readMaybeDigits readHex [Just d0, d1]
+    unicode = oneOf "uU" >> fail "Unicode in string literals not yet supported"
+    simple = choice $ map charRet [ ('a', '\a')
+                                  , ('b', '\b')
+                                  , ('f', '\f')
+                                  , ('n', '\n')
+                                  , ('r', '\r')
+                                  , ('t', '\t')
+                                  , ('v', '\v')
+                                  , ('\\', '\\')
+                                  , ('\'', '\'')
+                                  , ('\"', '\"')
+                                  ]
+      where
+        charRet :: (Char, Char) -> Parser Word8
+        charRet (escapeCh, ch) = do _ <- char escapeCh
+                                    return $ fromIntegral $ ord ch


### PR DESCRIPTION
…istribution

The Unicode escaping that the Protocol Buffer distribution supports is
not implemented for now.

Add tests.