### PR TITLE
Miscellaneous documentation improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ source files from the original protocol buffer specifications (`.proto` files).
 
 First, edit the `.cabal` file of your project to:
 
-* Specify `build-type: Custom`.
+* Specify `build-type: Custom` and list `proto-lens-protoc` in `setup-depends`.
 * List the .proto files in `extra-source-files`.  Note that the field belongs
   at the top level of the `.cabal` file, rather than once per
   library/executable/etc.
@@ -31,16 +31,26 @@ First, edit the `.cabal` file of your project to:
   or `other-modules` of the rule(s) that use them (e.g. the library or
   executables).
 * Add `proto-lens-protoc` to the build-depends of those rules.
+* If using stack, enable `explicit-setup-deps` for your package.
 
-For example:
+For example, in `foo-bar-proto.cabal`:
 
     ...
     build-type: Custom
+    custom-setup
+        setup-depends: proto-lens-protoc
     extra-source-files: src/foo/bar.proto
     ...
     library
         exposed-modules: Proto.Foo.Bar
         build-depends: proto-lens-protoc, ...
+
+And in `stack.yaml`:
+
+    ...
+    explicit-setup-deps:
+        foo-bar-proto: true
+    ...
 
 Next, write a `Setup.hs` file that uses `Data.ProtoLens.Setup` and specifies the
 directory containing the `.proto` files.  For example:

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ named something like `protoc-*-.zip`.)
 `proto-lens` can be used as part of a Cabal project to auto-generate Haskell
 source files from the original protocol buffer specifications (`.proto` files).
 
-First, edit the `.cabal` file of your project to:
+First, edit the `.cabal` and (if using stack) `stack.yaml` files of your project
+to:
 
-* Specify `build-type: Custom` and list `proto-lens-protoc` in `setup-depends`.
+* Specify `build-type: Custom`.
 * List the .proto files in `extra-source-files`.  Note that the field belongs
   at the top level of the `.cabal` file, rather than once per
   library/executable/etc.
@@ -37,8 +38,6 @@ For example, in `foo-bar-proto.cabal`:
 
     ...
     build-type: Custom
-    custom-setup
-        setup-depends: proto-lens-protoc
     extra-source-files: src/foo/bar.proto
     ...
     library

--- a/proto-lens/src/Data/ProtoLens/Encoding.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding.hs
@@ -126,7 +126,7 @@ manyReversedTill p end = loop []
   where
     loop xs = (end >> return xs) <|> (p >>= \x -> loop (x:xs))
 
--- | Encode a message to the wire format.
+-- | Encode a message to the wire format as a strict 'ByteString'.
 encodeMessage :: Message msg => msg -> B.ByteString
 encodeMessage = L.toStrict . toLazyByteString . buildMessage
 


### PR DESCRIPTION
While using proto-lens for a side project I took note of a few minor issues I ran into:

- The quick start instructions result in broken packages due to missing setup-depends.
- The Haddock of encodeMessage is ambiguous about which ByteString it returns.