### PR TITLE
Update library versions and changelog, and change the maintainer.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## v0.2.0.0
+- Support OverloadedLabels with the new `lens-labels` package.
+- Fix codegen for field names that are already camel-cased.
+- Increase version bounds to work with Stackage lts-8.
+
 ## v0.1.0.5
 - Fix the handling of packed repeated fields (#38)
 - Improve space usage and time of decoding (#63)

--- a/lens-labels/lens-labels.cabal
+++ b/lens-labels/lens-labels.cabal
@@ -7,7 +7,7 @@ homepage:            https://github.com/google/proto-lens
 license:             BSD3
 license-file:        LICENSE
 author:              Judah Jacobson
-maintainer:          judahjacobson+protolens@google.com
+maintainer:          proto-lens@googlegroups.com
 copyright:           Google Inc.
 category:            Data
 build-type:          Simple

--- a/proto-lens-arbitrary/proto-lens-arbitrary.cabal
+++ b/proto-lens-arbitrary/proto-lens-arbitrary.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-arbitrary
-version:             0.1.0.1
+version:             0.1.0.2
 synopsis:            Arbitrary instances for proto-lens.
 description:
   The proto-lens-arbitrary allows generating arbitrary messages for
@@ -18,7 +18,7 @@ cabal-version:       >=1.8
 library
   hs-source-dirs: src
   exposed-modules:     Data.ProtoLens.Arbitrary
-  build-depends:  proto-lens == 0.1.*
+  build-depends:  proto-lens >= 0.1 && < 0.3
                 , base >= 4.8 && < 4.10
                 , bytestring == 0.10.*
                 , containers == 0.5.*

--- a/proto-lens-benchmarks/proto-lens-benchmarks.cabal
+++ b/proto-lens-benchmarks/proto-lens-benchmarks.cabal
@@ -18,8 +18,8 @@ library
   hs-source-dirs: src
   exposed-modules:     Data.ProtoLens.BenchmarkUtil
   default-language: Haskell2010
-  build-depends: proto-lens == 0.1.*
-               , proto-lens-protoc == 0.1.*
+  build-depends: proto-lens == 0.2.*
+               , proto-lens-protoc == 0.2.*
                , base >= 4.8 && < 4.10
                , bytestring == 0.10.*
                , criterion == 1.1.*

--- a/proto-lens-combinators/proto-lens-combinators.cabal
+++ b/proto-lens-combinators/proto-lens-combinators.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-combinators
-version:             0.1.0.4
+version:             0.1.0.6
 synopsis:            Utilities functions to proto-lens.
 description:
   Useful things for working with protos.
@@ -19,9 +19,9 @@ library
   default-language: Haskell2010
   hs-source-dirs: src
   exposed-modules:     Data.ProtoLens.Combinators
-  build-depends:  proto-lens == 0.1.*
+  build-depends:  proto-lens >= 0.1 && < 0.3
                 -- Used by the custom Setup script (for the test-suite).
-                , proto-lens-protoc == 0.1.*
+                , proto-lens-protoc >= 0.1 && < 0.3
                 , base >= 4.8 && < 4.10
                 , data-default-class >= 0.0 && < 0.2
                 , lens-family == 1.2.*

--- a/proto-lens-descriptors/proto-lens-descriptors.cabal
+++ b/proto-lens-descriptors/proto-lens-descriptors.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-descriptors
-version:             0.1.0.5
+version:             0.2.0.0
 synopsis:            Protocol buffers for describing the definitions of messages.
 description:
     This package provides definitions for the 'proto-lens' package
@@ -7,7 +7,7 @@ description:
 license:             BSD3
 license-file:        LICENSE
 author:              Judah Jacobson
-maintainer:          judahjacobson@google.com
+maintainer:          proto-lens@googlegroups.com
 copyright:           Google Inc.
 category:            Data
 build-type:          Simple
@@ -25,8 +25,8 @@ library
     , bytestring == 0.10.*
     , data-default-class >= 0.0 && < 0.2
     , lens-family == 1.2.*
-    , lens-labels == 0.1.0.0
+    , lens-labels == 0.1.*
     -- Specify an exact version of `proto-lens`, since it's tied closely
     -- to the generated code.
-    , proto-lens == 0.1.0.5
+    , proto-lens == 0.2.0.0
     , text == 1.2.*

--- a/proto-lens-optparse/proto-lens-optparse.cabal
+++ b/proto-lens-optparse/proto-lens-optparse.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-optparse
-version:             0.1.0.1
+version:             0.1.0.2
 synopsis:            Adapting proto-lens to optparse-applicative ReadMs.
 description:
    A package adapting proto-lens to optparse-applicative ReadMs.
@@ -19,7 +19,7 @@ cabal-version:       >=1.8
 library
   hs-source-dirs: src
   exposed-modules:     Data.ProtoLens.Optparse
-  build-depends:  proto-lens == 0.1.*
+  build-depends:  proto-lens >= 0.1 && < 0.3
                 , base >= 4.8 && < 4.10
                 , optparse-applicative >= 0.12 && < 0.14
                 , text == 1.2.*

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-protoc
-version:             0.1.0.5
+version:             0.2.0.0
 synopsis:            Protocol buffer compiler for the proto-lens library.
 description:
   Turn protocol buffer files (.proto) into Haskell files (.hs) which
@@ -10,7 +10,7 @@ description:
 license:             BSD3
 license-file:        LICENSE
 author:              Judah Jacobson
-maintainer:          judahjacobson@google.com
+maintainer:          proto-lens@googlegroups.com
 copyright:           Google Inc.
 category:            Data
 build-type:          Simple
@@ -47,8 +47,8 @@ library
         , lens-family == 1.2.*
         , lens-labels == 0.1.*
         , process >= 1.2 && < 1.5
-        , proto-lens == 0.1.0.5
-        , proto-lens-descriptors == 0.1.0.5
+        , proto-lens == 0.2.0.0
+        , proto-lens-descriptors == 0.2.0.0
         , text == 1.2.*
     reexported-modules:
         -- Modules that are needed by the generated Haskell files.
@@ -79,8 +79,8 @@ executable proto-lens-protoc
       , lens-family == 1.2.*
       -- Specify an exact version of `proto-lens`, since it's tied closely
       -- to the generated code.
-      , proto-lens == 0.1.0.5
-      , proto-lens-descriptors == 0.1.0.5
+      , proto-lens == 0.2.0.0
+      , proto-lens-descriptors == 0.2.0.0
       , text == 1.2.*
   hs-source-dirs:      src
   other-modules:

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -7,7 +7,7 @@ homepage:            https://github.com/google/proto-lens
 license:             BSD3
 license-file:        LICENSE
 author:              Judah Jacobson
-maintainer:          judahjacobson+protolens@google.com
+maintainer:          proto-lens@googlegroups.com
 copyright:           Google Inc.
 category:            Data
 build-type:          Custom
@@ -19,8 +19,8 @@ library
   exposed-modules:     Data.ProtoLens.TestUtil
   default-language: Haskell2010
   build-depends: proto-lens-arbitrary == 0.1.*
-               , proto-lens == 0.1.*
-               , proto-lens-protoc == 0.1.*
+               , proto-lens == 0.2.*
+               , proto-lens-protoc == 0.2.*
                , base >= 4.8 && < 4.10
                , bytestring == 0.10.*
                , text == 1.2.*

--- a/proto-lens/proto-lens.cabal
+++ b/proto-lens/proto-lens.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens
-version:             0.1.0.5
+version:             0.2.0.0
 synopsis:            A lens-based implementation of protocol buffers in Haskell.
 description:
   The proto-lens library provides to protocol buffers using modern
@@ -15,7 +15,7 @@ homepage:            https://github.com/google/proto-lens
 license:             BSD3
 license-file:        LICENSE
 author:              Judah Jacobson
-maintainer:          judahjacobson+protolens@google.com
+maintainer:          proto-lens@googlegroups.com
 copyright:           Google Inc.
 category:            Data
 build-type:          Simple


### PR DESCRIPTION
I didn't bother changing the versions of proto-lens-benchmarks and
proto-lens-tests since we're not uploading them to Hackage.

Changed the maintainer to proto-lens@googlegroups.com.