### PR TITLE
Make the build -Wall -Werror clean.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
     addons: {apt: {packages: [libgmp-dev]}}
   - env: BUILD=stack STACK='stack --resolver=lts-7.4'
     addons: {apt: {packages: [libgmp-dev]}}
-  - env: BUILD=stack STACK=stack # use the resolver in stack.yaml
+  - env: BUILD=stack STACK=stack # Use the resolver in stack.yaml
     addons: {apt: {packages: [libgmp-dev]}}
 
 before_install:
@@ -39,6 +39,7 @@ before_install:
   - rm protoc-release.zip
 
 install:
+  # Don't use '-Wall -Werror' to build the snapshot packages.
   - case "$BUILD" in
       stack)
         $STACK setup --no-terminal;
@@ -52,7 +53,8 @@ script:
   # edge cases around custom Setup.hs script dependencies.
   - case "$BUILD" in
       stack)
-        $STACK build --haddock --no-haddock-deps && $STACK test --haddock --no-haddock-deps;;
+        STACK_ARGS=(--haddock --no-haddock-deps --ghc-options="-Wall -Werror");
+        $STACK build "${STACK_ARGS[@]}" && $STACK test "${STACK_ARGS[@]}";;
       cabal)
         ./travis-cabal.sh;;
     esac

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v0.2.0.1
+- Make the libraries '-Wall -Werror'-clean for the latest
+  version of GHC.
+
 ## v0.2.0.0
 - Support OverloadedLabels with the new `lens-labels` package.
 - Fix codegen for field names that are already camel-cased.

--- a/lens-labels/lens-labels.cabal
+++ b/lens-labels/lens-labels.cabal
@@ -1,5 +1,5 @@
 name:                lens-labels
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            Integration of lenses with OverloadedLabels.
 description:         Provides a framework to integrate lenses with GHC's
                      OverloadedLabels extension.

--- a/lens-labels/src/Lens/Labels.hs
+++ b/lens-labels/src/Lens/Labels.hs
@@ -32,7 +32,7 @@ module Lens.Labels (
     Lens,
     -- * HasLens
     HasLens(..),
-    Proxy#(..),
+    Proxy#,
     proxy#,
     -- * Setters
     ASetter,

--- a/proto-lens-arbitrary/src/Data/ProtoLens/Arbitrary.hs
+++ b/proto-lens-arbitrary/src/Data/ProtoLens/Arbitrary.hs
@@ -14,7 +14,6 @@ module Data.ProtoLens.Arbitrary
 
 import Data.ProtoLens.Message
 
-import Control.Applicative ((<$>), pure)
 import Control.Arrow ((&&&))
 import Control.Monad (foldM)
 import qualified Data.ByteString as BS

--- a/proto-lens-descriptors/proto-lens-descriptors.cabal
+++ b/proto-lens-descriptors/proto-lens-descriptors.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-descriptors
-version:             0.2.0.0
+version:             0.2.0.1
 synopsis:            Protocol buffers for describing the definitions of messages.
 description:
     This package provides definitions for the 'proto-lens' package
@@ -28,5 +28,5 @@ library
     , lens-labels == 0.1.*
     -- Specify an exact version of `proto-lens`, since it's tied closely
     -- to the generated code.
-    , proto-lens == 0.2.0.0
+    , proto-lens == 0.2.0.1
     , text == 1.2.*

--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -256,68 +256,59 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
                     ("content", content__field_descriptor)])
 
 content ::
-        forall x f s t a b .
-          (Prelude.Functor f, Lens.Labels.HasLens "content" f s t a b) =>
+        forall f s t a b . Lens.Labels.HasLens "content" f s t a b =>
           Lens.Family2.LensLike f s t a b
 content
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "content")
 
 error ::
-      forall x f s t a b .
-        (Prelude.Functor f, Lens.Labels.HasLens "error" f s t a b) =>
+      forall f s t a b . Lens.Labels.HasLens "error" f s t a b =>
         Lens.Family2.LensLike f s t a b
 error
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "error")
 
 file ::
-     forall x f s t a b .
-       (Prelude.Functor f, Lens.Labels.HasLens "file" f s t a b) =>
+     forall f s t a b . Lens.Labels.HasLens "file" f s t a b =>
        Lens.Family2.LensLike f s t a b
 file
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "file")
 
 fileToGenerate ::
-               forall x f s t a b .
-                 (Prelude.Functor f,
-                  Lens.Labels.HasLens "fileToGenerate" f s t a b) =>
+               forall f s t a b .
+                 Lens.Labels.HasLens "fileToGenerate" f s t a b =>
                  Lens.Family2.LensLike f s t a b
 fileToGenerate
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "fileToGenerate")
 
 insertionPoint ::
-               forall x f s t a b .
-                 (Prelude.Functor f,
-                  Lens.Labels.HasLens "insertionPoint" f s t a b) =>
+               forall f s t a b .
+                 Lens.Labels.HasLens "insertionPoint" f s t a b =>
                  Lens.Family2.LensLike f s t a b
 insertionPoint
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "insertionPoint")
 
 maybe'content ::
-              forall x f s t a b .
-                (Prelude.Functor f,
-                 Lens.Labels.HasLens "maybe'content" f s t a b) =>
+              forall f s t a b . Lens.Labels.HasLens "maybe'content" f s t a b =>
                 Lens.Family2.LensLike f s t a b
 maybe'content
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'content")
 
 maybe'error ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "maybe'error" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "maybe'error" f s t a b =>
               Lens.Family2.LensLike f s t a b
 maybe'error
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'error")
 
 maybe'insertionPoint ::
-                     forall x f s t a b .
-                       (Prelude.Functor f,
-                        Lens.Labels.HasLens "maybe'insertionPoint" f s t a b) =>
+                     forall f s t a b .
+                       Lens.Labels.HasLens "maybe'insertionPoint" f s t a b =>
                        Lens.Family2.LensLike f s t a b
 maybe'insertionPoint
   = Lens.Labels.lensOf
@@ -325,41 +316,36 @@ maybe'insertionPoint
          (Lens.Labels.Proxy#) "maybe'insertionPoint")
 
 maybe'name ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "maybe'name" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "maybe'name" f s t a b =>
              Lens.Family2.LensLike f s t a b
 maybe'name
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'name")
 
 maybe'parameter ::
-                forall x f s t a b .
-                  (Prelude.Functor f,
-                   Lens.Labels.HasLens "maybe'parameter" f s t a b) =>
+                forall f s t a b .
+                  Lens.Labels.HasLens "maybe'parameter" f s t a b =>
                   Lens.Family2.LensLike f s t a b
 maybe'parameter
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'parameter")
 
 name ::
-     forall x f s t a b .
-       (Prelude.Functor f, Lens.Labels.HasLens "name" f s t a b) =>
+     forall f s t a b . Lens.Labels.HasLens "name" f s t a b =>
        Lens.Family2.LensLike f s t a b
 name
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "name")
 
 parameter ::
-          forall x f s t a b .
-            (Prelude.Functor f, Lens.Labels.HasLens "parameter" f s t a b) =>
+          forall f s t a b . Lens.Labels.HasLens "parameter" f s t a b =>
             Lens.Family2.LensLike f s t a b
 parameter
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "parameter")
 
 protoFile ::
-          forall x f s t a b .
-            (Prelude.Functor f, Lens.Labels.HasLens "protoFile" f s t a b) =>
+          forall f s t a b . Lens.Labels.HasLens "protoFile" f s t a b =>
             Lens.Family2.LensLike f s t a b
 protoFile
   = Lens.Labels.lensOf

--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor.hs
@@ -3388,209 +3388,183 @@ instance Data.ProtoLens.Message UninterpretedOption'NamePart where
                     ("is_extension", isExtension__field_descriptor)])
 
 aggregateValue ::
-               forall x f s t a b .
-                 (Prelude.Functor f,
-                  Lens.Labels.HasLens "aggregateValue" f s t a b) =>
+               forall f s t a b .
+                 Lens.Labels.HasLens "aggregateValue" f s t a b =>
                  Lens.Family2.LensLike f s t a b
 aggregateValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "aggregateValue")
 
 allowAlias ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "allowAlias" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "allowAlias" f s t a b =>
              Lens.Family2.LensLike f s t a b
 allowAlias
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "allowAlias")
 
 annotation ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "annotation" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "annotation" f s t a b =>
              Lens.Family2.LensLike f s t a b
 annotation
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "annotation")
 
 begin ::
-      forall x f s t a b .
-        (Prelude.Functor f, Lens.Labels.HasLens "begin" f s t a b) =>
+      forall f s t a b . Lens.Labels.HasLens "begin" f s t a b =>
         Lens.Family2.LensLike f s t a b
 begin
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "begin")
 
 ccEnableArenas ::
-               forall x f s t a b .
-                 (Prelude.Functor f,
-                  Lens.Labels.HasLens "ccEnableArenas" f s t a b) =>
+               forall f s t a b .
+                 Lens.Labels.HasLens "ccEnableArenas" f s t a b =>
                  Lens.Family2.LensLike f s t a b
 ccEnableArenas
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "ccEnableArenas")
 
 ccGenericServices ::
-                  forall x f s t a b .
-                    (Prelude.Functor f,
-                     Lens.Labels.HasLens "ccGenericServices" f s t a b) =>
+                  forall f s t a b .
+                    Lens.Labels.HasLens "ccGenericServices" f s t a b =>
                     Lens.Family2.LensLike f s t a b
 ccGenericServices
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "ccGenericServices")
 
 clientStreaming ::
-                forall x f s t a b .
-                  (Prelude.Functor f,
-                   Lens.Labels.HasLens "clientStreaming" f s t a b) =>
+                forall f s t a b .
+                  Lens.Labels.HasLens "clientStreaming" f s t a b =>
                   Lens.Family2.LensLike f s t a b
 clientStreaming
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "clientStreaming")
 
 csharpNamespace ::
-                forall x f s t a b .
-                  (Prelude.Functor f,
-                   Lens.Labels.HasLens "csharpNamespace" f s t a b) =>
+                forall f s t a b .
+                  Lens.Labels.HasLens "csharpNamespace" f s t a b =>
                   Lens.Family2.LensLike f s t a b
 csharpNamespace
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "csharpNamespace")
 
 ctype ::
-      forall x f s t a b .
-        (Prelude.Functor f, Lens.Labels.HasLens "ctype" f s t a b) =>
+      forall f s t a b . Lens.Labels.HasLens "ctype" f s t a b =>
         Lens.Family2.LensLike f s t a b
 ctype
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "ctype")
 
 defaultValue ::
-             forall x f s t a b .
-               (Prelude.Functor f,
-                Lens.Labels.HasLens "defaultValue" f s t a b) =>
+             forall f s t a b . Lens.Labels.HasLens "defaultValue" f s t a b =>
                Lens.Family2.LensLike f s t a b
 defaultValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "defaultValue")
 
 dependency ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "dependency" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "dependency" f s t a b =>
              Lens.Family2.LensLike f s t a b
 dependency
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "dependency")
 
 deprecated ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "deprecated" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "deprecated" f s t a b =>
              Lens.Family2.LensLike f s t a b
 deprecated
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "deprecated")
 
 doubleValue ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "doubleValue" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "doubleValue" f s t a b =>
               Lens.Family2.LensLike f s t a b
 doubleValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "doubleValue")
 
 end ::
-    forall x f s t a b .
-      (Prelude.Functor f, Lens.Labels.HasLens "end" f s t a b) =>
+    forall f s t a b . Lens.Labels.HasLens "end" f s t a b =>
       Lens.Family2.LensLike f s t a b
 end
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "end")
 
 enumType ::
-         forall x f s t a b .
-           (Prelude.Functor f, Lens.Labels.HasLens "enumType" f s t a b) =>
+         forall f s t a b . Lens.Labels.HasLens "enumType" f s t a b =>
            Lens.Family2.LensLike f s t a b
 enumType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "enumType")
 
 extendee ::
-         forall x f s t a b .
-           (Prelude.Functor f, Lens.Labels.HasLens "extendee" f s t a b) =>
+         forall f s t a b . Lens.Labels.HasLens "extendee" f s t a b =>
            Lens.Family2.LensLike f s t a b
 extendee
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "extendee")
 
 extension ::
-          forall x f s t a b .
-            (Prelude.Functor f, Lens.Labels.HasLens "extension" f s t a b) =>
+          forall f s t a b . Lens.Labels.HasLens "extension" f s t a b =>
             Lens.Family2.LensLike f s t a b
 extension
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "extension")
 
 extensionRange ::
-               forall x f s t a b .
-                 (Prelude.Functor f,
-                  Lens.Labels.HasLens "extensionRange" f s t a b) =>
+               forall f s t a b .
+                 Lens.Labels.HasLens "extensionRange" f s t a b =>
                  Lens.Family2.LensLike f s t a b
 extensionRange
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "extensionRange")
 
 field ::
-      forall x f s t a b .
-        (Prelude.Functor f, Lens.Labels.HasLens "field" f s t a b) =>
+      forall f s t a b . Lens.Labels.HasLens "field" f s t a b =>
         Lens.Family2.LensLike f s t a b
 field
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "field")
 
 file ::
-     forall x f s t a b .
-       (Prelude.Functor f, Lens.Labels.HasLens "file" f s t a b) =>
+     forall f s t a b . Lens.Labels.HasLens "file" f s t a b =>
        Lens.Family2.LensLike f s t a b
 file
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "file")
 
 goPackage ::
-          forall x f s t a b .
-            (Prelude.Functor f, Lens.Labels.HasLens "goPackage" f s t a b) =>
+          forall f s t a b . Lens.Labels.HasLens "goPackage" f s t a b =>
             Lens.Family2.LensLike f s t a b
 goPackage
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "goPackage")
 
 identifierValue ::
-                forall x f s t a b .
-                  (Prelude.Functor f,
-                   Lens.Labels.HasLens "identifierValue" f s t a b) =>
+                forall f s t a b .
+                  Lens.Labels.HasLens "identifierValue" f s t a b =>
                   Lens.Family2.LensLike f s t a b
 identifierValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "identifierValue")
 
 inputType ::
-          forall x f s t a b .
-            (Prelude.Functor f, Lens.Labels.HasLens "inputType" f s t a b) =>
+          forall f s t a b . Lens.Labels.HasLens "inputType" f s t a b =>
             Lens.Family2.LensLike f s t a b
 inputType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "inputType")
 
 isExtension ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "isExtension" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "isExtension" f s t a b =>
               Lens.Family2.LensLike f s t a b
 isExtension
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "isExtension")
 
 javaGenerateEqualsAndHash ::
-                          forall x f s t a b .
-                            (Prelude.Functor f,
-                             Lens.Labels.HasLens "javaGenerateEqualsAndHash" f s t a b) =>
+                          forall f s t a b .
+                            Lens.Labels.HasLens "javaGenerateEqualsAndHash" f s t a b =>
                             Lens.Family2.LensLike f s t a b
 javaGenerateEqualsAndHash
   = Lens.Labels.lensOf
@@ -3598,9 +3572,8 @@ javaGenerateEqualsAndHash
          (Lens.Labels.Proxy#) "javaGenerateEqualsAndHash")
 
 javaGenericServices ::
-                    forall x f s t a b .
-                      (Prelude.Functor f,
-                       Lens.Labels.HasLens "javaGenericServices" f s t a b) =>
+                    forall f s t a b .
+                      Lens.Labels.HasLens "javaGenericServices" f s t a b =>
                       Lens.Family2.LensLike f s t a b
 javaGenericServices
   = Lens.Labels.lensOf
@@ -3608,35 +3581,31 @@ javaGenericServices
          (Lens.Labels.Proxy#) "javaGenericServices")
 
 javaMultipleFiles ::
-                  forall x f s t a b .
-                    (Prelude.Functor f,
-                     Lens.Labels.HasLens "javaMultipleFiles" f s t a b) =>
+                  forall f s t a b .
+                    Lens.Labels.HasLens "javaMultipleFiles" f s t a b =>
                     Lens.Family2.LensLike f s t a b
 javaMultipleFiles
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "javaMultipleFiles")
 
 javaOuterClassname ::
-                   forall x f s t a b .
-                     (Prelude.Functor f,
-                      Lens.Labels.HasLens "javaOuterClassname" f s t a b) =>
+                   forall f s t a b .
+                     Lens.Labels.HasLens "javaOuterClassname" f s t a b =>
                      Lens.Family2.LensLike f s t a b
 javaOuterClassname
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "javaOuterClassname")
 
 javaPackage ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "javaPackage" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "javaPackage" f s t a b =>
               Lens.Family2.LensLike f s t a b
 javaPackage
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "javaPackage")
 
 javaStringCheckUtf8 ::
-                    forall x f s t a b .
-                      (Prelude.Functor f,
-                       Lens.Labels.HasLens "javaStringCheckUtf8" f s t a b) =>
+                    forall f s t a b .
+                      Lens.Labels.HasLens "javaStringCheckUtf8" f s t a b =>
                       Lens.Family2.LensLike f s t a b
 javaStringCheckUtf8
   = Lens.Labels.lensOf
@@ -3644,50 +3613,44 @@ javaStringCheckUtf8
          (Lens.Labels.Proxy#) "javaStringCheckUtf8")
 
 jsonName ::
-         forall x f s t a b .
-           (Prelude.Functor f, Lens.Labels.HasLens "jsonName" f s t a b) =>
+         forall f s t a b . Lens.Labels.HasLens "jsonName" f s t a b =>
            Lens.Family2.LensLike f s t a b
 jsonName
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "jsonName")
 
 jstype ::
-       forall x f s t a b .
-         (Prelude.Functor f, Lens.Labels.HasLens "jstype" f s t a b) =>
+       forall f s t a b . Lens.Labels.HasLens "jstype" f s t a b =>
          Lens.Family2.LensLike f s t a b
 jstype
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "jstype")
 
 label ::
-      forall x f s t a b .
-        (Prelude.Functor f, Lens.Labels.HasLens "label" f s t a b) =>
+      forall f s t a b . Lens.Labels.HasLens "label" f s t a b =>
         Lens.Family2.LensLike f s t a b
 label
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "label")
 
 lazy ::
-     forall x f s t a b .
-       (Prelude.Functor f, Lens.Labels.HasLens "lazy" f s t a b) =>
+     forall f s t a b . Lens.Labels.HasLens "lazy" f s t a b =>
        Lens.Family2.LensLike f s t a b
 lazy
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "lazy")
 
 leadingComments ::
-                forall x f s t a b .
-                  (Prelude.Functor f,
-                   Lens.Labels.HasLens "leadingComments" f s t a b) =>
+                forall f s t a b .
+                  Lens.Labels.HasLens "leadingComments" f s t a b =>
                   Lens.Family2.LensLike f s t a b
 leadingComments
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "leadingComments")
 
 leadingDetachedComments ::
-                        forall x f s t a b .
-                          (Prelude.Functor f,
-                           Lens.Labels.HasLens "leadingDetachedComments" f s t a b) =>
+                        forall f s t a b .
+                          Lens.Labels.HasLens "leadingDetachedComments" f s t a b =>
                           Lens.Family2.LensLike f s t a b
 leadingDetachedComments
   = Lens.Labels.lensOf
@@ -3695,25 +3658,22 @@ leadingDetachedComments
          (Lens.Labels.Proxy#) "leadingDetachedComments")
 
 location ::
-         forall x f s t a b .
-           (Prelude.Functor f, Lens.Labels.HasLens "location" f s t a b) =>
+         forall f s t a b . Lens.Labels.HasLens "location" f s t a b =>
            Lens.Family2.LensLike f s t a b
 location
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "location")
 
 mapEntry ::
-         forall x f s t a b .
-           (Prelude.Functor f, Lens.Labels.HasLens "mapEntry" f s t a b) =>
+         forall f s t a b . Lens.Labels.HasLens "mapEntry" f s t a b =>
            Lens.Family2.LensLike f s t a b
 mapEntry
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "mapEntry")
 
 maybe'aggregateValue ::
-                     forall x f s t a b .
-                       (Prelude.Functor f,
-                        Lens.Labels.HasLens "maybe'aggregateValue" f s t a b) =>
+                     forall f s t a b .
+                       Lens.Labels.HasLens "maybe'aggregateValue" f s t a b =>
                        Lens.Family2.LensLike f s t a b
 maybe'aggregateValue
   = Lens.Labels.lensOf
@@ -3721,26 +3681,23 @@ maybe'aggregateValue
          (Lens.Labels.Proxy#) "maybe'aggregateValue")
 
 maybe'allowAlias ::
-                 forall x f s t a b .
-                   (Prelude.Functor f,
-                    Lens.Labels.HasLens "maybe'allowAlias" f s t a b) =>
+                 forall f s t a b .
+                   Lens.Labels.HasLens "maybe'allowAlias" f s t a b =>
                    Lens.Family2.LensLike f s t a b
 maybe'allowAlias
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'allowAlias")
 
 maybe'begin ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "maybe'begin" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "maybe'begin" f s t a b =>
               Lens.Family2.LensLike f s t a b
 maybe'begin
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'begin")
 
 maybe'ccEnableArenas ::
-                     forall x f s t a b .
-                       (Prelude.Functor f,
-                        Lens.Labels.HasLens "maybe'ccEnableArenas" f s t a b) =>
+                     forall f s t a b .
+                       Lens.Labels.HasLens "maybe'ccEnableArenas" f s t a b =>
                        Lens.Family2.LensLike f s t a b
 maybe'ccEnableArenas
   = Lens.Labels.lensOf
@@ -3748,9 +3705,8 @@ maybe'ccEnableArenas
          (Lens.Labels.Proxy#) "maybe'ccEnableArenas")
 
 maybe'ccGenericServices ::
-                        forall x f s t a b .
-                          (Prelude.Functor f,
-                           Lens.Labels.HasLens "maybe'ccGenericServices" f s t a b) =>
+                        forall f s t a b .
+                          Lens.Labels.HasLens "maybe'ccGenericServices" f s t a b =>
                           Lens.Family2.LensLike f s t a b
 maybe'ccGenericServices
   = Lens.Labels.lensOf
@@ -3758,9 +3714,8 @@ maybe'ccGenericServices
          (Lens.Labels.Proxy#) "maybe'ccGenericServices")
 
 maybe'clientStreaming ::
-                      forall x f s t a b .
-                        (Prelude.Functor f,
-                         Lens.Labels.HasLens "maybe'clientStreaming" f s t a b) =>
+                      forall f s t a b .
+                        Lens.Labels.HasLens "maybe'clientStreaming" f s t a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'clientStreaming
   = Lens.Labels.lensOf
@@ -3768,9 +3723,8 @@ maybe'clientStreaming
          (Lens.Labels.Proxy#) "maybe'clientStreaming")
 
 maybe'csharpNamespace ::
-                      forall x f s t a b .
-                        (Prelude.Functor f,
-                         Lens.Labels.HasLens "maybe'csharpNamespace" f s t a b) =>
+                      forall f s t a b .
+                        Lens.Labels.HasLens "maybe'csharpNamespace" f s t a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'csharpNamespace
   = Lens.Labels.lensOf
@@ -3778,70 +3732,62 @@ maybe'csharpNamespace
          (Lens.Labels.Proxy#) "maybe'csharpNamespace")
 
 maybe'ctype ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "maybe'ctype" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "maybe'ctype" f s t a b =>
               Lens.Family2.LensLike f s t a b
 maybe'ctype
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'ctype")
 
 maybe'defaultValue ::
-                   forall x f s t a b .
-                     (Prelude.Functor f,
-                      Lens.Labels.HasLens "maybe'defaultValue" f s t a b) =>
+                   forall f s t a b .
+                     Lens.Labels.HasLens "maybe'defaultValue" f s t a b =>
                      Lens.Family2.LensLike f s t a b
 maybe'defaultValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'defaultValue")
 
 maybe'deprecated ::
-                 forall x f s t a b .
-                   (Prelude.Functor f,
-                    Lens.Labels.HasLens "maybe'deprecated" f s t a b) =>
+                 forall f s t a b .
+                   Lens.Labels.HasLens "maybe'deprecated" f s t a b =>
                    Lens.Family2.LensLike f s t a b
 maybe'deprecated
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'deprecated")
 
 maybe'doubleValue ::
-                  forall x f s t a b .
-                    (Prelude.Functor f,
-                     Lens.Labels.HasLens "maybe'doubleValue" f s t a b) =>
+                  forall f s t a b .
+                    Lens.Labels.HasLens "maybe'doubleValue" f s t a b =>
                     Lens.Family2.LensLike f s t a b
 maybe'doubleValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'doubleValue")
 
 maybe'end ::
-          forall x f s t a b .
-            (Prelude.Functor f, Lens.Labels.HasLens "maybe'end" f s t a b) =>
+          forall f s t a b . Lens.Labels.HasLens "maybe'end" f s t a b =>
             Lens.Family2.LensLike f s t a b
 maybe'end
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'end")
 
 maybe'extendee ::
-               forall x f s t a b .
-                 (Prelude.Functor f,
-                  Lens.Labels.HasLens "maybe'extendee" f s t a b) =>
+               forall f s t a b .
+                 Lens.Labels.HasLens "maybe'extendee" f s t a b =>
                  Lens.Family2.LensLike f s t a b
 maybe'extendee
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'extendee")
 
 maybe'goPackage ::
-                forall x f s t a b .
-                  (Prelude.Functor f,
-                   Lens.Labels.HasLens "maybe'goPackage" f s t a b) =>
+                forall f s t a b .
+                  Lens.Labels.HasLens "maybe'goPackage" f s t a b =>
                   Lens.Family2.LensLike f s t a b
 maybe'goPackage
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'goPackage")
 
 maybe'identifierValue ::
-                      forall x f s t a b .
-                        (Prelude.Functor f,
-                         Lens.Labels.HasLens "maybe'identifierValue" f s t a b) =>
+                      forall f s t a b .
+                        Lens.Labels.HasLens "maybe'identifierValue" f s t a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'identifierValue
   = Lens.Labels.lensOf
@@ -3849,19 +3795,16 @@ maybe'identifierValue
          (Lens.Labels.Proxy#) "maybe'identifierValue")
 
 maybe'inputType ::
-                forall x f s t a b .
-                  (Prelude.Functor f,
-                   Lens.Labels.HasLens "maybe'inputType" f s t a b) =>
+                forall f s t a b .
+                  Lens.Labels.HasLens "maybe'inputType" f s t a b =>
                   Lens.Family2.LensLike f s t a b
 maybe'inputType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'inputType")
 
 maybe'javaGenerateEqualsAndHash ::
-                                forall x f s t a b .
-                                  (Prelude.Functor f,
-                                   Lens.Labels.HasLens "maybe'javaGenerateEqualsAndHash" f s t a
-                                     b) =>
+                                forall f s t a b .
+                                  Lens.Labels.HasLens "maybe'javaGenerateEqualsAndHash" f s t a b =>
                                   Lens.Family2.LensLike f s t a b
 maybe'javaGenerateEqualsAndHash
   = Lens.Labels.lensOf
@@ -3869,9 +3812,8 @@ maybe'javaGenerateEqualsAndHash
          (Lens.Labels.Proxy#) "maybe'javaGenerateEqualsAndHash")
 
 maybe'javaGenericServices ::
-                          forall x f s t a b .
-                            (Prelude.Functor f,
-                             Lens.Labels.HasLens "maybe'javaGenericServices" f s t a b) =>
+                          forall f s t a b .
+                            Lens.Labels.HasLens "maybe'javaGenericServices" f s t a b =>
                             Lens.Family2.LensLike f s t a b
 maybe'javaGenericServices
   = Lens.Labels.lensOf
@@ -3879,9 +3821,8 @@ maybe'javaGenericServices
          (Lens.Labels.Proxy#) "maybe'javaGenericServices")
 
 maybe'javaMultipleFiles ::
-                        forall x f s t a b .
-                          (Prelude.Functor f,
-                           Lens.Labels.HasLens "maybe'javaMultipleFiles" f s t a b) =>
+                        forall f s t a b .
+                          Lens.Labels.HasLens "maybe'javaMultipleFiles" f s t a b =>
                           Lens.Family2.LensLike f s t a b
 maybe'javaMultipleFiles
   = Lens.Labels.lensOf
@@ -3889,9 +3830,8 @@ maybe'javaMultipleFiles
          (Lens.Labels.Proxy#) "maybe'javaMultipleFiles")
 
 maybe'javaOuterClassname ::
-                         forall x f s t a b .
-                           (Prelude.Functor f,
-                            Lens.Labels.HasLens "maybe'javaOuterClassname" f s t a b) =>
+                         forall f s t a b .
+                           Lens.Labels.HasLens "maybe'javaOuterClassname" f s t a b =>
                            Lens.Family2.LensLike f s t a b
 maybe'javaOuterClassname
   = Lens.Labels.lensOf
@@ -3899,18 +3839,16 @@ maybe'javaOuterClassname
          (Lens.Labels.Proxy#) "maybe'javaOuterClassname")
 
 maybe'javaPackage ::
-                  forall x f s t a b .
-                    (Prelude.Functor f,
-                     Lens.Labels.HasLens "maybe'javaPackage" f s t a b) =>
+                  forall f s t a b .
+                    Lens.Labels.HasLens "maybe'javaPackage" f s t a b =>
                     Lens.Family2.LensLike f s t a b
 maybe'javaPackage
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'javaPackage")
 
 maybe'javaStringCheckUtf8 ::
-                          forall x f s t a b .
-                            (Prelude.Functor f,
-                             Lens.Labels.HasLens "maybe'javaStringCheckUtf8" f s t a b) =>
+                          forall f s t a b .
+                            Lens.Labels.HasLens "maybe'javaStringCheckUtf8" f s t a b =>
                             Lens.Family2.LensLike f s t a b
 maybe'javaStringCheckUtf8
   = Lens.Labels.lensOf
@@ -3918,43 +3856,37 @@ maybe'javaStringCheckUtf8
          (Lens.Labels.Proxy#) "maybe'javaStringCheckUtf8")
 
 maybe'jsonName ::
-               forall x f s t a b .
-                 (Prelude.Functor f,
-                  Lens.Labels.HasLens "maybe'jsonName" f s t a b) =>
+               forall f s t a b .
+                 Lens.Labels.HasLens "maybe'jsonName" f s t a b =>
                  Lens.Family2.LensLike f s t a b
 maybe'jsonName
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'jsonName")
 
 maybe'jstype ::
-             forall x f s t a b .
-               (Prelude.Functor f,
-                Lens.Labels.HasLens "maybe'jstype" f s t a b) =>
+             forall f s t a b . Lens.Labels.HasLens "maybe'jstype" f s t a b =>
                Lens.Family2.LensLike f s t a b
 maybe'jstype
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'jstype")
 
 maybe'label ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "maybe'label" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "maybe'label" f s t a b =>
               Lens.Family2.LensLike f s t a b
 maybe'label
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'label")
 
 maybe'lazy ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "maybe'lazy" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "maybe'lazy" f s t a b =>
              Lens.Family2.LensLike f s t a b
 maybe'lazy
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'lazy")
 
 maybe'leadingComments ::
-                      forall x f s t a b .
-                        (Prelude.Functor f,
-                         Lens.Labels.HasLens "maybe'leadingComments" f s t a b) =>
+                      forall f s t a b .
+                        Lens.Labels.HasLens "maybe'leadingComments" f s t a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'leadingComments
   = Lens.Labels.lensOf
@@ -3962,18 +3894,16 @@ maybe'leadingComments
          (Lens.Labels.Proxy#) "maybe'leadingComments")
 
 maybe'mapEntry ::
-               forall x f s t a b .
-                 (Prelude.Functor f,
-                  Lens.Labels.HasLens "maybe'mapEntry" f s t a b) =>
+               forall f s t a b .
+                 Lens.Labels.HasLens "maybe'mapEntry" f s t a b =>
                  Lens.Family2.LensLike f s t a b
 maybe'mapEntry
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'mapEntry")
 
 maybe'messageSetWireFormat ::
-                           forall x f s t a b .
-                             (Prelude.Functor f,
-                              Lens.Labels.HasLens "maybe'messageSetWireFormat" f s t a b) =>
+                           forall f s t a b .
+                             Lens.Labels.HasLens "maybe'messageSetWireFormat" f s t a b =>
                              Lens.Family2.LensLike f s t a b
 maybe'messageSetWireFormat
   = Lens.Labels.lensOf
@@ -3981,17 +3911,15 @@ maybe'messageSetWireFormat
          (Lens.Labels.Proxy#) "maybe'messageSetWireFormat")
 
 maybe'name ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "maybe'name" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "maybe'name" f s t a b =>
              Lens.Family2.LensLike f s t a b
 maybe'name
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'name")
 
 maybe'negativeIntValue ::
-                       forall x f s t a b .
-                         (Prelude.Functor f,
-                          Lens.Labels.HasLens "maybe'negativeIntValue" f s t a b) =>
+                       forall f s t a b .
+                         Lens.Labels.HasLens "maybe'negativeIntValue" f s t a b =>
                          Lens.Family2.LensLike f s t a b
 maybe'negativeIntValue
   = Lens.Labels.lensOf
@@ -3999,10 +3927,9 @@ maybe'negativeIntValue
          (Lens.Labels.Proxy#) "maybe'negativeIntValue")
 
 maybe'noStandardDescriptorAccessor ::
-                                   forall x f s t a b .
-                                     (Prelude.Functor f,
-                                      Lens.Labels.HasLens "maybe'noStandardDescriptorAccessor" f s t
-                                        a b) =>
+                                   forall f s t a b .
+                                     Lens.Labels.HasLens "maybe'noStandardDescriptorAccessor" f s t
+                                       a b =>
                                      Lens.Family2.LensLike f s t a b
 maybe'noStandardDescriptorAccessor
   = Lens.Labels.lensOf
@@ -4010,18 +3937,15 @@ maybe'noStandardDescriptorAccessor
          (Lens.Labels.Proxy#) "maybe'noStandardDescriptorAccessor")
 
 maybe'number ::
-             forall x f s t a b .
-               (Prelude.Functor f,
-                Lens.Labels.HasLens "maybe'number" f s t a b) =>
+             forall f s t a b . Lens.Labels.HasLens "maybe'number" f s t a b =>
                Lens.Family2.LensLike f s t a b
 maybe'number
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'number")
 
 maybe'objcClassPrefix ::
-                      forall x f s t a b .
-                        (Prelude.Functor f,
-                         Lens.Labels.HasLens "maybe'objcClassPrefix" f s t a b) =>
+                      forall f s t a b .
+                        Lens.Labels.HasLens "maybe'objcClassPrefix" f s t a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'objcClassPrefix
   = Lens.Labels.lensOf
@@ -4029,63 +3953,53 @@ maybe'objcClassPrefix
          (Lens.Labels.Proxy#) "maybe'objcClassPrefix")
 
 maybe'oneofIndex ::
-                 forall x f s t a b .
-                   (Prelude.Functor f,
-                    Lens.Labels.HasLens "maybe'oneofIndex" f s t a b) =>
+                 forall f s t a b .
+                   Lens.Labels.HasLens "maybe'oneofIndex" f s t a b =>
                    Lens.Family2.LensLike f s t a b
 maybe'oneofIndex
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'oneofIndex")
 
 maybe'optimizeFor ::
-                  forall x f s t a b .
-                    (Prelude.Functor f,
-                     Lens.Labels.HasLens "maybe'optimizeFor" f s t a b) =>
+                  forall f s t a b .
+                    Lens.Labels.HasLens "maybe'optimizeFor" f s t a b =>
                     Lens.Family2.LensLike f s t a b
 maybe'optimizeFor
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'optimizeFor")
 
 maybe'options ::
-              forall x f s t a b .
-                (Prelude.Functor f,
-                 Lens.Labels.HasLens "maybe'options" f s t a b) =>
+              forall f s t a b . Lens.Labels.HasLens "maybe'options" f s t a b =>
                 Lens.Family2.LensLike f s t a b
 maybe'options
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'options")
 
 maybe'outputType ::
-                 forall x f s t a b .
-                   (Prelude.Functor f,
-                    Lens.Labels.HasLens "maybe'outputType" f s t a b) =>
+                 forall f s t a b .
+                   Lens.Labels.HasLens "maybe'outputType" f s t a b =>
                    Lens.Family2.LensLike f s t a b
 maybe'outputType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'outputType")
 
 maybe'package ::
-              forall x f s t a b .
-                (Prelude.Functor f,
-                 Lens.Labels.HasLens "maybe'package" f s t a b) =>
+              forall f s t a b . Lens.Labels.HasLens "maybe'package" f s t a b =>
                 Lens.Family2.LensLike f s t a b
 maybe'package
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'package")
 
 maybe'packed ::
-             forall x f s t a b .
-               (Prelude.Functor f,
-                Lens.Labels.HasLens "maybe'packed" f s t a b) =>
+             forall f s t a b . Lens.Labels.HasLens "maybe'packed" f s t a b =>
                Lens.Family2.LensLike f s t a b
 maybe'packed
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'packed")
 
 maybe'positiveIntValue ::
-                       forall x f s t a b .
-                         (Prelude.Functor f,
-                          Lens.Labels.HasLens "maybe'positiveIntValue" f s t a b) =>
+                       forall f s t a b .
+                         Lens.Labels.HasLens "maybe'positiveIntValue" f s t a b =>
                          Lens.Family2.LensLike f s t a b
 maybe'positiveIntValue
   = Lens.Labels.lensOf
@@ -4093,9 +4007,8 @@ maybe'positiveIntValue
          (Lens.Labels.Proxy#) "maybe'positiveIntValue")
 
 maybe'pyGenericServices ::
-                        forall x f s t a b .
-                          (Prelude.Functor f,
-                           Lens.Labels.HasLens "maybe'pyGenericServices" f s t a b) =>
+                        forall f s t a b .
+                          Lens.Labels.HasLens "maybe'pyGenericServices" f s t a b =>
                           Lens.Family2.LensLike f s t a b
 maybe'pyGenericServices
   = Lens.Labels.lensOf
@@ -4103,9 +4016,8 @@ maybe'pyGenericServices
          (Lens.Labels.Proxy#) "maybe'pyGenericServices")
 
 maybe'serverStreaming ::
-                      forall x f s t a b .
-                        (Prelude.Functor f,
-                         Lens.Labels.HasLens "maybe'serverStreaming" f s t a b) =>
+                      forall f s t a b .
+                        Lens.Labels.HasLens "maybe'serverStreaming" f s t a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'serverStreaming
   = Lens.Labels.lensOf
@@ -4113,9 +4025,8 @@ maybe'serverStreaming
          (Lens.Labels.Proxy#) "maybe'serverStreaming")
 
 maybe'sourceCodeInfo ::
-                     forall x f s t a b .
-                       (Prelude.Functor f,
-                        Lens.Labels.HasLens "maybe'sourceCodeInfo" f s t a b) =>
+                     forall f s t a b .
+                       Lens.Labels.HasLens "maybe'sourceCodeInfo" f s t a b =>
                        Lens.Family2.LensLike f s t a b
 maybe'sourceCodeInfo
   = Lens.Labels.lensOf
@@ -4123,44 +4034,38 @@ maybe'sourceCodeInfo
          (Lens.Labels.Proxy#) "maybe'sourceCodeInfo")
 
 maybe'sourceFile ::
-                 forall x f s t a b .
-                   (Prelude.Functor f,
-                    Lens.Labels.HasLens "maybe'sourceFile" f s t a b) =>
+                 forall f s t a b .
+                   Lens.Labels.HasLens "maybe'sourceFile" f s t a b =>
                    Lens.Family2.LensLike f s t a b
 maybe'sourceFile
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'sourceFile")
 
 maybe'start ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "maybe'start" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "maybe'start" f s t a b =>
               Lens.Family2.LensLike f s t a b
 maybe'start
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'start")
 
 maybe'stringValue ::
-                  forall x f s t a b .
-                    (Prelude.Functor f,
-                     Lens.Labels.HasLens "maybe'stringValue" f s t a b) =>
+                  forall f s t a b .
+                    Lens.Labels.HasLens "maybe'stringValue" f s t a b =>
                     Lens.Family2.LensLike f s t a b
 maybe'stringValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'stringValue")
 
 maybe'syntax ::
-             forall x f s t a b .
-               (Prelude.Functor f,
-                Lens.Labels.HasLens "maybe'syntax" f s t a b) =>
+             forall f s t a b . Lens.Labels.HasLens "maybe'syntax" f s t a b =>
                Lens.Family2.LensLike f s t a b
 maybe'syntax
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'syntax")
 
 maybe'trailingComments ::
-                       forall x f s t a b .
-                         (Prelude.Functor f,
-                          Lens.Labels.HasLens "maybe'trailingComments" f s t a b) =>
+                       forall f s t a b .
+                         Lens.Labels.HasLens "maybe'trailingComments" f s t a b =>
                          Lens.Family2.LensLike f s t a b
 maybe'trailingComments
   = Lens.Labels.lensOf
@@ -4168,34 +4073,30 @@ maybe'trailingComments
          (Lens.Labels.Proxy#) "maybe'trailingComments")
 
 maybe'type' ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "maybe'type'" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "maybe'type'" f s t a b =>
               Lens.Family2.LensLike f s t a b
 maybe'type'
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'type'")
 
 maybe'typeName ::
-               forall x f s t a b .
-                 (Prelude.Functor f,
-                  Lens.Labels.HasLens "maybe'typeName" f s t a b) =>
+               forall f s t a b .
+                 Lens.Labels.HasLens "maybe'typeName" f s t a b =>
                  Lens.Family2.LensLike f s t a b
 maybe'typeName
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'typeName")
 
 maybe'weak ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "maybe'weak" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "maybe'weak" f s t a b =>
              Lens.Family2.LensLike f s t a b
 maybe'weak
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'weak")
 
 messageSetWireFormat ::
-                     forall x f s t a b .
-                       (Prelude.Functor f,
-                        Lens.Labels.HasLens "messageSetWireFormat" f s t a b) =>
+                     forall f s t a b .
+                       Lens.Labels.HasLens "messageSetWireFormat" f s t a b =>
                        Lens.Family2.LensLike f s t a b
 messageSetWireFormat
   = Lens.Labels.lensOf
@@ -4203,58 +4104,51 @@ messageSetWireFormat
          (Lens.Labels.Proxy#) "messageSetWireFormat")
 
 messageType ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "messageType" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "messageType" f s t a b =>
               Lens.Family2.LensLike f s t a b
 messageType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "messageType")
 
 method ::
-       forall x f s t a b .
-         (Prelude.Functor f, Lens.Labels.HasLens "method" f s t a b) =>
+       forall f s t a b . Lens.Labels.HasLens "method" f s t a b =>
          Lens.Family2.LensLike f s t a b
 method
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "method")
 
 name ::
-     forall x f s t a b .
-       (Prelude.Functor f, Lens.Labels.HasLens "name" f s t a b) =>
+     forall f s t a b . Lens.Labels.HasLens "name" f s t a b =>
        Lens.Family2.LensLike f s t a b
 name
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "name")
 
 namePart ::
-         forall x f s t a b .
-           (Prelude.Functor f, Lens.Labels.HasLens "namePart" f s t a b) =>
+         forall f s t a b . Lens.Labels.HasLens "namePart" f s t a b =>
            Lens.Family2.LensLike f s t a b
 namePart
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "namePart")
 
 negativeIntValue ::
-                 forall x f s t a b .
-                   (Prelude.Functor f,
-                    Lens.Labels.HasLens "negativeIntValue" f s t a b) =>
+                 forall f s t a b .
+                   Lens.Labels.HasLens "negativeIntValue" f s t a b =>
                    Lens.Family2.LensLike f s t a b
 negativeIntValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "negativeIntValue")
 
 nestedType ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "nestedType" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "nestedType" f s t a b =>
              Lens.Family2.LensLike f s t a b
 nestedType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "nestedType")
 
 noStandardDescriptorAccessor ::
-                             forall x f s t a b .
-                               (Prelude.Functor f,
-                                Lens.Labels.HasLens "noStandardDescriptorAccessor" f s t a b) =>
+                             forall f s t a b .
+                               Lens.Labels.HasLens "noStandardDescriptorAccessor" f s t a b =>
                                Lens.Family2.LensLike f s t a b
 noStandardDescriptorAccessor
   = Lens.Labels.lensOf
@@ -4262,226 +4156,197 @@ noStandardDescriptorAccessor
          (Lens.Labels.Proxy#) "noStandardDescriptorAccessor")
 
 number ::
-       forall x f s t a b .
-         (Prelude.Functor f, Lens.Labels.HasLens "number" f s t a b) =>
+       forall f s t a b . Lens.Labels.HasLens "number" f s t a b =>
          Lens.Family2.LensLike f s t a b
 number
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "number")
 
 objcClassPrefix ::
-                forall x f s t a b .
-                  (Prelude.Functor f,
-                   Lens.Labels.HasLens "objcClassPrefix" f s t a b) =>
+                forall f s t a b .
+                  Lens.Labels.HasLens "objcClassPrefix" f s t a b =>
                   Lens.Family2.LensLike f s t a b
 objcClassPrefix
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "objcClassPrefix")
 
 oneofDecl ::
-          forall x f s t a b .
-            (Prelude.Functor f, Lens.Labels.HasLens "oneofDecl" f s t a b) =>
+          forall f s t a b . Lens.Labels.HasLens "oneofDecl" f s t a b =>
             Lens.Family2.LensLike f s t a b
 oneofDecl
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "oneofDecl")
 
 oneofIndex ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "oneofIndex" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "oneofIndex" f s t a b =>
              Lens.Family2.LensLike f s t a b
 oneofIndex
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "oneofIndex")
 
 optimizeFor ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "optimizeFor" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "optimizeFor" f s t a b =>
               Lens.Family2.LensLike f s t a b
 optimizeFor
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "optimizeFor")
 
 options ::
-        forall x f s t a b .
-          (Prelude.Functor f, Lens.Labels.HasLens "options" f s t a b) =>
+        forall f s t a b . Lens.Labels.HasLens "options" f s t a b =>
           Lens.Family2.LensLike f s t a b
 options
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "options")
 
 outputType ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "outputType" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "outputType" f s t a b =>
              Lens.Family2.LensLike f s t a b
 outputType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "outputType")
 
 package ::
-        forall x f s t a b .
-          (Prelude.Functor f, Lens.Labels.HasLens "package" f s t a b) =>
+        forall f s t a b . Lens.Labels.HasLens "package" f s t a b =>
           Lens.Family2.LensLike f s t a b
 package
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "package")
 
 packed ::
-       forall x f s t a b .
-         (Prelude.Functor f, Lens.Labels.HasLens "packed" f s t a b) =>
+       forall f s t a b . Lens.Labels.HasLens "packed" f s t a b =>
          Lens.Family2.LensLike f s t a b
 packed
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "packed")
 
 path ::
-     forall x f s t a b .
-       (Prelude.Functor f, Lens.Labels.HasLens "path" f s t a b) =>
+     forall f s t a b . Lens.Labels.HasLens "path" f s t a b =>
        Lens.Family2.LensLike f s t a b
 path
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "path")
 
 positiveIntValue ::
-                 forall x f s t a b .
-                   (Prelude.Functor f,
-                    Lens.Labels.HasLens "positiveIntValue" f s t a b) =>
+                 forall f s t a b .
+                   Lens.Labels.HasLens "positiveIntValue" f s t a b =>
                    Lens.Family2.LensLike f s t a b
 positiveIntValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "positiveIntValue")
 
 publicDependency ::
-                 forall x f s t a b .
-                   (Prelude.Functor f,
-                    Lens.Labels.HasLens "publicDependency" f s t a b) =>
+                 forall f s t a b .
+                   Lens.Labels.HasLens "publicDependency" f s t a b =>
                    Lens.Family2.LensLike f s t a b
 publicDependency
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "publicDependency")
 
 pyGenericServices ::
-                  forall x f s t a b .
-                    (Prelude.Functor f,
-                     Lens.Labels.HasLens "pyGenericServices" f s t a b) =>
+                  forall f s t a b .
+                    Lens.Labels.HasLens "pyGenericServices" f s t a b =>
                     Lens.Family2.LensLike f s t a b
 pyGenericServices
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "pyGenericServices")
 
 reservedName ::
-             forall x f s t a b .
-               (Prelude.Functor f,
-                Lens.Labels.HasLens "reservedName" f s t a b) =>
+             forall f s t a b . Lens.Labels.HasLens "reservedName" f s t a b =>
                Lens.Family2.LensLike f s t a b
 reservedName
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "reservedName")
 
 reservedRange ::
-              forall x f s t a b .
-                (Prelude.Functor f,
-                 Lens.Labels.HasLens "reservedRange" f s t a b) =>
+              forall f s t a b . Lens.Labels.HasLens "reservedRange" f s t a b =>
                 Lens.Family2.LensLike f s t a b
 reservedRange
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "reservedRange")
 
 serverStreaming ::
-                forall x f s t a b .
-                  (Prelude.Functor f,
-                   Lens.Labels.HasLens "serverStreaming" f s t a b) =>
+                forall f s t a b .
+                  Lens.Labels.HasLens "serverStreaming" f s t a b =>
                   Lens.Family2.LensLike f s t a b
 serverStreaming
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "serverStreaming")
 
 service ::
-        forall x f s t a b .
-          (Prelude.Functor f, Lens.Labels.HasLens "service" f s t a b) =>
+        forall f s t a b . Lens.Labels.HasLens "service" f s t a b =>
           Lens.Family2.LensLike f s t a b
 service
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "service")
 
 sourceCodeInfo ::
-               forall x f s t a b .
-                 (Prelude.Functor f,
-                  Lens.Labels.HasLens "sourceCodeInfo" f s t a b) =>
+               forall f s t a b .
+                 Lens.Labels.HasLens "sourceCodeInfo" f s t a b =>
                  Lens.Family2.LensLike f s t a b
 sourceCodeInfo
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "sourceCodeInfo")
 
 sourceFile ::
-           forall x f s t a b .
-             (Prelude.Functor f, Lens.Labels.HasLens "sourceFile" f s t a b) =>
+           forall f s t a b . Lens.Labels.HasLens "sourceFile" f s t a b =>
              Lens.Family2.LensLike f s t a b
 sourceFile
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "sourceFile")
 
 span ::
-     forall x f s t a b .
-       (Prelude.Functor f, Lens.Labels.HasLens "span" f s t a b) =>
+     forall f s t a b . Lens.Labels.HasLens "span" f s t a b =>
        Lens.Family2.LensLike f s t a b
 span
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "span")
 
 start ::
-      forall x f s t a b .
-        (Prelude.Functor f, Lens.Labels.HasLens "start" f s t a b) =>
+      forall f s t a b . Lens.Labels.HasLens "start" f s t a b =>
         Lens.Family2.LensLike f s t a b
 start
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "start")
 
 stringValue ::
-            forall x f s t a b .
-              (Prelude.Functor f, Lens.Labels.HasLens "stringValue" f s t a b) =>
+            forall f s t a b . Lens.Labels.HasLens "stringValue" f s t a b =>
               Lens.Family2.LensLike f s t a b
 stringValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "stringValue")
 
 syntax ::
-       forall x f s t a b .
-         (Prelude.Functor f, Lens.Labels.HasLens "syntax" f s t a b) =>
+       forall f s t a b . Lens.Labels.HasLens "syntax" f s t a b =>
          Lens.Family2.LensLike f s t a b
 syntax
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "syntax")
 
 trailingComments ::
-                 forall x f s t a b .
-                   (Prelude.Functor f,
-                    Lens.Labels.HasLens "trailingComments" f s t a b) =>
+                 forall f s t a b .
+                   Lens.Labels.HasLens "trailingComments" f s t a b =>
                    Lens.Family2.LensLike f s t a b
 trailingComments
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "trailingComments")
 
 type' ::
-      forall x f s t a b .
-        (Prelude.Functor f, Lens.Labels.HasLens "type'" f s t a b) =>
+      forall f s t a b . Lens.Labels.HasLens "type'" f s t a b =>
         Lens.Family2.LensLike f s t a b
 type'
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "type'")
 
 typeName ::
-         forall x f s t a b .
-           (Prelude.Functor f, Lens.Labels.HasLens "typeName" f s t a b) =>
+         forall f s t a b . Lens.Labels.HasLens "typeName" f s t a b =>
            Lens.Family2.LensLike f s t a b
 typeName
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "typeName")
 
 uninterpretedOption ::
-                    forall x f s t a b .
-                      (Prelude.Functor f,
-                       Lens.Labels.HasLens "uninterpretedOption" f s t a b) =>
+                    forall f s t a b .
+                      Lens.Labels.HasLens "uninterpretedOption" f s t a b =>
                       Lens.Family2.LensLike f s t a b
 uninterpretedOption
   = Lens.Labels.lensOf
@@ -4489,25 +4354,22 @@ uninterpretedOption
          (Lens.Labels.Proxy#) "uninterpretedOption")
 
 value ::
-      forall x f s t a b .
-        (Prelude.Functor f, Lens.Labels.HasLens "value" f s t a b) =>
+      forall f s t a b . Lens.Labels.HasLens "value" f s t a b =>
         Lens.Family2.LensLike f s t a b
 value
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "value")
 
 weak ::
-     forall x f s t a b .
-       (Prelude.Functor f, Lens.Labels.HasLens "weak" f s t a b) =>
+     forall f s t a b . Lens.Labels.HasLens "weak" f s t a b =>
        Lens.Family2.LensLike f s t a b
 weak
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "weak")
 
 weakDependency ::
-               forall x f s t a b .
-                 (Prelude.Functor f,
-                  Lens.Labels.HasLens "weakDependency" f s t a b) =>
+               forall f s t a b .
+                 Lens.Labels.HasLens "weakDependency" f s t a b =>
                  Lens.Family2.LensLike f s t a b
 weakDependency
   = Lens.Labels.lensOf

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-protoc
-version:             0.2.0.0
+version:             0.2.0.1
 synopsis:            Protocol buffer compiler for the proto-lens library.
 description:
   Turn protocol buffer files (.proto) into Haskell files (.hs) which
@@ -47,8 +47,8 @@ library
         , lens-family == 1.2.*
         , lens-labels == 0.1.*
         , process >= 1.2 && < 1.5
-        , proto-lens == 0.2.0.0
-        , proto-lens-descriptors == 0.2.0.0
+        , proto-lens == 0.2.0.1
+        , proto-lens-descriptors == 0.2.0.1
         , text == 1.2.*
     reexported-modules:
         -- Modules that are needed by the generated Haskell files.
@@ -79,8 +79,8 @@ executable proto-lens-protoc
       , lens-family == 1.2.*
       -- Specify an exact version of `proto-lens`, since it's tied closely
       -- to the generated code.
-      , proto-lens == 0.2.0.0
-      , proto-lens-descriptors == 0.2.0.0
+      , proto-lens == 0.2.0.1
+      , proto-lens-descriptors == 0.2.0.1
       , text == 1.2.*
   hs-source-dirs:      src
   other-modules:

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -15,7 +15,6 @@ module Data.ProtoLens.Compiler.Generate(
     ) where
 
 
-import Control.Applicative ((<$>))
 import Control.Arrow (second)
 import qualified Data.Foldable as F
 import qualified Data.List as List
@@ -34,7 +33,6 @@ import Proto.Google.Protobuf.Descriptor
     , FieldDescriptorProto'Label(..)
     , FieldDescriptorProto'Type(..)
     , FileDescriptorProto
-    , FieldOptions
     , defaultValue
     , label
     , mapEntry
@@ -321,14 +319,12 @@ generateEnumDecls info =
 generateFieldDecls :: String -> [Decl]
 generateFieldDecls xStr =
     -- foo :: forall x f s t a b
-    --        . (Functor f, HasLens x f s t a b)
-    --        => LensLike f s t a b
+    --        . HasLens x f s t a b => LensLike f s t a b
+    -- -- Note: `Lens.Family2.LensLike f` implies Functor f.
     -- foo = lensOf (Proxy# :: Proxy# x)
     [ typeSig [x]
-          $ tyForAll ["x", "f", "s", "t", "a", "b"]
-                  [ classA "Prelude.Functor" ["f"]
-                  , classA "Lens.Labels.HasLens" [xSym, "f", "s", "t", "a", "b"]
-                  ]
+          $ tyForAll ["f", "s", "t", "a", "b"]
+                  [classA "Lens.Labels.HasLens" [xSym, "f", "s", "t", "a", "b"]]
                     $ "Lens.Family2.LensLike" @@ "f" @@ "s" @@ "t" @@ "a" @@ "b"
     , funBind [match x []
                   $ "Lens.Labels.lensOf"

--- a/proto-lens-tests/tests/canonical_test.hs
+++ b/proto-lens-tests/tests/canonical_test.hs
@@ -19,11 +19,11 @@ import Test.Framework (testGroup)
 import Data.ProtoLens
 import qualified Data.ByteString as B
 import Data.ByteString.Builder (word8)
-import Data.Monoid (mconcat)
 import Data.Word (Word8)
 
 import Data.ProtoLens.TestUtil
 
+main :: IO ()
 main = testMain
            [int32Test, stringTest, embeddedTest, packedIntsTest, roundTripTests]
 
@@ -32,6 +32,7 @@ canonicalTest :: (Show a, Eq a, Message a)
 canonicalTest name val text bytes
     = testGroup name [serializeTo "bytes" val text $ mconcat $ map word8 bytes]
 
+int32Test, stringTest, embeddedTest, packedIntsTest, roundTripTests :: Test
 int32Test = canonicalTest
     "int32"
     (def & a .~ 150 :: Test1)

--- a/proto-lens-tests/tests/enum_test.hs
+++ b/proto-lens-tests/tests/enum_test.hs
@@ -14,14 +14,13 @@ import Test.Framework (plusTestOptions, testGroup)
 import Test.Framework.Options (topt_timeout)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit ((@?=))
-import Text.PrettyPrint (text)
-import Data.Monoid (mempty)
 
 import Data.ProtoLens.TestUtil
 
 defFoo :: Foo
 defFoo = def
 
+main :: IO ()
 main = testMain
     [ serializeTo "default" defFoo mempty mempty
     , testExternalEnum
@@ -36,10 +35,14 @@ main = testMain
     , testAliases
     ]
 
+testExternalEnum, testNestedEnum, testDefaults, testBadEnumValues,
+    testNamedEnumValues, testRoundTrip, testBounded, testMaybeSuccAndPred,
+    testEnumFromThenTo, testAliases :: Test
+
 testExternalEnum = testGroup "external"
     [ serializeTo (show e1)
           (defFoo & bar .~ e1)
-          (keyedDoc "bar" $ text e2)
+          (keyed "bar" e2)
           (tagged 1 $ VarInt e3)
     -- Use ":: Bar" to confirm that the external type doesn't have a prefix.
     | (e1, e2, e3) <- zip3 [BAR3, BAR5, NEGATIVE :: Bar]
@@ -50,7 +53,7 @@ testExternalEnum = testGroup "external"
 testNestedEnum = testGroup "nested"
     [ serializeTo (show e1)
           (defFoo & baz .~ e1)
-          (keyedDoc "baz" $ text e2)
+          (keyed "baz" e2)
           (tagged 2 $ VarInt e3)
     -- Use ":: Foo'Baz" to confirm that the nested type has a prefix.
     | (e1, e2, e3) <- zip3 [Foo'BAZ2, Foo'BAZ4 :: Foo'Baz]

--- a/proto-lens-tests/tests/group_test.hs
+++ b/proto-lens-tests/tests/group_test.hs
@@ -15,6 +15,7 @@ import Lens.Family2 ((&), (.~))
 
 import Data.ProtoLens.TestUtil
 
+main :: IO ()
 main = testMain
            [ serializeSimple
            , deserializeEndMismatch
@@ -22,10 +23,13 @@ main = testMain
            , roundTripComplicated
            ]
 
+serializeSimple, deserializeEndMismatch, roundTripSimple,
+    roundTripComplicated :: Test
+
 serializeSimple = serializeTo
     "serialize Simple"
     (def & (grp . int) .~ 12 :: Simple)
-    (braced "Grp" (keyed "int" 12))
+    (braced "Grp" (keyedInt "int" 12))
     (tagged 1 GroupStart <> tagged 2 (VarInt 12) <> tagged 1 GroupEnd)
 
 deserializeEndMismatch = deserializeFrom

--- a/proto-lens-tests/tests/labels_test.hs
+++ b/proto-lens-tests/tests/labels_test.hs
@@ -6,7 +6,7 @@ import Prelude hiding ((.))
 import Lens.Labels ((&), (.~), (^.), (.), runLens, set)
 import qualified Lens.Family2
 import qualified Lens.Family
-import Proto.Canonical (Test1, Test2, Test3, Test4)
+import Proto.Canonical (Test1, Test3)
 
 import Data.Default.Class (def)
 import Data.ProtoLens (build)
@@ -14,6 +14,7 @@ import Data.ProtoLens.TestUtil
 import Test.HUnit ((@?=))
 import Test.Framework.Providers.HUnit (testCase)
 
+main :: IO ()
 main = testMain
     [ testCase "inside" inside
     , testCase "outside" outside

--- a/proto-lens-tests/tests/map_test.hs
+++ b/proto-lens-tests/tests/map_test.hs
@@ -4,7 +4,8 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-{-# LANGUAGE OverloadedStrings, OverloadedLists #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Main where
 
 import Proto.Map
@@ -12,7 +13,7 @@ import Data.ProtoLens
 import Lens.Family2 ((&), (.~))
 import qualified Data.ByteString.Char8 as C
 import Data.ByteString.Builder (Builder, byteString)
-import Data.Monoid (mempty, (<>))
+import Data.Monoid ((<>))
 import Data.Word (Word64)
 
 import Data.ProtoLens.TestUtil
@@ -27,21 +28,23 @@ entry k v = tagged 1 $ Lengthy $ tagged 1 (VarInt k)
 taggedValue :: String -> Builder
 taggedValue = tagged 2 . Lengthy . byteString . C.pack
 
-kvPair :: (Show k, Show v) => k -> v -> Doc
+kvPair :: Doc -> Doc -> Doc
 kvPair k v = keyed "key" k $+$ keyed "value" v
 
 
 -- Note how OverloadedLists work here in the "bar" field.
 -- For proto-lens, it resolves to a (Map Int32 Text).
+main :: IO ()
 main = testMain
     [ serializeTo "default" defFoo "" mempty
     , serializeTo "singleton"
         (defFoo & bar .~ [(42, "qwerty")])
-        (braced "bar" $ kvPair 42 "qwerty")
+        (braced "bar" $ kvPair "42" $ doubleQuotes "qwerty")
         (entry 42 "qwerty")
     , serializeTo "moreElements"
         (defFoo & bar .~ [(17, "abc"), (42, "qwerty")])
-        (braced "bar" (kvPair 17 "abc") $+$ braced "bar" (kvPair 42 "qwerty"))
+        (braced "bar" (kvPair "17" $ doubleQuotes "abc")
+            $+$ braced "bar" (kvPair "42" $ doubleQuotes "qwerty"))
         (entry 17 "abc" <> entry 42 "qwerty")
     -- Check that we can tolerate missing keys and values.
     , deserializeFrom "missing key"

--- a/proto-lens-tests/tests/names_test.hs
+++ b/proto-lens-tests/tests/names_test.hs
@@ -29,6 +29,7 @@ import Data.ProtoLens.TestUtil
     , testMain
     )
 
+main :: IO ()
 main = testMain
     [ testNames
     , testPreludeType
@@ -37,6 +38,9 @@ main = testMain
     , testProtoKeywordTypes
     , testReadReservedName
     ]
+
+testNames, testPreludeType, testHaskellKeywords, testProtoKeywords,
+    testProtoKeywordTypes, testReadReservedName :: Test
 
 -- | Test that we can get/set each individual field.
 testFields :: forall a . (Show a, Message a, Eq a)

--- a/proto-lens-tests/tests/no_package_test.hs
+++ b/proto-lens-tests/tests/no_package_test.hs
@@ -7,11 +7,13 @@ import Lens.Family2 ((&), (.~), (^.))
 import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit ((@=?))
 
-import Data.ProtoLens.TestUtil (testMain)
+import Data.ProtoLens.TestUtil (Test, testMain)
 import Proto.NoPackage
 
+main :: IO ()
 main = testMain [testNames]
 
+testNames :: Test
 testNames = testCase "testNoPackage" $ do
     42 @=? (def & c . a .~ 42 :: Foo) ^. c . a
     42 @=? (def & d . e .~ 42 :: Foo) ^. d . e

--- a/proto-lens-tests/tests/optional_test.hs
+++ b/proto-lens-tests/tests/optional_test.hs
@@ -3,7 +3,6 @@
 -- Use of this source code is governed by a BSD-style
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
-
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
@@ -13,27 +12,27 @@ import Lens.Family2 ((&), (.~), (^.))
 import Test.Framework (testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit ((@=?))
-import Data.Monoid (mempty)
 
 import Data.ProtoLens.TestUtil
 
 defFoo :: Foo
 defFoo = def
 
+main :: IO ()
 main = testMain
     [ testGroup "serialize"
         [ serializeTo "default" defFoo "" mempty
         , serializeTo "different-from-implicit-default" (defFoo & a .~ 17)
-              (keyed "a" 17)
+              (keyed "a" "17")
               $ tagged 1 $ VarInt 17
         , serializeTo "different-from-explicit-default" (defFoo & b .~ 17)
-              (keyed "b" 17)
+              (keyed "b" "17")
               $ tagged 2 $ VarInt 17
         , serializeTo "same-as-implicit-default" (defFoo & a .~ 0)
-              (keyed "a" 0)
+              (keyed "a" "0")
               $ tagged 1 $ VarInt 0
         , serializeTo "same-as-explicit-default" (defFoo & b .~ 42)
-              (keyed "b" 42)
+              (keyed "b" "42")
               $ tagged 2 $ VarInt 42
         ]
     , testGroup "lens"

--- a/proto-lens-tests/tests/packed_test.hs
+++ b/proto-lens-tests/tests/packed_test.hs
@@ -3,28 +3,28 @@
 -- Use of this source code is governed by a BSD-style
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
-
+{-# LANGUAGE OverloadedStrings #-}
 module Main where
 
 import Proto.Packed
 import Lens.Family2 ((&), (.~))
 import Data.ProtoLens
-import Data.Monoid (mconcat, mempty, (<>))
 
 import Data.ProtoLens.TestUtil
 
 defFoo :: Foo
 defFoo = def
 
+main :: IO ()
 main = testMain
     [ serializeTo "default" defFoo mempty mempty
     , serializeTo "unpacked"
           (defFoo & a .~ [1..3])
-          (vcat [keyed "a" x | x <- [1..3]])
+          (vcat [keyedInt "a" x | x <- [1..3]])
           $ mconcat [tagged 1 $ VarInt x | x <- [1..3]]
     , serializeTo "packed"
           (defFoo & b .~ [1..3])
-          (vcat [keyed "b" x | x <- [1..3]])
+          (vcat [keyedInt "b" x | x <- [1..3]])
           $ tagged 2 $ Lengthy $ mconcat [varInt x | x <- [1..3]]
     , deserializeFrom "unpacked-as-packed"
           (Just $ defFoo & a .~ [1..3])

--- a/proto-lens-tests/tests/proto3_test.hs
+++ b/proto-lens-tests/tests/proto3_test.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Data.Monoid (mconcat)
 import Data.ProtoLens
 import Lens.Family2 ((&), (.~), (^.))
 import qualified Data.ByteString as B
@@ -38,6 +37,7 @@ import Test.HUnit ((@=?))
 
 import Data.ProtoLens.TestUtil
 
+main :: IO ()
 main = testMain
   [ testGroup "Foo"
     [ serializeTo "int32"
@@ -46,7 +46,7 @@ main = testMain
         $ tagged 1 $ VarInt 150
     , serializeTo "repeated-string"
         (def & b .~ ["one", "two"] :: Foo)
-        (vcat $ map (keyed "b") ["one", "two"])
+        (vcat $ map (keyedStr "b") ["one", "two"])
         $ mconcat (map (tagged 2 . Lengthy) ["one", "two"])
     , testGroup "oneof"
         [ serializeTo "float"
@@ -66,7 +66,7 @@ main = testMain
     -- Repeated scalar fields in proto3 should serialize as "packed" by default.
     , serializeTo "packed-by-default"
         (def & f .~ [1,2,3] :: Foo)
-        (vcat [keyed "f" x | x <- [1..3]])
+        (vcat [keyedInt "f" x | x <- [1..3]])
         $ tagged 7 $ Lengthy $ mconcat [varInt x | x <- [1..3]]
     , runTypedTest (roundTripTest "foo" :: TypedTest Foo)
     ]

--- a/proto-lens-tests/tests/raw_fields_test.hs
+++ b/proto-lens-tests/tests/raw_fields_test.hs
@@ -23,7 +23,6 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as LT
 import Data.Text.Encoding (encodeUtf8)
-import Data.Monoid (mempty)
 import Data.ByteString.Builder (Builder, byteString)
 
 import Data.ProtoLens.TestUtil
@@ -40,6 +39,7 @@ readFails name = readFrom name (Nothing :: Maybe Raw)
 readSucceeds :: String -> Raw -> LT.Text -> Test
 readSucceeds name value = readFrom name (Just value)
 
+main :: IO ()
 main = testMain
     [ serializeTo "default" (def :: Raw) mempty mempty
     , testInt32
@@ -61,13 +61,18 @@ main = testMain
     , testFailedDecoding
     ]
 
-testRawValues :: Show a => String -> Lens' Raw a -> (a -> Doc)
+testInt32, testInt64, testUInt32, testUInt64, testSInt32, testSInt64,
+    testFixed32, testFixed64, testSFixed32, testSFixed64, testFloat,
+    testDouble, testBool, testString, testUnicode, testBytes,
+    testFailedDecoding :: Test
+
+testRawValues :: String -> Lens' Raw a -> (a -> Doc)
               -> (a -> Builder) -> [(String, a)] -> Test
 testRawValues groupName access showMsg encode values
     = testRawValuePairs groupName access showMsg encode
         [(name, x, x) | (name, x) <- values]
 
-testRawValuePairs :: Show a => String -> Lens' Raw a -> (a -> Doc)
+testRawValuePairs :: String -> Lens' Raw a -> (a -> Doc)
                   -> (b -> Builder) -> [(String, a, b)] -> Test
 testRawValuePairs groupName access showMsg encode values
     = testGroup groupName
@@ -92,12 +97,12 @@ int32Values =
     ]
 
 testInt32 = testRawValues "int32" a
-                (keyed "a")
+                (keyedShow "a")
                 (tagged 1 . VarInt . fromIntegral)
                 int32Values
 
 testSInt32 = testRawValues "sint32" l
-                (keyed "l")
+                (keyedShow "l")
                 (tagged 12 . VarInt . signed)
                 int32Values
 
@@ -109,7 +114,7 @@ signed x
     | otherwise = 1 + 2 * fromIntegral (negate $ x + 1)
 
 testSFixed32 = testRawValues "sfixed32" n
-                  (keyed "n")
+                  (keyedShow "n")
                   (tagged 14 . Fixed32 . fromIntegral)
                   int32Values
 
@@ -126,17 +131,17 @@ int64Values =
     ]
 
 testInt64 = testRawValues "int64" b
-                (keyed "b")
+                (keyedShow "b")
                 (tagged 2 . VarInt . fromIntegral)
                 int64Values
 
 testSInt64 = testRawValues "sint64" m
-                (keyed "m")
+                (keyedShow "m")
                 (tagged 13 . VarInt . signed)
                 int64Values
 
 testSFixed64 = testRawValues "sfixed64" o
-                  (keyed "o")
+                  (keyedShow "o")
                   (tagged 15 . Fixed64 . fromIntegral)
                   int64Values
 
@@ -149,12 +154,12 @@ word32Values =
     ]
 
 testUInt32 = testRawValues "uint32" j
-                (keyed "j")
+                (keyedShow "j")
                 (tagged 10 . VarInt . fromIntegral)
                 word32Values
 
 testFixed32 = testRawValues "fixed32" c
-                (keyed "c")
+                (keyedShow "c")
                 (tagged 3 . Fixed32)
                 word32Values
 
@@ -168,17 +173,17 @@ word64Values =
     ]
 
 testUInt64 = testRawValues "uint64" k
-                (keyed "k")
+                (keyedShow "k")
                 (tagged 11 . VarInt)
                 word64Values
 
 testFixed64 = testRawValues "fixed64" d
-                (keyed "d")
+                (keyedShow "d")
                 (tagged 4 . Fixed64)
                 word64Values
 
 testFloat = testRawValuePairs "float" e
-    (keyed "e")
+    (keyedShow "e")
     (tagged 5 . Fixed32)
     ([ ("zero", 0, 0x0)
      , ("simple", 27, 0x41d80000)
@@ -189,7 +194,7 @@ testFloat = testRawValuePairs "float" e
      , ("negative fractional", -(20/3), 0xc0d55555)
      ] :: [(String, Float, Word32)])
 testDouble = testRawValuePairs "double" f
-    (keyed "f")
+    (keyedShow "f")
     (tagged 6 . Fixed64)
     ([ ("zero", 0, 0x0)
      , ("simple", 27, 0x403b000000000000)
@@ -202,7 +207,7 @@ testDouble = testRawValuePairs "double" f
 
 testBool = testGroup "bool"
     [ testRawValuePairs "named" g
-        (keyedDoc "g" . (\t -> if t then "true" else "false"))
+        (keyed "g" . (\t -> if t then "true" else "false"))
         (tagged 7 . VarInt)
         [ ("true", True, 1)
         , ("false", False, 0)
@@ -214,7 +219,7 @@ testBool = testGroup "bool"
     ]
 
 testString = testRawValues "string" h
-    (keyed "h")
+    (keyedShow "h")
     (tagged 8 . Lengthy . byteString . encodeUtf8)
     ([ ("empty", "")
      , ("one-char", "x")
@@ -235,7 +240,7 @@ testUnicode = testGroup "unicode"
 
 
 testBytes = testRawValues "bytes" i
-    (keyed "i")
+    (keyedShow "i")
     (tagged 9 . Lengthy . byteString)
     (fmap (second B.pack)
         [ ("empty", [])
@@ -245,7 +250,6 @@ testBytes = testRawValues "bytes" i
         , ("very long", replicate 12345 42)
         ])
 
-testFailedDecoding :: Test
 testFailedDecoding = testGroup "failedDecoding"
     [ deserializeFails "different types" (def & a .~ fromString "foo")
     , deserializeFrom "unknown tag" (Just (def :: Raw))

--- a/proto-lens-tests/tests/repeated_test.hs
+++ b/proto-lens-tests/tests/repeated_test.hs
@@ -12,7 +12,7 @@ import Test.Framework (testGroup)
 import Data.ProtoLens
 import Lens.Family2 ((&), (.~))
 import Data.ByteString.Builder (byteString)
-import Data.Monoid (mempty, mconcat, (<>))
+import Data.Monoid ((<>))
 
 import Data.ProtoLens.TestUtil
 
@@ -22,15 +22,16 @@ defFoo = def
 defBar :: Bar
 defBar = def
 
+main :: IO ()
 main = testMain
     [ serializeTo "default" defFoo mempty mempty
     , serializeTo "int32"
           (defFoo & a .~ [1..3])
-          (vcat $ map (keyed "a") [1..3])
+          (vcat $ map (keyedInt "a") [1..3])
           $ mconcat [tagged 1 $ VarInt x | x <- [1..3]]
     , serializeTo "string"
           (defFoo & b .~ ["one", "two", "three"])
-          (vcat $ map (keyed "b") ["one", "two", "three"])
+          (vcat $ map (keyedStr "b") ["one", "two", "three"])
           $ mconcat [ tagged 2 $ Lengthy $ byteString x
                     | x <- ["one", "two", "three"]
                     ]
@@ -40,16 +41,16 @@ main = testMain
           $ tagged 3 (Lengthy mempty) <> tagged 3 (Lengthy mempty)
     , serializeTo "nested/fixed32"
           (defFoo & c .~ [defBar & d .~ [1..3]])
-          (braced "c" $ vcat $ map (keyed "d") [1..3])
+          (braced "c" $ vcat $ map (keyedInt "d") [1..3])
           $ tagged 3 $ Lengthy $ mconcat [tagged 3 $ Fixed32 x | x <- [1..3]]
     , serializeTo "nested/fixed64"
           (defFoo & c .~ [defBar & e .~ [1..3]])
-          (braced "c" $ vcat $ map (keyed "e") [1..3])
+          (braced "c" $ vcat $ map (keyedInt "e") [1..3])
           $ tagged 3 $ Lengthy $ mconcat [tagged 4 $ Fixed64 x | x <- [1..3]]
     , serializeTo "nested/repeated"
           (defFoo & c .~ [defBar & d .~ [1..3], defBar & e .~ [1..3]])
-          (braced "c" (vcat $ map (keyed "d") [1..3])
-              $+$ braced "c" (vcat $ map (keyed "e") [1..3]))
+          (braced "c" (vcat $ map (keyedInt "d") [1..3])
+              $+$ braced "c" (vcat $ map (keyedInt "e") [1..3]))
           $ tagged 3 (Lengthy $ mconcat [tagged 3 $ Fixed32 x | x <- [1..3]])
           <> tagged 3 (Lengthy $ mconcat [tagged 4 $ Fixed64 x | x <- [1..3]])
     -- Test that if the same nested tag appears twice, we append the lists

--- a/proto-lens-tests/tests/required_test.hs
+++ b/proto-lens-tests/tests/required_test.hs
@@ -8,7 +8,7 @@
 module Main where
 
 import Data.Default.Class (def)
-import Data.Monoid (mempty, (<>))
+import Data.Monoid ((<>))
 import Lens.Family ((&), (.~))
 import Proto.Required (Foo, a, b)
 import Test.Framework (testGroup)
@@ -21,12 +21,15 @@ defFoo = def
 failedFoo :: Maybe Foo
 failedFoo = Nothing
 
+main :: IO ()
 main = testMain
     [ empty
     , onlyRequired
     , onlyOptional
     , both
     ]
+
+empty, onlyRequired, onlyOptional, both :: Test
 
 empty = testGroup "empty"
     [ deserializeFrom "wire" failedFoo mempty

--- a/proto-lens-tests/tests/text_format_test.hs
+++ b/proto-lens-tests/tests/text_format_test.hs
@@ -11,7 +11,6 @@ import qualified Data.ByteString
 import Data.Char (ord)
 import Data.Monoid ((<>))
 import qualified Data.Text.Lazy
-import Data.Word (Word8)
 import Data.ProtoLens (
     def, Message, showMessage, showMessageShort, pprintMessage)
 import Lens.Family2 ((&), (.~))
@@ -34,6 +33,7 @@ failed1 = Nothing
 showMessageWithLineLength :: Message a => Int -> a -> String
 showMessageWithLineLength n = renderStyle style {lineLength=n} . pprintMessage
 
+main :: IO ()
 main = testMain
     [ readFrom "spaces" (Just $ def1 & a .~ 5) "  a: \n5  "
     , readFrom "string concat" (Just $ def1 & b .~ "abcdef")

--- a/proto-lens/proto-lens.cabal
+++ b/proto-lens/proto-lens.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens
-version:             0.2.0.0
+version:             0.2.0.1
 synopsis:            A lens-based implementation of protocol buffers in Haskell.
 description:
   The proto-lens library provides to protocol buffers using modern

--- a/proto-lens/src/Data/ProtoLens/Encoding.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding.hs
@@ -24,8 +24,8 @@ import Data.ProtoLens.Message
 import Data.ProtoLens.Encoding.Bytes
 import Data.ProtoLens.Encoding.Wire
 
-import Control.Applicative ((<|>), (<$>))
-import Control.Monad (foldM, guard, join)
+import Control.Applicative ((<|>))
+import Control.Monad (guard)
 import Data.Attoparsec.ByteString as Parse
 import Data.Bool (bool)
 import Data.Text.Encoding (encodeUtf8, decodeUtf8')
@@ -34,10 +34,7 @@ import qualified Data.ByteString as B
 import qualified Data.Map.Strict as Map
 import Data.ByteString.Lazy.Builder as Builder
 import qualified Data.ByteString.Lazy as L
-import Data.Monoid (mconcat, mempty)
-import Data.Foldable (foldMap, toList, foldl')
 import Lens.Family2 (set, over, (^.), (&))
-import Data.Functor.Identity (Identity(..))
 
 -- TODO: We could be more incremental when parsing/encoding length-based fields,
 -- rather than forcing the whole thing.  E.g., for encoding we're doing extra

--- a/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
@@ -24,11 +24,8 @@ module Data.ProtoLens.Encoding.Wire(
 import Data.Attoparsec.ByteString as Parse
 import Data.Bits
 import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
 import Data.ByteString.Lazy.Builder as Builder
-import Data.Foldable (foldMap)
-import Data.Monoid ((<>), mempty)
-import Data.Void (Void)
+import Data.Monoid ((<>))
 import Data.Word
 
 import Data.ProtoLens.Encoding.Bytes
@@ -72,8 +69,8 @@ getWireValue VarInt _ = getVarInt
 getWireValue Fixed64 _ = anyBits
 getWireValue Fixed32 _ = anyBits
 getWireValue Lengthy _ = getVarInt >>= Parse.take . fromIntegral
-getWireValue StartGroup tag = return ()
-getWireValue EndGroup tag = return ()
+getWireValue StartGroup _ = return ()
+getWireValue EndGroup _ = return ()
 
 putWireValue :: WireType a -> a -> Builder
 putWireValue VarInt n = putVarInt n

--- a/proto-lens/src/Data/ProtoLens/Message/Enum.hs
+++ b/proto-lens/src/Data/ProtoLens/Message/Enum.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 -- | This internal module provides functions used to define the various
 -- @enumFrom*@ functions of 'Enum'.
 --
@@ -69,7 +70,7 @@ messageEnumFromThen start step = case comparing fromEnum start step of
     EQ -> repeat start
     GT -> messageEnumFromThenTo start step minBound
 
-messageEnumFromThenTo :: Enum a => a -> a -> a -> [a]
+messageEnumFromThenTo :: forall a . Enum a => a -> a -> a -> [a]
 messageEnumFromThenTo start step stop = case comparing fromEnum start step of
     LT -> helper succ GT
     EQ -> if stopInt >= stepInt then repeat start else []
@@ -90,6 +91,7 @@ messageEnumFromThenTo start step stop = case comparing fromEnum start step of
             | stopInt == fromEnum a = Nothing
             | otherwise = jump (n-1) $ iter a
         unfoldIter a = (a, jump skipCount a)
+        countSkips :: Integer -> a -> Integer
         countSkips n start'
             | stepInt == fromEnum start' = n
             | otherwise = countSkips (n+1) $ iter start'

--- a/proto-lens/src/Data/ProtoLens/TextFormat.hs
+++ b/proto-lens/src/Data/ProtoLens/TextFormat.hs
@@ -18,7 +18,6 @@ module Data.ProtoLens.TextFormat(
     ) where
 
 import Lens.Family2 ((&),(^.),(.~), set, over)
-import Control.Applicative ((<$>))
 import Control.Arrow (left)
 import qualified Data.ByteString
 import Data.Char (isPrint, isAscii, chr)

--- a/proto-lens/src/Data/ProtoLens/TextFormat/Parser.hs
+++ b/proto-lens/src/Data/ProtoLens/TextFormat/Parser.hs
@@ -19,7 +19,6 @@ import Data.Char (ord)
 import Data.Functor.Identity (Identity)
 import Data.List (intercalate)
 import Data.Maybe (catMaybes)
-import Data.Monoid (mconcat)
 import Data.Text.Lazy (Text)
 import Data.Word (Word8)
 import Numeric (readOct, readHex)
@@ -28,7 +27,7 @@ import Text.Parsec.Char
 import Text.Parsec.Text.Lazy (Parser)
 import Text.Parsec.Combinator (choice, eof, many1, optionMaybe, sepBy1)
 import Text.Parsec.Token hiding (octal)
-import Control.Applicative ((<*), (<|>), (*>), many)
+import Control.Applicative ((<|>), many)
 import Control.Monad (liftM, liftM2, mzero)
 
 -- | A 'TokenParser' for the protobuf text format.


### PR DESCRIPTION
- Turn on -Wall -Werror in the Travis build using stack.
- Fix all the various warnings.
    - In particular: change the test utility "keyed" to take explicit Docs
      instead of arbitrary (Show a => a), since the latter leads to
      -Wtype-defaults warnings.
- Bump proto-lens, proto-lens-protoc and proto-lens-descriptors to 0.2.0.1.
- Bump lens-labels to 0.1.0.1.