### PR TITLE
Use the "Annotated" API from haskell-src-exts-1.17.*.

### DIFF
--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies,
   UndecidableInstances, MultiParamTypeClasses, FlexibleContexts,
   FlexibleInstances, PatternSynonyms, MagicHash #-}
-{-# OPTIONS_GHC -fno-warn-unused-imports#-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 module Proto.Google.Protobuf.Compiler.Plugin where
 import qualified Prelude
 import qualified Data.Int

--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies,
   UndecidableInstances, MultiParamTypeClasses, FlexibleContexts,
   FlexibleInstances, PatternSynonyms, MagicHash #-}
-{-# OPTIONS_GHC -fno-warn-unused-imports#-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 module Proto.Google.Protobuf.Descriptor where
 import qualified Prelude
 import qualified Data.Int
@@ -1014,14 +1014,14 @@ instance Prelude.Enum FieldDescriptorProto'Label where
         fromEnum FieldDescriptorProto'LABEL_REPEATED = 3
         succ FieldDescriptorProto'LABEL_REPEATED
           = Prelude.error
-              "Ident \"FieldDescriptorProto'Label\".Ident \"succ\": bad argument Ident \"FieldDescriptorProto'LABEL_REPEATED\". This value would be out of bounds."
+              "FieldDescriptorProto'Label.succ: bad argument FieldDescriptorProto'LABEL_REPEATED. This value would be out of bounds."
         succ FieldDescriptorProto'LABEL_OPTIONAL
           = FieldDescriptorProto'LABEL_REQUIRED
         succ FieldDescriptorProto'LABEL_REQUIRED
           = FieldDescriptorProto'LABEL_REPEATED
         pred FieldDescriptorProto'LABEL_OPTIONAL
           = Prelude.error
-              "Ident \"FieldDescriptorProto'Label\".Ident \"pred\": bad argument Ident \"FieldDescriptorProto'LABEL_OPTIONAL\". This value would be out of bounds."
+              "FieldDescriptorProto'Label.pred: bad argument FieldDescriptorProto'LABEL_OPTIONAL. This value would be out of bounds."
         pred FieldDescriptorProto'LABEL_REQUIRED
           = FieldDescriptorProto'LABEL_OPTIONAL
         pred FieldDescriptorProto'LABEL_REPEATED
@@ -1164,7 +1164,7 @@ instance Prelude.Enum FieldDescriptorProto'Type where
         fromEnum FieldDescriptorProto'TYPE_SINT64 = 18
         succ FieldDescriptorProto'TYPE_SINT64
           = Prelude.error
-              "Ident \"FieldDescriptorProto'Type\".Ident \"succ\": bad argument Ident \"FieldDescriptorProto'TYPE_SINT64\". This value would be out of bounds."
+              "FieldDescriptorProto'Type.succ: bad argument FieldDescriptorProto'TYPE_SINT64. This value would be out of bounds."
         succ FieldDescriptorProto'TYPE_DOUBLE
           = FieldDescriptorProto'TYPE_FLOAT
         succ FieldDescriptorProto'TYPE_FLOAT
@@ -1201,7 +1201,7 @@ instance Prelude.Enum FieldDescriptorProto'Type where
           = FieldDescriptorProto'TYPE_SINT64
         pred FieldDescriptorProto'TYPE_DOUBLE
           = Prelude.error
-              "Ident \"FieldDescriptorProto'Type\".Ident \"pred\": bad argument Ident \"FieldDescriptorProto'TYPE_DOUBLE\". This value would be out of bounds."
+              "FieldDescriptorProto'Type.pred: bad argument FieldDescriptorProto'TYPE_DOUBLE. This value would be out of bounds."
         pred FieldDescriptorProto'TYPE_FLOAT
           = FieldDescriptorProto'TYPE_DOUBLE
         pred FieldDescriptorProto'TYPE_INT64
@@ -1459,12 +1459,12 @@ instance Prelude.Enum FieldOptions'CType where
         fromEnum FieldOptions'STRING_PIECE = 2
         succ FieldOptions'STRING_PIECE
           = Prelude.error
-              "Ident \"FieldOptions'CType\".Ident \"succ\": bad argument Ident \"FieldOptions'STRING_PIECE\". This value would be out of bounds."
+              "FieldOptions'CType.succ: bad argument FieldOptions'STRING_PIECE. This value would be out of bounds."
         succ FieldOptions'STRING = FieldOptions'CORD
         succ FieldOptions'CORD = FieldOptions'STRING_PIECE
         pred FieldOptions'STRING
           = Prelude.error
-              "Ident \"FieldOptions'CType\".Ident \"pred\": bad argument Ident \"FieldOptions'STRING\". This value would be out of bounds."
+              "FieldOptions'CType.pred: bad argument FieldOptions'STRING. This value would be out of bounds."
         pred FieldOptions'CORD = FieldOptions'STRING
         pred FieldOptions'STRING_PIECE = FieldOptions'CORD
         enumFrom = Data.ProtoLens.Message.Enum.messageEnumFrom
@@ -1513,12 +1513,12 @@ instance Prelude.Enum FieldOptions'JSType where
         fromEnum FieldOptions'JS_NUMBER = 2
         succ FieldOptions'JS_NUMBER
           = Prelude.error
-              "Ident \"FieldOptions'JSType\".Ident \"succ\": bad argument Ident \"FieldOptions'JS_NUMBER\". This value would be out of bounds."
+              "FieldOptions'JSType.succ: bad argument FieldOptions'JS_NUMBER. This value would be out of bounds."
         succ FieldOptions'JS_NORMAL = FieldOptions'JS_STRING
         succ FieldOptions'JS_STRING = FieldOptions'JS_NUMBER
         pred FieldOptions'JS_NORMAL
           = Prelude.error
-              "Ident \"FieldOptions'JSType\".Ident \"pred\": bad argument Ident \"FieldOptions'JS_NORMAL\". This value would be out of bounds."
+              "FieldOptions'JSType.pred: bad argument FieldOptions'JS_NORMAL. This value would be out of bounds."
         pred FieldOptions'JS_STRING = FieldOptions'JS_NORMAL
         pred FieldOptions'JS_NUMBER = FieldOptions'JS_STRING
         enumFrom = Data.ProtoLens.Message.Enum.messageEnumFrom
@@ -2268,12 +2268,12 @@ instance Prelude.Enum FileOptions'OptimizeMode where
         fromEnum FileOptions'LITE_RUNTIME = 3
         succ FileOptions'LITE_RUNTIME
           = Prelude.error
-              "Ident \"FileOptions'OptimizeMode\".Ident \"succ\": bad argument Ident \"FileOptions'LITE_RUNTIME\". This value would be out of bounds."
+              "FileOptions'OptimizeMode.succ: bad argument FileOptions'LITE_RUNTIME. This value would be out of bounds."
         succ FileOptions'SPEED = FileOptions'CODE_SIZE
         succ FileOptions'CODE_SIZE = FileOptions'LITE_RUNTIME
         pred FileOptions'SPEED
           = Prelude.error
-              "Ident \"FileOptions'OptimizeMode\".Ident \"pred\": bad argument Ident \"FileOptions'SPEED\". This value would be out of bounds."
+              "FileOptions'OptimizeMode.pred: bad argument FileOptions'SPEED. This value would be out of bounds."
         pred FileOptions'CODE_SIZE = FileOptions'SPEED
         pred FileOptions'LITE_RUNTIME = FileOptions'CODE_SIZE
         enumFrom = Data.ProtoLens.Message.Enum.messageEnumFrom

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
@@ -5,19 +5,205 @@
 -- https://developers.google.com/open-source/licenses/bsd
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
--- | Some utility functions, classes and instances for nicer code generation
--- with haskell-src-exts.
+{-# LANGUAGE FlexibleInstances #-}
+-- | Some utility functions, classes and instances for nicer code generation.
 --
--- In particular, we define orphan instances of IsString for various syntax
+-- Re-exports simpler versions of the types and constructors from
+-- @haskell-src-exts@.
+--
+-- We define orphan instances of IsString for various syntax
 -- datatypes, with some intelligence about Haskell names.  For example, @"foo"
 -- :: Exp@ is treated as a variable and @"Foo" :: Exp@ is treated as a
 -- constructor.
-module Data.ProtoLens.Compiler.Combinators where
+module Data.ProtoLens.Compiler.Combinators
+    ( module Data.ProtoLens.Compiler.Combinators
+    -- Since ImportDecl is a record type, for simplicity we just export it
+    -- directly.
+    , Syntax.ImportDecl(..)
+    ) where
 
 import Data.Char (isAlphaNum, isUpper)
 import Data.String (IsString(..))
-import Language.Haskell.Exts.SrcLoc (noLoc)
-import Language.Haskell.Exts.Syntax as Syntax
+import qualified Language.Haskell.Exts.Annotated.Syntax as Syntax
+import qualified Language.Haskell.Exts.Pretty as Pretty
+import Language.Haskell.Exts.SrcLoc (SrcLoc, noLoc)
+
+prettyPrint :: (Functor m, Pretty.Pretty (m SrcLoc)) => m () -> String
+prettyPrint = Pretty.prettyPrint . fmap (const noLoc)
+
+type Asst = Syntax.Asst ()
+
+classA :: QName -> [Type] -> Asst
+classA = Syntax.ClassA ()
+
+equalP :: Type -> Type -> Asst
+equalP = Syntax.EqualP ()
+
+
+type ConDecl = Syntax.ConDecl ()
+
+conDecl :: Name -> [Type] -> ConDecl
+conDecl = Syntax.ConDecl ()
+
+recDecl :: Name -> [(Name, Type)] -> ConDecl
+recDecl dataName fields
+    = Syntax.RecDecl () dataName
+        [ Syntax.FieldDecl () [n] (Syntax.TyBang () (Syntax.BangedTy ())
+                                        t)
+        | (n,t) <- fields
+        ]
+
+
+type Decl = Syntax.Decl ()
+
+patSynSig :: Name -> Type -> Decl
+patSynSig n t = Syntax.PatSynSig () n Nothing Nothing Nothing t
+
+patSyn :: Pat -> Pat -> Decl
+patSyn p1 p2 = Syntax.PatSyn () p1 p2 Syntax.ImplicitBidirectional
+
+dataDecl :: Name -> [ConDecl] -> [QName] -> Decl
+dataDecl name conDecls derives
+    = Syntax.DataDecl () (Syntax.DataType ()) Nothing
+        (Syntax.DHead () name)
+            [Syntax.QualConDecl () Nothing Nothing q | q <- conDecls]
+        $ Just $ Syntax.Deriving ()
+            [ Syntax.IRule () Nothing Nothing (Syntax.IHCon () c)
+            | c <- derives
+            ]
+
+funBind :: [Match] -> Decl
+funBind = Syntax.FunBind ()
+
+instDecl :: [Asst] -> InstHead -> [[Match]] -> Decl
+instDecl ctx instHead matches
+    = Syntax.InstDecl () Nothing
+        (Syntax.IRule () Nothing ctx' instHead)
+        $ Just [Syntax.InsDecl () $ funBind m | m <- matches]
+  where
+    ctx' = case ctx of
+        [] -> Nothing
+        [c] -> Just $ Syntax.CxSingle () c
+        cs -> Just $ Syntax.CxTuple () cs
+
+typeSig :: [Name] -> Type -> Decl
+typeSig = Syntax.TypeSig ()
+
+
+type Exp = Syntax.Exp ()
+
+let' :: [Decl] -> Exp -> Exp
+let' ds e = Syntax.Let () (Syntax.BDecls () ds) e
+
+stringExp :: String -> Exp
+stringExp = Syntax.Lit () . string
+
+tuple :: [Exp] -> Exp
+tuple = Syntax.Tuple () Syntax.Boxed
+
+lambda :: [Pat] -> Exp -> Exp
+lambda = Syntax.Lambda ()
+
+(@::@) :: Exp -> Type -> Exp
+(@::@) = Syntax.ExpTypeSig ()
+infixl 2 @::@
+
+recConstr :: QName -> [FieldUpdate] -> Exp
+recConstr = Syntax.RecConstr ()
+
+recUpdate :: Exp -> [FieldUpdate] -> Exp
+recUpdate = Syntax.RecUpdate ()
+
+var, con :: QName -> Exp
+var = Syntax.Var ()
+con = Syntax.Con ()
+
+list :: [Exp] -> Exp
+list = Syntax.List ()
+
+
+type FieldUpdate = Syntax.FieldUpdate ()
+
+fieldUpdate :: QName -> Exp -> FieldUpdate
+fieldUpdate = Syntax.FieldUpdate ()
+
+type InstHead = Syntax.InstHead ()
+
+ihApp :: InstHead -> [Type] -> InstHead
+ihApp = foldl (Syntax.IHApp ())
+
+
+type Match = Syntax.Match ()
+
+-- | A simple clause of a function binding.
+match :: Name -> [Pat] -> Exp -> Syntax.Match ()
+match n ps e = Syntax.Match () n ps (Syntax.UnGuardedRhs () e) Nothing
+
+type Module = Syntax.Module ()
+
+module' :: ModuleName -> [ModulePragma] -> [Syntax.ImportDecl ()] -> [Decl] -> Module
+module' modName
+    = Syntax.Module ()
+        (Just $ Syntax.ModuleHead () modName
+                    -- no warning text
+                    Nothing
+                    -- no explicit exporst; we export everything.
+                    -- TODO: Also export public imports, taking care not to
+                    -- cause a name conflict between field accessors.
+                    Nothing)
+
+type ModuleName = Syntax.ModuleName ()
+type ModulePragma = Syntax.ModulePragma ()
+
+languagePragma :: [Name] -> ModulePragma
+languagePragma = Syntax.LanguagePragma ()
+
+optionsGhcPragma :: String -> ModulePragma
+optionsGhcPragma = Syntax.OptionsPragma () (Just Syntax.GHC)
+
+type Name = Syntax.Name ()
+
+type Pat = Syntax.Pat ()
+
+pApp :: QName -> [Pat] -> Pat
+pApp = Syntax.PApp ()
+
+pVar :: Name -> Pat
+pVar = Syntax.PVar ()
+
+pWildCard :: Pat
+pWildCard = Syntax.PWildCard ()
+
+stringPat :: String -> Pat
+stringPat = Syntax.PLit () (Syntax.Signless ()) . string
+
+
+type QName = Syntax.QName ()
+
+qual :: ModuleName -> Name -> QName
+qual = Syntax.Qual ()
+
+unQual :: Name -> QName
+unQual = Syntax.UnQual ()
+
+
+type TyVarBind = Syntax.TyVarBind ()
+type Type = Syntax.Type ()
+
+tyCon :: QName -> Type
+tyCon = Syntax.TyCon ()
+
+tyList :: Type -> Type
+tyList = Syntax.TyList ()
+
+tyPromotedString :: String -> Type
+tyPromotedString s = Syntax.TyPromoted () $ Syntax.PromotedString () s s
+
+tyForAll :: [TyVarBind] -> [Asst] -> Type -> Type
+tyForAll vars ctx t = Syntax.TyForall () (Just vars)
+                            (Just $ Syntax.CxTuple () ctx)
+                            t
+
 
 -- | Application of a Haskell type or expression to an argument.
 -- For example, to represent @f x y@, you can write
@@ -28,16 +214,16 @@ class App a where
     infixl 2 @@
 
 instance App Type where
-    (@@) = TyApp
+    (@@) = Syntax.TyApp ()
 
 instance App Exp where
-    (@@) = App
+    (@@) = Syntax.App ()
 
 instance IsString Name where
     fromString s
         -- TODO: better handle the case of mixed ident and symbol characters.
-        | all isIdentChar s = Ident s
-        | otherwise = Symbol s
+        | all isIdentChar s = Syntax.Ident () s
+        | otherwise = Syntax.Symbol () s
 
 -- | Whether this character belongs to an Ident (e.g., "foo") or a symbol
 -- (e.g., "<$>").
@@ -45,7 +231,7 @@ isIdentChar :: Char -> Bool
 isIdentChar c = isAlphaNum c || c `elem` "_'"
 
 instance IsString ModuleName where
-    fromString = ModuleName
+    fromString = Syntax.ModuleName ()
 
 instance IsString QName where
     fromString f
@@ -55,44 +241,47 @@ instance IsString QName where
       | isIdentChar (last f), '.' `elem` f
       -- Split "Foo.Bar.baz" into ("Foo.Bar", "baz")
       , (f', '.':f'') <- span (/='.') (reverse f)
-            = Qual (fromString $ reverse f'') (fromString $ reverse f')
-      | otherwise = UnQual $ fromString f
+            = Syntax.Qual () (fromString $ reverse f'') (fromString $ reverse f')
+      | otherwise = Syntax.UnQual () $ fromString f
 
 instance IsString Type where
   fromString fs@(f:_)
-      | isUpper f = TyCon $ fromString fs
-  fromString fs = TyVar $ fromString fs
+      | isUpper f = Syntax.TyCon () $ fromString fs
+  fromString fs = Syntax.TyVar () $ fromString fs
 
 instance IsString Exp where
     fromString fs@(f:_)
-        | isUpper f = Con $ fromString fs
-    fromString fs = Var $ fromString fs
+        | isUpper f = Syntax.Con () $ fromString fs
+    fromString fs = Syntax.Var () $ fromString fs
 
 instance IsString Pat where
-    fromString = PVar . fromString
+    fromString = Syntax.PVar () . fromString
 
 instance IsString TyVarBind where
-    fromString = UnkindedVar . fromString
+    fromString = Syntax.UnkindedVar () . fromString
 
+instance IsString InstHead where
+    fromString = Syntax.IHCon () . fromString
 
 -- Helper functions for literal numbers, since haskell-src-exts doesn't
 -- put parentheses around negative numbers automatically.
 
 litInt :: Integer -> Exp
 litInt n
-    | n >= 0 = Lit $ Int n
-    | otherwise = NegApp $ Lit $ Int $ negate n
+    | n >= 0 = Syntax.Lit () $ Syntax.Int () n (show n)
+    | otherwise = Syntax.NegApp () $ litInt $ negate n
 
 litFrac :: Rational -> Exp
 litFrac x
-    | x >= 0 = Lit $ Frac x
-    | otherwise = NegApp $ Lit $ Frac $ negate x
+    | x >= 0 = Syntax.Lit () $ Syntax.Frac () x (show x)
+    | otherwise = Syntax.NegApp () $ litFrac $ negate x
 
 pLitInt :: Integer -> Pat
-pLitInt n
-    | n >= 0 = PLit Signless $ Int n
-    | otherwise = PLit Negative $ Int $ negate n
+pLitInt n = Syntax.PLit () sign $ Syntax.Int () n' (show n')
+  where
+    (n', sign)
+        | n >= 0 = (n, Syntax.Signless ())
+        | otherwise = (negate n, Syntax.Negative ())
 
--- | A simple clause of a function binding.
-match :: Name -> [Pat] -> Exp -> Match
-match n ps e = Match noLoc n ps Nothing (UnGuardedRhs e) Nothing
+string :: String -> Syntax.Literal ()
+string s = Syntax.String () s (show s)

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
@@ -147,7 +147,7 @@ module' modName
         (Just $ Syntax.ModuleHead () modName
                     -- no warning text
                     Nothing
-                    -- no explicit exporst; we export everything.
+                    -- no explicit exports; we export everything.
                     -- TODO: Also export public imports, taking care not to
                     -- cause a name conflict between field accessors.
                     Nothing)

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
@@ -22,9 +22,9 @@ import Data.List (foldl', intercalate)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map, unions, (!))
 import Data.Monoid ((<>))
+import Data.String (fromString)
 import qualified Data.Text as T
 import Data.Text (Text)
-import Language.Haskell.Exts.Syntax (ModuleName(..), Name(..), QName(..))
 import Lens.Family2
 import Proto.Google.Protobuf.Descriptor
     (FileDescriptorProto, name, dependency, publicDependency)
@@ -32,6 +32,7 @@ import System.FilePath (dropExtension, splitDirectories)
 
 
 import Data.ProtoLens.Compiler.Definitions
+import Data.ProtoLens.Compiler.Combinators (ModuleName, Name, QName)
 
 -- | The filename of an input .proto file.
 type ProtoFileName = Text
@@ -84,7 +85,7 @@ outputFilePath n = T.replace "." "/" (T.pack n) <> ".hs"
 
 -- | Get the Haskell 'ModuleName' corresponding to a given .proto file.
 moduleName :: Text -> FileDescriptorProto -> ModuleName
-moduleName modulePrefix fd = ModuleName (moduleNameStr modulePrefix fd)
+moduleName modulePrefix fd = fromString (moduleNameStr modulePrefix fd)
 
 -- | Get the Haskell module name corresponding to a given .proto file.
 moduleNameStr :: Text -> FileDescriptorProto -> String

--- a/proto-lens-protoc/src/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/src/protoc-gen-haskell.hs
@@ -5,6 +5,7 @@
 -- https://developers.google.com/open-source/licenses/bsd
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
 module Main where
 
 import qualified Data.ByteString as B
@@ -17,8 +18,6 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import Data.Text (Text, pack)
 import Data.ProtoLens (decodeMessage, def, encodeMessage)
-import Language.Haskell.Exts.Pretty (prettyPrint)
-import Language.Haskell.Exts.Syntax (ModuleName(..), Name(..), QName(..))
 import Lens.Family2
 import Proto.Google.Protobuf.Compiler.Plugin
     ( CodeGeneratorRequest
@@ -37,6 +36,11 @@ import System.IO as IO
 import System.FilePath (dropExtension, replaceExtension, splitDirectories)
 import Text.Read (readEither)
 
+import Data.ProtoLens.Compiler.Combinators
+    ( ModuleName
+    , Name
+    , QName
+    , prettyPrint)
 import Data.ProtoLens.Compiler.Definitions
 import Data.ProtoLens.Compiler.Generate
 import Data.ProtoLens.Compiler.Plugin
@@ -87,7 +91,7 @@ generateFiles modifyImports header files toGenerate = let
              modifyImports
              (definitions file)
              (collectEnvFromDeps deps filesByName)
-  in [ ( outputFilePath . (\(ModuleName n) -> n) . haskellModule $ file
+  in [ ( outputFilePath . prettyPrint . haskellModule $ file
        , header (descriptor file) <> pack (prettyPrint $ buildFile file)
        )
      | fileName <- toGenerate


### PR DESCRIPTION
Adapted from PR #59 by @expipiplus1.

This is the first step to building `proto-lens` with both older and newer versions of
`haskell-src-exts`, and thus thus getting proto-lens into stackage nightly.

This switches to `haskell-src-exts<=1.17`'s `Language.Haskell.Exts.Annotated.*`
API, which corresponds to `haskell-src-exts>=1.18`'s
`Language.Haskell.Exts.*` .  Annoyingly, every datatype in the new API is
parametrized by a type, which is just `()` in our case.  To simplify the
codegen modules, I moved more functionality into the `Combinators` module and exposed
an API similar to what we had before.

Along the way, I also fixed a bug in the codegenerated error messages.  I
re-ran the bootstrap script to make sure no other changes were introduced.

The next PR will wrap the imports in CPP (exposing a common API from
`Combinators`) so we can support both versions of haskell-src-exts (and in
particular, multiple Stackage snapshots).