### PR TITLE
Make the bootstrapping process more robust:

### DIFF
--- a/bootstrap.hs
+++ b/bootstrap.hs
@@ -6,29 +6,28 @@
 
 -- To regenerate the bootstrapping proto bindings:
 -- $ runghc bootstrap.hs
+-- Note: if this doesn't work, you may need to edit the "location" field in
+-- stack-boostrap.yaml.
 import Control.Applicative ((<$>))
 import System.FilePath ((</>))
 import System.Process (callProcess, readProcess)
 
 protoRoot = "google/protobuf/src"
-protoc = protoRoot </> "protoc"
-modulePrefix = "Bootstrap.Proto"
-bootstrapModuleRoot = "proto-lens-protoc/src"
+protoc = "protoc"
+bootstrapModuleRoot = "proto-lens-descriptors/src"
+useBootstrappingYaml = "--stack-yaml=stack-bootstrap.yaml"
 
 main = do
   [installRoot] <- lines <$> readProcess "stack"
-                                ["path", "--local-install-root"] ""
-  -- TODO: use Data.ProtoLens.Setup (but use the locally built proto-lens-protoc)
+                    [useBootstrappingYaml, "path", "--local-install-root"] ""
   let protocGenHaskell = installRoot </> "bin/proto-lens-protoc"
-  callProcess "stack" ["build"]
+  callProcess "stack" [useBootstrappingYaml, "build", "proto-lens-protoc"]
   callProcess protoc $
       [ "--plugin=protoc-gen-haskell=" ++ protocGenHaskell
-      , "--haskell_out=" ++ modulePrefix ++ ":" ++ bootstrapModuleRoot
+      , "--haskell_out=UseOriginal:" ++ bootstrapModuleRoot
       , "--proto_path=" ++ protoRoot
       ]
       ++ map (protoRoot </>)
           [ "google/protobuf/descriptor.proto"
           , "google/protobuf/compiler/plugin.proto"
           ]
-
-

--- a/bootstrap.hs
+++ b/bootstrap.hs
@@ -24,7 +24,7 @@ main = do
   callProcess "stack" [useBootstrappingYaml, "build", "proto-lens-protoc"]
   callProcess protoc $
       [ "--plugin=protoc-gen-haskell=" ++ protocGenHaskell
-      , "--haskell_out=UseOriginal:" ++ bootstrapModuleRoot
+      , "--haskell_out=no-reexports:" ++ bootstrapModuleRoot
       , "--proto_path=" ++ protoRoot
       ]
       ++ map (protoRoot </>)

--- a/proto-lens-descriptors/LICENSE
+++ b/proto-lens-descriptors/LICENSE
@@ -1,0 +1,30 @@
+Copyright Author name here (c) 2017
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Author name here nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/proto-lens-descriptors/LICENSE
+++ b/proto-lens-descriptors/LICENSE
@@ -1,4 +1,4 @@
-Copyright Author name here (c) 2017
+Copyright (c) 2017, Google Inc.
 
 All rights reserved.
 

--- a/proto-lens-descriptors/Setup.hs
+++ b/proto-lens-descriptors/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/proto-lens-descriptors/proto-lens-descriptors.cabal
+++ b/proto-lens-descriptors/proto-lens-descriptors.cabal
@@ -1,0 +1,31 @@
+name:                proto-lens-descriptors
+version:             0.1.0.4
+synopsis:            Protocol buffers for describing the definitions of messages.
+description:
+    This package provides definitions for the 'proto-lens' package
+    of message types which describe @.proto@ files.
+license:             BSD3
+license-file:        LICENSE
+author:              Judah Jacobson
+maintainer:          judahjacobson@google.com
+copyright:           Google Inc.
+category:            Data
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  exposed-modules:
+      Proto.Google.Protobuf.Compiler.Plugin
+      Proto.Google.Protobuf.Descriptor
+  default-language:    Haskell2010
+  build-depends:
+      base >= 4.8 && < 4.10
+    , containers == 0.5.*
+    , bytestring == 0.10.*
+    , data-default-class >= 0.0 && < 0.2
+    , lens-family == 1.2.*
+    -- Specify an exact version of `proto-lens`, since it's tied closely
+    -- to the generated code.
+    , proto-lens == 0.1.0.4
+    , text == 1.2.*

--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -1,27 +1,28 @@
 {- This file was auto-generated from google/protobuf/compiler/plugin.proto by the proto-lens-protoc program. -}
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies,
-  MultiParamTypeClasses, FlexibleContexts, FlexibleInstances #-}
+  MultiParamTypeClasses, FlexibleContexts, FlexibleInstances,
+  PatternSynonyms #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports#-}
-module Bootstrap.Proto.Google.Protobuf.Compiler.Plugin where
+module Proto.Google.Protobuf.Compiler.Plugin where
 import qualified Prelude
+import qualified Data.Int
+import qualified Data.Word
 import qualified Data.ProtoLens
 import qualified Data.ProtoLens.Message.Enum
 import qualified Lens.Family2
 import qualified Lens.Family2.Unchecked
 import qualified Data.Default.Class
 import qualified Data.Text
-import qualified Data.Int
-import qualified Data.Word
 import qualified Data.Map
 import qualified Data.ByteString
-import qualified Bootstrap.Proto.Google.Protobuf.Descriptor
+import qualified Proto.Google.Protobuf.Descriptor
 
 data CodeGeneratorRequest = CodeGeneratorRequest{_CodeGeneratorRequest'fileToGenerate
                                                  :: [Data.Text.Text],
                                                  _CodeGeneratorRequest'parameter ::
                                                  Prelude.Maybe Data.Text.Text,
                                                  _CodeGeneratorRequest'protoFile ::
-                                                 [Bootstrap.Proto.Google.Protobuf.Descriptor.FileDescriptorProto]}
+                                                 [Proto.Google.Protobuf.Descriptor.FileDescriptorProto]}
                           deriving (Prelude.Show, Prelude.Eq)
 
 type instance
@@ -54,7 +55,7 @@ instance Data.ProtoLens.HasField "maybe'parameter"
               (\ x__ y__ -> x__{_CodeGeneratorRequest'parameter = y__})
 
 type instance Data.ProtoLens.Field "protoFile" CodeGeneratorRequest
-     = [Bootstrap.Proto.Google.Protobuf.Descriptor.FileDescriptorProto]
+     = [Proto.Google.Protobuf.Descriptor.FileDescriptorProto]
 
 instance Data.ProtoLens.HasField "protoFile" CodeGeneratorRequest
          CodeGeneratorRequest where
@@ -85,7 +86,7 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                   = Data.ProtoLens.FieldDescriptor "proto_file"
                       (Data.ProtoLens.MessageField ::
                          Data.ProtoLens.FieldTypeDescriptor
-                           Bootstrap.Proto.Google.Protobuf.Descriptor.FileDescriptorProto)
+                           Proto.Google.Protobuf.Descriptor.FileDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked protoFile)
               in
               Data.ProtoLens.MessageDescriptor

--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor.hs
@@ -1,17 +1,18 @@
 {- This file was auto-generated from google/protobuf/descriptor.proto by the proto-lens-protoc program. -}
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies,
-  MultiParamTypeClasses, FlexibleContexts, FlexibleInstances #-}
+  MultiParamTypeClasses, FlexibleContexts, FlexibleInstances,
+  PatternSynonyms #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports#-}
-module Bootstrap.Proto.Google.Protobuf.Descriptor where
+module Proto.Google.Protobuf.Descriptor where
 import qualified Prelude
+import qualified Data.Int
+import qualified Data.Word
 import qualified Data.ProtoLens
 import qualified Data.ProtoLens.Message.Enum
 import qualified Lens.Family2
 import qualified Lens.Family2.Unchecked
 import qualified Data.Default.Class
 import qualified Data.Text
-import qualified Data.Int
-import qualified Data.Word
 import qualified Data.Map
 import qualified Data.ByteString
 

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -16,10 +16,18 @@ category:            Data
 build-type:          Simple
 cabal-version:       >=1.21
 
+-- Work around stack bug, since we don't want to build the library
+-- during bootstrapping:
+-- https://github.com/commercialhaskell/stack/issues/1406
+flag only-executable
+    Description: Only build the executable.  Used for bootstrapping.
+    Default: False
+
 library
+  if flag(only-executable) {
+      buildable: False
+  }
   exposed-modules:
-      Bootstrap.Proto.Google.Protobuf.Compiler.Plugin
-      Bootstrap.Proto.Google.Protobuf.Descriptor
       Data.ProtoLens.Compiler.Combinators
       Data.ProtoLens.Compiler.Definitions
       Data.ProtoLens.Compiler.Generate
@@ -39,6 +47,7 @@ library
       , lens-family == 1.2.*
       , process >= 1.2 && < 1.5
       , proto-lens == 0.1.0.4
+      , proto-lens-descriptors == 0.1.0.4
       , text == 1.2.*
   reexported-modules:
       -- Modules that are needed by the generated Haskell files.
@@ -68,11 +77,10 @@ executable proto-lens-protoc
       -- Specify an exact version of `proto-lens`, since it's tied closely
       -- to the generated code.
       , proto-lens == 0.1.0.4
+      , proto-lens-descriptors == 0.1.0.4
       , text == 1.2.*
   hs-source-dirs:      src
   other-modules:
-      Bootstrap.Proto.Google.Protobuf.Compiler.Plugin
-      Bootstrap.Proto.Google.Protobuf.Descriptor
       Data.ProtoLens.Compiler.Combinators
       Data.ProtoLens.Compiler.Definitions
       Data.ProtoLens.Compiler.Generate

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -32,7 +32,7 @@ import Data.Text (Text, cons, splitOn, toLower, uncons, unpack)
 import qualified Data.Text as T
 import Language.Haskell.Exts.Syntax (Name(..), QName(..), ModuleName(..))
 import Lens.Family2 ((^.))
-import Bootstrap.Proto.Google.Protobuf.Descriptor
+import Proto.Google.Protobuf.Descriptor
     ( DescriptorProto
     , EnumDescriptorProto
     , EnumValueDescriptorProto

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -10,7 +10,7 @@
 module Data.ProtoLens.Compiler.Generate(
     generateModule,
     fileSyntaxType,
-    ImportDecl,
+    ModifyImports,
     reexported,
     ) where
 
@@ -72,7 +72,7 @@ data UseReexport = UseReexport | UseOriginal
 generateModule :: ModuleName
                -> [ModuleName]  -- ^ The imported modules
                -> SyntaxType
-               -> (ImportDecl -> ImportDecl)
+               -> ModifyImports
                -> Env Name      -- ^ Definitions in this file
                -> Env QName     -- ^ Definitions in the imported modules
                -> Module
@@ -125,7 +125,9 @@ importSimple m = ImportDecl
     , importSpecs = Nothing
     }
 
-reexported :: ImportDecl -> ImportDecl
+type ModifyImports = ImportDecl -> ImportDecl
+
+reexported :: ModifyImports
 reexported imp@ImportDecl {importModule = m@(ModuleName s)}
     = imp { importAs = Just m, importModule = m' }
   where

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
@@ -26,7 +26,7 @@ import qualified Data.Text as T
 import Data.Text (Text)
 import Language.Haskell.Exts.Syntax (ModuleName(..), Name(..), QName(..))
 import Lens.Family2
-import Bootstrap.Proto.Google.Protobuf.Descriptor
+import Proto.Google.Protobuf.Descriptor
     (FileDescriptorProto, name, dependency, publicDependency)
 import System.FilePath (dropExtension, splitDirectories)
 
@@ -88,12 +88,9 @@ moduleName modulePrefix fd = ModuleName (moduleNameStr modulePrefix fd)
 
 -- | Get the Haskell module name corresponding to a given .proto file.
 moduleNameStr :: Text -> FileDescriptorProto -> String
-moduleNameStr modulePrefix fd = fixModuleName rawModuleName
+moduleNameStr prefix fd = fixModuleName rawModuleName
   where
     path = fd ^. name
-    prefix
-        | T.null modulePrefix = "Proto"
-        | otherwise = modulePrefix
     fixModuleName "" = ""
     -- Characters allowed in Bazel filenames but not in module names:
     fixModuleName ('.':c:cs) = '.' : toUpper c : fixModuleName cs

--- a/proto-lens-protoc/src/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/src/protoc-gen-haskell.hs
@@ -20,7 +20,7 @@ import Data.ProtoLens (decodeMessage, def, encodeMessage)
 import Language.Haskell.Exts.Pretty (prettyPrint)
 import Language.Haskell.Exts.Syntax (ModuleName(..), Name(..), QName(..))
 import Lens.Family2
-import Bootstrap.Proto.Google.Protobuf.Compiler.Plugin
+import Proto.Google.Protobuf.Compiler.Plugin
     ( CodeGeneratorRequest
     , CodeGeneratorResponse
     , content
@@ -29,28 +29,36 @@ import Bootstrap.Proto.Google.Protobuf.Compiler.Plugin
     , parameter
     , protoFile
     )
-import Bootstrap.Proto.Google.Protobuf.Descriptor
+import Proto.Google.Protobuf.Descriptor
     (FileDescriptorProto, name, dependency, publicDependency)
 import System.Environment (getProgName)
 import System.Exit (exitWith, ExitCode(..))
 import System.IO as IO
 import System.FilePath (dropExtension, replaceExtension, splitDirectories)
-
+import Text.Read (readEither)
 
 import Data.ProtoLens.Compiler.Definitions
 import Data.ProtoLens.Compiler.Generate
 import Data.ProtoLens.Compiler.Plugin
+import System.Environment (getArgs)
 
 main = do
     contents <- B.getContents
     progName <- getProgName
+    args <- getArgs
     case decodeMessage contents of
         Left e -> IO.hPutStrLn stderr e >> exitWith (ExitFailure 1)
         Right x -> B.putStr $ encodeMessage $ makeResponse progName x
 
 makeResponse :: String -> CodeGeneratorRequest -> CodeGeneratorResponse
 makeResponse prog request = let
-    outputFiles = generateFiles (request ^. parameter) header
+    useReexport = case T.unpack $ request ^. parameter of
+                    "" -> UseReexport
+                    p -> case readEither p of
+                            Left err -> error $ "Error reading parameter: "
+                                            ++ err
+                            Right x -> x
+    outputFiles = generateFiles useReexport header
                       (request ^. protoFile)
                       (request ^. fileToGenerate)
     header :: FileDescriptorProto -> Text
@@ -63,9 +71,10 @@ makeResponse prog request = let
                      ]
 
 
-generateFiles :: Text -> (FileDescriptorProto -> Text) -> [FileDescriptorProto]
+generateFiles :: UseReexport -> (FileDescriptorProto -> Text) -> [FileDescriptorProto]
               -> [ProtoFileName] -> [(Text, Text)]
-generateFiles modulePrefix header files toGenerate = let
+generateFiles useReexport header files toGenerate = let
+  modulePrefix = "Proto"
   filesByName = analyzeProtoFiles modulePrefix files
   -- The contents of the generated Haskell file for a given .proto file.
   buildFile file = let
@@ -77,6 +86,7 @@ generateFiles modulePrefix header files toGenerate = let
                   ]
       in generateModule (haskellModule file) imports
              (fileSyntaxType (descriptor file))
+             useReexport
              (definitions file)
              (collectEnvFromDeps deps filesByName)
   in [ ( outputFilePath . (\(ModuleName n) -> n) . haskellModule $ file

--- a/proto-lens-protoc/src/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/src/protoc-gen-haskell.hs
@@ -69,7 +69,7 @@ makeResponse prog request = let
                      ]
 
 
-generateFiles :: (ImportDecl -> ImportDecl) -> (FileDescriptorProto -> Text)
+generateFiles :: ModifyImports -> (FileDescriptorProto -> Text)
               -> [FileDescriptorProto] -> [ProtoFileName] -> [(Text, Text)]
 generateFiles modifyImports header files toGenerate = let
   modulePrefix = "Proto"

--- a/stack-7.10.yaml
+++ b/stack-7.10.yaml
@@ -1,6 +1,7 @@
 resolver: lts-6.22
 packages:
 - proto-lens
+- proto-lens-descriptors
 - proto-lens-protoc
 - proto-lens-arbitrary
 - proto-lens-combinators

--- a/stack-bootstrap.yaml
+++ b/stack-bootstrap.yaml
@@ -1,0 +1,22 @@
+resolver: lts-7.4
+packages:
+- proto-lens-protoc
+# Build the current HEAD proto-lens-protoc against older revisions of proto-lens
+# and proto-lens-descriptors that are consistent with each other.
+- location:
+    commit: master
+    # To use the github master:
+    # TODO(judahjacobson): Switch to this after we push
+    # proto-lens-descriptors to github.
+    # git: https://github.com/google/proto-lens
+    # To use the current repository:
+    git: ../..  # stack runs 'git clone' in a subdirectory
+  subdirs:
+  - proto-lens
+  - proto-lens-descriptors
+  extra-dep: True
+flags:
+  proto-lens-protoc:
+    # Skip the library; it's not needed for the executable, and the modules
+    # that it reexports may change between versions of proto-lens.
+    only-executable: True

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,7 @@
 resolver: lts-7.4
 packages:
 - proto-lens
+- proto-lens-descriptors
 - proto-lens-protoc
 - proto-lens-arbitrary
 - proto-lens-combinators

--- a/travis-cabal.sh
+++ b/travis-cabal.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 # give them to us in the right order.)
 PACKAGES="
     proto-lens
+    proto-lens-descriptors
     proto-lens-protoc
     proto-lens-arbitrary
     proto-lens-combinators


### PR DESCRIPTION
- Make a new package 'proto-lens-descriptors' for the descriptors
- Name those modules "Proto.*" instead of "Bootstrap.Proto.*"
- Add special logic so the descriptors modules don't use the reexported
  modules from proto-lens-protoc (otherwise we'd get a circular dependency)
- Make the bootstrapping script use a special stack YAML file.