### PR TITLE
Make bootstrapping more robust:

### DIFF
--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -36,7 +36,7 @@ library
     default-language:  Haskell2010
     hs-source-dirs:    src
     build-depends:
-            Cabal >= 1.22 && < 1.25
+          Cabal >= 1.22 && < 1.25
         , base >= 4.8 && < 4.10
         , bytestring == 0.10.*
         , containers == 0.5.*
@@ -54,7 +54,7 @@ library
         -- For forwards compatibility, reexport them as new module names so that
         -- other packages don't accidentally write non-generated code that
         -- relies on these modules being reexported by proto-lens-protoc.
-            Data.ByteString as Data.ProtoLens.Reexport.Data.ByteString
+          Data.ByteString as Data.ProtoLens.Reexport.Data.ByteString
         , Data.Default.Class as Data.ProtoLens.Reexport.Data.Default.Class
         , Data.Map as Data.ProtoLens.Reexport.Data.Map
         , Data.ProtoLens as Data.ProtoLens.Reexport.Data.ProtoLens

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -26,42 +26,43 @@ flag only-executable
 library
   if flag(only-executable) {
       buildable: False
-  }
-  exposed-modules:
-      Data.ProtoLens.Compiler.Combinators
-      Data.ProtoLens.Compiler.Definitions
-      Data.ProtoLens.Compiler.Generate
-      Data.ProtoLens.Compiler.Plugin
-      Data.ProtoLens.Setup
-  default-language:  Haskell2010
-  hs-source-dirs:    src
-  build-depends:
-        Cabal >= 1.22 && < 1.25
-      , base >= 4.8 && < 4.10
-      , bytestring == 0.10.*
-      , containers == 0.5.*
-      , data-default-class >= 0.0 && < 0.2
-      , directory == 1.2.*
-      , filepath == 1.4.*
-      , haskell-src-exts == 1.17.*
-      , lens-family == 1.2.*
-      , process >= 1.2 && < 1.5
-      , proto-lens == 0.1.0.4
-      , proto-lens-descriptors == 0.1.0.4
-      , text == 1.2.*
-  reexported-modules:
-      -- Modules that are needed by the generated Haskell files.
-      -- For forwards compatibility, reexport them as new module names so that
-      -- other packages don't accidentally write non-generated code that
-      -- relies on these modules being reexported by proto-lens-protoc.
-        Data.ByteString as Data.ProtoLens.Reexport.Data.ByteString
-      , Data.Default.Class as Data.ProtoLens.Reexport.Data.Default.Class
-      , Data.Map as Data.ProtoLens.Reexport.Data.Map
-      , Data.ProtoLens as Data.ProtoLens.Reexport.Data.ProtoLens
-      , Data.ProtoLens.Message.Enum as Data.ProtoLens.Reexport.Data.ProtoLens.Message.Enum
-      , Data.Text as Data.ProtoLens.Reexport.Data.Text
-      , Lens.Family2 as Data.ProtoLens.Reexport.Lens.Family2
-      , Lens.Family2.Unchecked as Data.ProtoLens.Reexport.Lens.Family2.Unchecked
+  } else {
+    exposed-modules:
+        Data.ProtoLens.Compiler.Combinators
+        Data.ProtoLens.Compiler.Definitions
+        Data.ProtoLens.Compiler.Generate
+        Data.ProtoLens.Compiler.Plugin
+        Data.ProtoLens.Setup
+    default-language:  Haskell2010
+    hs-source-dirs:    src
+    build-depends:
+            Cabal >= 1.22 && < 1.25
+        , base >= 4.8 && < 4.10
+        , bytestring == 0.10.*
+        , containers == 0.5.*
+        , data-default-class >= 0.0 && < 0.2
+        , directory == 1.2.*
+        , filepath == 1.4.*
+        , haskell-src-exts == 1.17.*
+        , lens-family == 1.2.*
+        , process >= 1.2 && < 1.5
+        , proto-lens == 0.1.0.4
+        , proto-lens-descriptors == 0.1.0.4
+        , text == 1.2.*
+    reexported-modules:
+        -- Modules that are needed by the generated Haskell files.
+        -- For forwards compatibility, reexport them as new module names so that
+        -- other packages don't accidentally write non-generated code that
+        -- relies on these modules being reexported by proto-lens-protoc.
+            Data.ByteString as Data.ProtoLens.Reexport.Data.ByteString
+        , Data.Default.Class as Data.ProtoLens.Reexport.Data.Default.Class
+        , Data.Map as Data.ProtoLens.Reexport.Data.Map
+        , Data.ProtoLens as Data.ProtoLens.Reexport.Data.ProtoLens
+        , Data.ProtoLens.Message.Enum as Data.ProtoLens.Reexport.Data.ProtoLens.Message.Enum
+        , Data.Text as Data.ProtoLens.Reexport.Data.Text
+        , Lens.Family2 as Data.ProtoLens.Reexport.Lens.Family2
+        , Lens.Family2.Unchecked as Data.ProtoLens.Reexport.Lens.Family2.Unchecked
+    }
 
 executable proto-lens-protoc
   main-is:  protoc-gen-haskell.hs


### PR DESCRIPTION
- Completely hide all library fields of proto-lens-protoc when only building
  the executable.  In particular, the `build-depends` packages may change
  between versions of the library, and otherwise stack would still try to
  resolve them.
- Do a full clean before and after running the bootstrapping script.  Stack
  doesn't seem robust enough to handle all edge cases, and I frequently had to
  do manual 'stack clean's in order to get things to work.