### PR TITLE
Fix #40 (print fields ordered by tag number).

### DIFF
--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -602,8 +602,8 @@ fieldDescriptorExpr :: SyntaxType -> Env QName -> FieldInfo
                     -> Exp
 fieldDescriptorExpr syntaxType env f
     = "Data.ProtoLens.FieldDescriptor"
-        -- Record the original .proto name for text format
-        @@ Lit (Syntax.String (T.unpack $ fd ^. name))
+        -- Record the .proto field name as used in text format
+        @@ Lit (Syntax.String $ T.unpack $ textFormatFieldName env fd)
         -- Force the type signature since it can't be inferred for Map entry
         -- types.
         @@ ExpTypeSig noLoc (fieldTypeDescriptorExpr (fd ^. type'))

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -123,7 +123,7 @@ Test-Suite text_format_test
   default-language: Haskell2010
   type: exitcode-stdio-1.0
   main-is: text_format_test.hs
-  other-modules: Proto.Canonical
+  other-modules: Proto.TextFormat
   hs-source-dirs: tests
   build-depends: HUnit
                , base

--- a/proto-lens-tests/tests/canonical.proto
+++ b/proto-lens-tests/tests/canonical.proto
@@ -19,8 +19,3 @@ message Test3 {
 message Test4 {
     repeated int32 d = 4 [packed=true];
 }
-
-message Test5 {
-    required bytes e = 1;
-}
-

--- a/proto-lens-tests/tests/text_format.proto
+++ b/proto-lens-tests/tests/text_format.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package text_format;
+
+message Test1 {
+  // Note: the field tag numbers are intentionally ordered differently
+  // than the names, to make sure we print ordered by tag number.
+  optional int32 a = 4;
+  optional string b = 1;
+  repeated int32 d = 2 [packed=true];
+  optional bytes e = 3;
+}
+
+message Test2 {
+  optional Test1 c = 1;
+}

--- a/proto-lens-tests/tests/text_format_test.hs
+++ b/proto-lens-tests/tests/text_format_test.hs
@@ -15,7 +15,7 @@ import Data.Word (Word8)
 import Data.ProtoLens (
     def, Message, showMessage, showMessageShort, pprintMessage)
 import Lens.Family2 ((&), (.~))
-import Proto.Canonical
+import Proto.TextFormat
 import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit ((@=?))
 import Text.PrettyPrint (renderStyle, style, lineLength)
@@ -28,15 +28,6 @@ def1 = def
 def2 :: Test2
 def2 = def
 
-def3 :: Test3
-def3 = def
-
-def4 :: Test4
-def4 = def
-
-def5 :: Test5
-def5 = def
-
 failed1 :: Maybe Test1
 failed1 = Nothing
 
@@ -45,36 +36,41 @@ showMessageWithLineLength n = renderStyle style {lineLength=n} . pprintMessage
 
 main = testMain
     [ readFrom "spaces" (Just $ def1 & a .~ 5) "  a: \n5  "
-    , readFrom "string concat" (Just $ def2 & b .~ "abcdef")
+    , readFrom "string concat" (Just $ def1 & b .~ "abcdef")
           "b: \"a\"\"bcd\" \n   \"ef\""
     , readFrom "bad char" failed1 "a: 5="
-    , readFrom "same line" (Just $ def4 & d .~ [1, 2, 3])
+    , readFrom "same line" (Just $ def1 & d .~ [1, 2, 3])
           "d: 1 d: 2    d: 3   "
-    , readFrom "int field" (Just $ def1 & a .~ 5) "1: 5"
-    , readFrom "bad int field" failed1 "4: 5"
-    , readFrom "braces" (Just $ def3 & c.a .~ 5) "c { a: 5 }"
-    , readFrom "bracesColon" (Just $ def3 & c.a .~ 5) "c: {  a: 5\n}"
-    , readFrom "angles" (Just $ def3 & c.a .~ 5) "c < a: 5 >"
-    , readFrom "anglesMultiLine" (Just $ def3 & c.a .~ 5) "c \n<  a: 5\n>"
+    , readFrom "int field" (Just $ def1 & a .~ 5) "4: 5"
+    , readFrom "bad int field" failed1 "1: 5"
+    , readFrom "braces" (Just $ def2 & c.a .~ 5) "c { a: 5 }"
+    , readFrom "bracesColon" (Just $ def2 & c.a .~ 5) "c: {  a: 5\n}"
+    , readFrom "angles" (Just $ def2 & c.a .~ 5) "c < a: 5 >"
+    , readFrom "anglesMultiLine" (Just $ def2 & c.a .~ 5) "c \n<  a: 5\n>"
     -- TODO: Note that this test currently fails either way since
     -- extensions aren't implemented yet.  Keeping it around to make
     -- sure the test case still fails when they are.
     , readFrom "empty extension" failed1 "[]: 5"
     , testCase "Render same line" $
-        "d: 1 d: 2 d: 3" @=? showMessage (def4 & d .~ [1, 2, 3])
+        "d: 1 d: 2 d: 3" @=? showMessage (def1 & d .~ [1, 2, 3])
     , testCase "Render multiple lines" $
         "d: 1\nd: 2\nd: 3" @=?
-            showMessageWithLineLength 3 (def4 & d .~ [1, 2, 3])
+            showMessageWithLineLength 3 (def1 & d .~ [1, 2, 3])
+    , testCase "Field order" $
+        "b: \"xyz\" d: 1 d: 2 a: 3" @=?
+            showMessage (def1 & b .~ "xyz"
+                              & d .~ [1,2]
+                              & a .~ 3)
     , readFrom
          ("Parse string with numeric escape sequences"
              ++ " (including ones we do not emit)")
           -- '\o172' == '\x7a' == 'z'
-         (Just $ def2 & b .~ "\o1\o12\o123\x2\o172z3z3")
+         (Just $ def1 & b .~ "\o1\o12\o123\x2\o172z3z3")
          (Data.Text.Lazy.pack "b: \"\\001\\012\\123\\002\\172\\x7a3\\1723\"")
     , readFrom
          ("Parse string with non-numeric escape sequences"
              ++ " (including ones we do not emit)")
-         (Just $ def2 & b .~ "\a\b\f\n\r\t\v\\\'\"")
+         (Just $ def1 & b .~ "\a\b\f\n\r\t\v\\\'\"")
          (Data.Text.Lazy.pack "b: \"\a\b\f\n\r\t\v\\\\\\\'\\\"\"")
     , testCase "Render string with escape sequences" $
         escapeRendered @=? showMessageShort escapeMessage
@@ -83,17 +79,17 @@ main = testMain
     , testCase "Render bytes" $
          invalidUTF8BytesRendered @=? showMessage invalidUTF8BytesMessage
     , readFrom "Parse single-quote-delimited string"
-         (Just $ def2 & b .~ "ab\o2") "b: \'ab\2\'"
+         (Just $ def1 & b .~ "ab\o2") "b: \'ab\2\'"
     , readFrom "Non-UTF8 bytes"
          (Just invalidUTF8BytesMessage)
          (Data.Text.Lazy.pack invalidUTF8BytesRendered)
     , let kNums = [0..99]  -- The default line limit is 100 so we exceed it.
           kExpected = unwords $ map (("d: " ++) . show) kNums
       in testCase "Render single line for debugString" $
-          kExpected @=? showMessageShort (def4 & d .~ kNums)
+          kExpected @=? showMessageShort (def1 & d .~ kNums)
     ]
   where
-    escapeMessage  = def2 & b
+    escapeMessage  = def1 & b
         .~ ("a\r\n\t\"\'\\" <> "bc\o030" <> "1" <> "\o109" <> "¢" <> "\o1")
     escapeRendered =
         -- 'a' followed by all the non-numeric escapes we emit:
@@ -105,6 +101,6 @@ main = testMain
         ++ "\\001"         -- Works fine at EOL.
         ++ "\""
     invalidUTF8BytesMessage =
-        def5 & e .~ Data.ByteString.pack (map (fromIntegral . ord) "abc"
+        def1 & e .~ Data.ByteString.pack (map (fromIntegral . ord) "abc"
             ++ [0xC0, 0xC0, 0x0])  -- Invalid UTF8.
     invalidUTF8BytesRendered = "e: \"abc\\300\\300\\000\""

--- a/proto-lens/src/Data/ProtoLens/Message.hs
+++ b/proto-lens/src/Data/ProtoLens/Message.hs
@@ -64,7 +64,9 @@ newtype Tag = Tag { unTag :: Int}
 
 -- | A description of a specific field of a protocol buffer.
 --
--- The 'String' parameter is the original name of the field in the .proto file.
+-- The 'String' parameter is the name of the field from the .proto file,
+-- as used in TextFormat, with the same behavior for groups as
+-- 'fieldsByTextFormatName'.
 -- (Haddock doesn't support per-argument docs for GADTs.)
 data FieldDescriptor msg where
     FieldDescriptor :: String

--- a/proto-lens/src/Data/ProtoLens/TextFormat.hs
+++ b/proto-lens/src/Data/ProtoLens/TextFormat.hs
@@ -70,11 +70,10 @@ pprintMessage' descr msg
     -- for each field.  We use a single "sep" for all fields (and all elements
     -- of all the repeated fields) to avoid putting some repeated fields on one
     -- line and other fields on multiple lines, which is less readable.
-    = sep $ concatMap (pprintField msg) $ Map.toList
-        $ fieldsByTextFormatName descr
+    = sep $ concatMap (pprintField msg) $ Map.elems $ fieldsByTag descr
 
-pprintField :: msg -> (String, FieldDescriptor msg) -> [Doc]
-pprintField msg (name, FieldDescriptor _ typeDescr accessor)
+pprintField :: msg -> FieldDescriptor msg -> [Doc]
+pprintField msg (FieldDescriptor name typeDescr accessor)
     = map (pprintFieldValue name typeDescr) $ case accessor of
         PlainField d f
             | Optional <- d, val == fieldDefault -> []


### PR DESCRIPTION
Also split out text_format_test's .proto file rather than sharing it
with canonical_test.

Also changed the "field name" stored in Data.ProtoLens.Message.FieldDescriptor
to be the name of that type, which is more consistent with how TextFormat
prints/parses such messages.

Note: PR #48 previously referenced this bug, but it looks like that was a
typo since that fix was for string escaping, not field ordering.