### PR TITLE
Reorganize LTS versions now that ghc-8.0.1 is out of nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ matrix:
     addons: {apt: {packages: [cabal-install-1.22, ghc-7.10.3], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=8.0.1 CABALVER=1.24
     addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.1], sources: [hvr-ghc]}}
-  - env: BUILD=stack GHCVER=7.10.3 STACK_YAML=stack.yaml
+  - env: BUILD=stack GHCVER=7.10.3 STACK_YAML=stack-7.10.yaml
     addons: {apt: {packages: [ghc-7.10.3], sources: [hvr-ghc]}}
-  - env: BUILD=stack GHCVER=8.0.1 STACK_YAML=stack-8.0.yaml
+  - env: BUILD=stack GHCVER=8.0.1 STACK_YAML=stack.yaml
     addons: {apt: {packages: [ghc-8.0.1], sources: [hvr-ghc]}}
 
 before_install:

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-06-27
+resolver: lts-6.22
 packages:
 - proto-lens
 - proto-lens-protoc

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-6.20
+resolver: lts-7.4
 packages:
 - proto-lens
 - proto-lens-protoc


### PR DESCRIPTION
Previously the default was ghc-7.10.3 (lts-6.20), and we built with ghc-8 using an old nightly lts.

Now:
- stack.yaml uses lts-7.4 to build with ghc-8.0.1.
- stack-7.10.3 uses lts-6.22 to build with ghc-7.10.3.