### PR TITLE
Improve space usage and time of decoding.

### DIFF
--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -130,7 +130,7 @@ generateMessageDecls syntaxType env info =
     [ DataDecl noLoc DataType [] dataName []
         [QualConDecl noLoc [] [] $ RecDecl dataName
                   [([recordFieldName f],
-                        internalType (lensInfo syntaxType env f))
+                        TyBang BangedTy $ internalType (lensInfo syntaxType env f))
                   | f <- fields
                   ]
         ]

--- a/proto-lens-tests/src/Data/ProtoLens/TestUtil.hs
+++ b/proto-lens-tests/src/Data/ProtoLens/TestUtil.hs
@@ -122,7 +122,8 @@ data Data
   | Fixed64 Word64
   | Fixed32 Word32
   | Lengthy Builder.Builder
-  | Group [(Word64, Data)]
+  | GroupStart
+  | GroupEnd
 
 -- | Build the binary representation of a proto field.
 -- Note that this code should be separate from anything in Data.ProtoLens.*,
@@ -135,10 +136,8 @@ tagged t (Lengthy bs) = let
     bs' = Builder.toLazyByteString bs
     in varInt (t `shiftL` 3 .|. 2) <> varInt (fromIntegral $ L.length bs')
         <> Builder.lazyByteString bs'
-tagged t (Group tvs) =
-    varInt (t `shiftL` 3 .|. 3)
-    <> foldMap (uncurry tagged) tvs
-    <> varInt (t `shiftL` 3 .|. 4)
+tagged t GroupStart = varInt (t `shiftL` 3 .|. 3)
+tagged t GroupEnd = varInt (t `shiftL` 3 .|. 4)
 
 -- | Utility to generate the text format for a single, non-message field.
 keyed :: Show a => String -> a -> PrettyPrint.Doc

--- a/proto-lens-tests/tests/group_test.hs
+++ b/proto-lens-tests/tests/group_test.hs
@@ -8,15 +8,16 @@
 
 module Main where
 
-import Proto.Group
 import Data.ProtoLens
+import Data.Monoid ((<>))
+import Proto.Group
 import Lens.Family2 ((&), (.~))
 
 import Data.ProtoLens.TestUtil
 
 main = testMain
            [ serializeSimple
-           , deserializeSimple
+           , deserializeEndMismatch
            , roundTripSimple
            , roundTripComplicated
            ]
@@ -25,12 +26,12 @@ serializeSimple = serializeTo
     "serialize Simple"
     (def & (grp . int) .~ 12 :: Simple)
     (braced "Grp" (keyed "int" 12))
-    (tagged 1 $ Group [(2, VarInt 12)])
+    (tagged 1 GroupStart <> tagged 2 (VarInt 12) <> tagged 1 GroupEnd)
 
-deserializeSimple = deserializeFrom
-    "Simple"
-    (Just (def & (grp . int) .~ 12 :: Simple))
-    (tagged 1 $ Group [(2, VarInt 12)])
+deserializeEndMismatch = deserializeFrom
+    "end mismatch"
+    (Nothing :: Maybe Simple)
+    (tagged 1 GroupStart <> tagged 2 (VarInt 12) <> tagged 5 GroupEnd)
 
 roundTripSimple = runTypedTest
     (roundTripTest "roundtrip Simple" :: TypedTest Simple)

--- a/proto-lens/src/Data/ProtoLens/Encoding.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding.hs
@@ -63,7 +63,7 @@ parseMessage end = do
     requiredFields = Map.filter isRequired fields
     loop :: msg -> Map.Map Tag (FieldDescriptor msg)
             -> Parser (msg, Map.Map Tag (FieldDescriptor msg))
-    loop msg unsetFields = (end >> pure (msg, unsetFields))
+    loop msg unsetFields = ((msg, unsetFields) <$ end)
                 <|> do
                     tv@(TaggedValue tag _) <- getTaggedValue
                     case Map.lookup (Tag tag) fields of

--- a/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
@@ -39,7 +39,6 @@ import System.IO.Unsafe (unsafePerformIO)
 getVarInt :: Parser Word64
 getVarInt = loop 1 0
   where
-  -- TODO: bang pattern?
     loop !s !n = do
         b <- anyWord8
         let n' = n + s * fromIntegral (b .&. 127)

--- a/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
@@ -4,6 +4,7 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -39,11 +40,11 @@ getVarInt :: Parser Word64
 getVarInt = loop 1 0
   where
   -- TODO: bang pattern?
-    loop s n = do
+    loop !s !n = do
         b <- anyWord8
         let n' = n + s * fromIntegral (b .&. 127)
         if (b .&. 128) == 0
-            then return n'
+            then return $! n'
             else loop (128*s) n'
 
 -- | Little-endian decoding function.
@@ -51,7 +52,7 @@ anyBits :: forall a . (Num a, FiniteBits a) => Parser a
 anyBits = loop 0 0
   where
     size = finiteBitSize (undefined :: a)
-    loop w n
+    loop !w !n
         | n >= size = return w
         | otherwise = do
             b <- anyWord8

--- a/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
@@ -38,8 +38,8 @@ data WireType a where
     Fixed64 :: WireType Word64
     Fixed32 :: WireType Word32
     Lengthy :: WireType B.ByteString
-    StartGroup :: WireType [TaggedValue]
-    EndGroup :: WireType Void
+    StartGroup :: WireType ()
+    EndGroup :: WireType ()
 
 -- A value read from the wire
 data WireValue = forall a . WireValue !(WireType a) !a
@@ -54,16 +54,17 @@ data Equal a b where
 
 -- Assert that two wire types are the same, or fail with a message about this
 -- field.
-equalWireTypes :: String -> WireType a -> WireType b
-               -> Either String (Equal a b)
-equalWireTypes _ VarInt VarInt = Right Equal
-equalWireTypes _ Fixed64 Fixed64 = Right Equal
-equalWireTypes _ Fixed32 Fixed32 = Right Equal
-equalWireTypes _ Lengthy Lengthy = Right Equal
-equalWireTypes _ StartGroup StartGroup = Right Equal
-equalWireTypes _ EndGroup EndGroup = Right Equal
+{-# INLINE equalWireTypes #-}
+equalWireTypes :: Monad m => String -> WireType a -> WireType b
+               -> m (Equal a b)
+equalWireTypes _ VarInt VarInt = return Equal
+equalWireTypes _ Fixed64 Fixed64 = return Equal
+equalWireTypes _ Fixed32 Fixed32 = return Equal
+equalWireTypes _ Lengthy Lengthy = return Equal
+equalWireTypes _ StartGroup StartGroup = return Equal
+equalWireTypes _ EndGroup EndGroup = return Equal
 equalWireTypes name expected actual
-    = Left $ "Field " ++ name ++ " expects wire type " ++ show expected
+    = fail $ "Field " ++ name ++ " expects wire type " ++ show expected
         ++ " but found " ++ show actual
 
 getWireValue :: WireType a -> Int -> Parser a
@@ -73,19 +74,15 @@ getWireValue Fixed32 _ = anyBits
 getWireValue Lengthy _ = getVarInt >>= Parse.take . fromIntegral
 -- Precompute the final EndGroup tag and keep parsing key-value pairs until
 -- we reach the EndGroup.
-getWireValue StartGroup tag = Parse.manyTill getTaggedValue end
-  where
-    typeAndTag = BL.toStrict $ toLazyByteString (putTypeAndTag EndGroup tag)
-    end = Parse.string typeAndTag
-getWireValue EndGroup tag =
-    fail $ "Encountered unexpected end of group with tag " ++ show tag
+getWireValue StartGroup tag = return ()
+getWireValue EndGroup tag = return ()
 
 putWireValue :: WireType a -> a -> Builder
 putWireValue VarInt n = putVarInt n
 putWireValue Fixed64 n = word64LE n
 putWireValue Fixed32 n = word32LE n
 putWireValue Lengthy b = putVarInt (fromIntegral $ B.length b) <> byteString b
-putWireValue StartGroup tvs = foldMap putTaggedValue tvs
+putWireValue StartGroup _ = mempty
 putWireValue EndGroup _ = mempty
 
 data SomeWireType where
@@ -126,9 +123,5 @@ getTaggedValue = do
     return $ TaggedValue tag (WireValue wt val)
 
 putTaggedValue :: TaggedValue -> Builder
-putTaggedValue (TaggedValue tag (WireValue StartGroup val)) =
-    putTypeAndTag StartGroup tag
-    <> putWireValue StartGroup val
-    <> putTypeAndTag EndGroup tag
 putTaggedValue (TaggedValue tag (WireValue wt val)) =
     putTypeAndTag wt tag <> putWireValue wt val

--- a/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
@@ -72,8 +72,6 @@ getWireValue VarInt _ = getVarInt
 getWireValue Fixed64 _ = anyBits
 getWireValue Fixed32 _ = anyBits
 getWireValue Lengthy _ = getVarInt >>= Parse.take . fromIntegral
--- Precompute the final EndGroup tag and keep parsing key-value pairs until
--- we reach the EndGroup.
 getWireValue StartGroup tag = return ()
 getWireValue EndGroup tag = return ()
 


### PR DESCRIPTION
Motivated by #58, it turned out there were a few space leaks in the decoder:
- Made all message fields strict
- Add bang patterns to the decoding code
- Don't generate an intermediate list of TaggedValues.

These changes had the happy side effect of significantly speeding up our
decoding benchmarks.  Additionally the "decode/whnf" and "decode/nf" tests now
take the same amount of time, indicating that we do fully force the messages.

|                                              |              before  |                after |
| -------------------------------------------- | -------------------- | -------------------- |
|nested:flat(68kB)/encode                      |  3.547ms (+/- 0.009) |  2.559ms (+/- 0.003) |
|nested:flat(68kB)/decode/whnf                 | 16.304ms (+/- 0.295) |  7.225ms (+/- 0.039) |
|nested:flat(68kB)/decode/nf                   | 19.417ms (+/- 0.198) |  7.283ms (+/- 0.044) |
|nested:nested(87kB)/encode                    | 10.670ms (+/- 0.279) |  7.791ms (+/- 0.040) |
|nested:nested(87kB)/decode/whnf               | 18.310ms (+/- 0.347) | 13.749ms (+/- 0.023) |
|nested:nested(87kB)/decode/nf                 | 21.977ms (+/- 0.185) | 13.780ms (+/- 0.043) |
|int-packing:int32-unpacked(19kB)/encode       |  1.319ms (+/- 0.003) |  0.704ms (+/- 0.011) |
|int-packing:int32-unpacked(19kB)/decode/whnf  |  8.300ms (+/- 0.337) |  3.246ms (+/- 0.005) |
|int-packing:int32-unpacked(19kB)/decode/nf    |  9.772ms (+/- 0.302) |  3.269ms (+/- 0.006) |
|int-packing:int32-packed(10003B)/encode       |  0.869ms (+/- 0.003) |  0.775ms (+/- 0.002) |
|int-packing:int32-packed(10003B)/decode/whnf  |  1.809ms (+/- 0.048) |  1.670ms (+/- 0.002) |
|int-packing:int32-packed(10003B)/decode/nf    |  3.372ms (+/- 0.129) |  1.707ms (+/- 0.002) |
|unused-fields:no-unused(19kB)/encode          |  1.341ms (+/- 0.004) |  0.693ms (+/- 0.004) |
|unused-fields:no-unused(19kB)/decode/whnf     |  8.253ms (+/- 0.076) |  3.125ms (+/- 0.015) |
|unused-fields:no-unused(19kB)/decode/nf       |  9.713ms (+/- 0.072) |  3.148ms (+/- 0.016) |
|unused-fields:with-unused(19kB)/encode        |  1.363ms (+/- 0.004) |  0.720ms (+/- 0.035) |
|unused-fields:with-unused(19kB)/decode/whnf   | 12.224ms (+/- 0.096) |  3.599ms (+/- 0.099) |
|unused-fields:with-unused(19kB)/decode/nf     | 13.383ms (+/- 0.233) |  3.608ms (+/- 0.007) |