### PR TITLE
Fix the handling of packed repeated fields (#38).

### DIFF
--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -34,14 +34,15 @@ import Bootstrap.Proto.Google.Protobuf.Descriptor
     , FieldDescriptorProto'Label(..)
     , FieldDescriptorProto'Type(..)
     , FileDescriptorProto
+    , FieldOptions
     , defaultValue
     , label
     , mapEntry
     , maybe'oneofIndex
+    , maybe'packed
     , name
     , number
     , options
-    , packed
     , syntax
     , type'
     , typeName
@@ -631,7 +632,7 @@ fieldAccessorExpr syntaxType env f = accessorCon @@ Var (UnQual hsFieldName)
                          @@ fromString (overloadedField k)
                          @@ fromString (overloadedField v)
               | otherwise -> "Data.ProtoLens.RepeatedField"
-                  @@ if fd ^. options.packed
+                  @@ if isPackedField syntaxType fd
                         then "Data.ProtoLens.Packed"
                         else "Data.ProtoLens.Unpacked"
     hsFieldName
@@ -648,6 +649,19 @@ isDefaultingOptional syntaxType f
           && f ^. type' /= FieldDescriptorProto'TYPE_MESSAGE
           -- For now, we treat oneof's like proto2 optional fields.
           && isNothing (f ^. maybe'oneofIndex)
+
+isPackedField :: SyntaxType -> FieldDescriptorProto -> Bool
+isPackedField s f = case f ^. options . maybe'packed of
+    Just t -> t
+    -- proto3 fields are packed by default.  Annoyingly, we need to
+    -- implement this logic manually rather than relying on protoc.
+    Nothing -> s == Proto3
+                && f ^. type' `notElem`
+                      [ FieldDescriptorProto'TYPE_MESSAGE
+                      , FieldDescriptorProto'TYPE_GROUP
+                      , FieldDescriptorProto'TYPE_STRING
+                      , FieldDescriptorProto'TYPE_BYTES
+                      ]
 
 fieldTypeDescriptorExpr :: FieldDescriptorProto'Type -> Exp
 fieldTypeDescriptorExpr =

--- a/proto-lens-tests/tests/packed_test.hs
+++ b/proto-lens-tests/tests/packed_test.hs
@@ -16,20 +16,21 @@ import Data.ProtoLens.TestUtil
 defFoo :: Foo
 defFoo = def
 
--- TODO: currently packed fields are *always* set in the encoding; see
--- empty "tagged 2" in the below tests.  Should we instead omit them
--- when they're empty?
-
 main = testMain
-    [ serializeTo "default" defFoo mempty $ tagged 2 $ Lengthy mempty
-    , serializeTo "repeated unpacked"
+    [ serializeTo "default" defFoo mempty mempty
+    , serializeTo "unpacked"
           (defFoo & a .~ [1..3])
           (vcat [keyed "a" x | x <- [1..3]])
           $ mconcat [tagged 1 $ VarInt x | x <- [1..3]]
-            <> tagged 2 (Lengthy mempty)
-    , serializeTo "repeated packed"
+    , serializeTo "packed"
           (defFoo & b .~ [1..3])
           (vcat [keyed "b" x | x <- [1..3]])
           $ tagged 2 $ Lengthy $ mconcat [varInt x | x <- [1..3]]
+    , deserializeFrom "unpacked-as-packed"
+          (Just $ defFoo & a .~ [1..3])
+          $ tagged 1 $ Lengthy $ mconcat [varInt x | x <- [1..3]]
+    , deserializeFrom "packed-as-unpacked"
+          (Just $ defFoo & b .~ [1..3])
+          $ mconcat [tagged 2 $ VarInt x | x <- [1..3]]
     , runTypedTest (roundTripTest "roundtrip" :: TypedTest Foo)
     ]

--- a/proto-lens-tests/tests/proto3.proto
+++ b/proto-lens-tests/tests/proto3.proto
@@ -20,6 +20,8 @@ message Foo {
     Enum2 = 1;
   }
   FooEnum enum = 6;
+
+  repeated int32 f = 7;
 }
 
 message Strings {

--- a/proto-lens-tests/tests/proto3_test.hs
+++ b/proto-lens-tests/tests/proto3_test.hs
@@ -24,6 +24,7 @@ import Proto.Proto3
     , c
     , d
     , e
+    , f
     , sub
     , maybe'c
     , maybe'sub
@@ -62,6 +63,11 @@ main = testMain
             Nothing @=? (def :: Foo) ^. maybe'c
             Just 42 @=? ((def :: Foo) & c .~ 42) ^. maybe'c
         ]
+    -- Repeated scalar fields in proto3 should serialize as "packed" by default.
+    , serializeTo "packed-by-default"
+        (def & f .~ [1,2,3] :: Foo)
+        (vcat [keyed "f" x | x <- [1..3]])
+        $ tagged 7 $ Lengthy $ mconcat [varInt x | x <- [1..3]]
     , runTypedTest (roundTripTest "foo" :: TypedTest Foo)
     ]
   , testGroup "Strings"

--- a/proto-lens/src/Data/ProtoLens/Encoding.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding.hs
@@ -101,7 +101,7 @@ parseAndAddField
           getPackedVals = case fieldWireType typeDescriptor of
             GroupFieldType -> fail "Groups can't be packed"
             FieldWireType fieldWt _ get -> runEither $ do
-              Equal <- equalWireTypes name wt Lengthy
+              Equal <- equalWireTypes name Lengthy wt
               let getElt = do
                         wv <- getWireValue fieldWt tag
                         x <- runEither $ get wv

--- a/proto-lens/src/Data/ProtoLens/Encoding.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding.hs
@@ -100,7 +100,7 @@ parseAndAddField
           -- Get a block of packed values, reversed.
           getPackedVals = case fieldWireType typeDescriptor of
             GroupFieldType -> fail "Groups can't be packed"
-            (FieldWireType fieldWt _ get :: FieldWireType a) -> runEither $ do
+            FieldWireType fieldWt _ get -> runEither $ do
               Equal <- equalWireTypes name wt Lengthy
               let getElt = do
                         wv <- getWireValue fieldWt tag

--- a/proto-lens/src/Data/ProtoLens/Encoding.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding.hs
@@ -100,13 +100,13 @@ parseAndAddField
           -- Get a block of packed values, reversed.
           getPackedVals = case fieldWireType typeDescriptor of
             GroupFieldType -> fail "Groups can't be packed"
-            FieldWireType fieldWt _ get -> runEither $ do
+            FieldWireType fieldWt _ get -> do
               Equal <- equalWireTypes name Lengthy wt
               let getElt = do
                         wv <- getWireValue fieldWt tag
                         x <- runEither $ get wv
                         return $! x
-              parseOnly (manyReversedTill getElt endOfInput) val
+              runEither $ parseOnly (manyReversedTill getElt endOfInput) val
           in case accessor of
               PlainField _ f -> do
                   !x <- getSimpleVal


### PR DESCRIPTION
- Don't emit empty packed fields during encoding.
- Allow parsing packed fields as unpacked and vice versa.
- Proto3 repeated fields are packed by default.