### PR TITLE
Allow .proto files to import between Haskell packages.

### DIFF
--- a/proto-lens-protobuf-types/LICENSE
+++ b/proto-lens-protobuf-types/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2016, Google Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Google Inc. nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/proto-lens-protobuf-types/Setup.hs
+++ b/proto-lens-protobuf-types/Setup.hs
@@ -1,0 +1,3 @@
+import Data.ProtoLens.Setup
+
+main = defaultMainGeneratingProtos "proto-src"

--- a/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
+++ b/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
@@ -1,0 +1,27 @@
+name:                proto-lens-protobuf-types
+version:             0.2.0.1
+synopsis:            Basic protocol buffer message types.
+description:
+    This package provides bindings standard protocol message types,
+    for use with the proto-lens library.
+
+homepage:            https://github.com/google/proto-lens
+license:             BSD3
+license-file:        LICENSE
+author:              Judah Jacobson
+maintainer:          proto-lens@googlegroups.com
+copyright:           Google Inc.
+category:            Data
+build-type:          Custom
+cabal-version:       >=1.8
+extra-source-files:
+    proto-src/google/protobuf/any.proto
+    proto-src/google/protobuf/duration.proto
+    proto-src/google/protobuf/wrappers.proto
+
+library
+  exposed-modules:     Proto.Google.Protobuf.Any
+                       Proto.Google.Protobuf.Duration
+                       Proto.Google.Protobuf.Wrappers
+  build-depends: base >= 4.8 && < 4.10
+                , proto-lens-protoc

--- a/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
+++ b/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
@@ -23,5 +23,4 @@ library
   exposed-modules:     Proto.Google.Protobuf.Any
                        Proto.Google.Protobuf.Duration
                        Proto.Google.Protobuf.Wrappers
-  build-depends: base >= 4.8 && < 4.10
-                , proto-lens-protoc
+  build-depends: proto-lens-protoc == 0.2.*

--- a/proto-lens-protobuf-types/proto-src
+++ b/proto-lens-protobuf-types/proto-src
@@ -1,0 +1,1 @@
+../google/protobuf/src/

--- a/proto-lens-protoc/src/Data/ProtoLens/Setup.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Setup.hs
@@ -19,6 +19,7 @@ module Data.ProtoLens.Setup
     , defaultMainGeneratingSpecificProtos
     , generatingProtos
     , generatingSpecificProtos
+    , generateProtosWithImports
     , generateProtos
     ) where
 
@@ -26,6 +27,8 @@ module Data.ProtoLens.Setup
 import Data.Functor ((<$>))
 #endif
 
+import Control.Monad (filterM, forM_, when)
+import qualified Distribution.InstalledPackageInfo as InstalledPackageInfo
 import Distribution.PackageDescription
     ( PackageDescription(..)
     , benchmarkBuildInfo
@@ -36,8 +39,19 @@ import Distribution.PackageDescription
     , testBuildInfo
     )
 import Distribution.Simple.BuildPaths (autogenModulesDir)
-import Distribution.Simple.LocalBuildInfo (LocalBuildInfo)
-import Distribution.Simple.Utils (matchFileGlob)
+import Distribution.Simple.InstallDirs (datadir)
+import Distribution.Simple.LocalBuildInfo
+    ( LocalBuildInfo(..)
+    , absoluteInstallDirs
+    , componentPackageDeps
+    )
+import Distribution.Simple.PackageIndex (lookupSourcePackageId)
+import Distribution.Simple.Setup (fromFlag, copyDest, copyVerbosity)
+import Distribution.Simple.Utils
+    ( createDirectoryIfMissingVerbose
+    , installOrdinaryFile
+    , matchFileGlob
+    )
 import Distribution.Simple
     ( defaultMainWithHooks
     , simpleUserHooks
@@ -49,9 +63,16 @@ import System.FilePath
     , isRelative
     , makeRelative
     , takeExtension
+    , takeDirectory
     )
-import System.Directory (createDirectoryIfMissing, findExecutable)
+import System.Directory
+    ( createDirectoryIfMissing
+    , doesDirectoryExist
+    , findExecutable
+    , removeDirectoryRecursive
+    )
 import System.Process (callProcess)
+import Distribution.Verbosity (Verbosity)
 
 -- | This behaves the same as 'Distribution.Simple.defaultMain', but
 -- auto-generates Haskell files from the .proto files listed in
@@ -123,21 +144,67 @@ generatingSpecificProtos
     -- provided root directory.
     -> UserHooks -> UserHooks
 generatingSpecificProtos root getProtos hooks = hooks
-    { buildHook = \p l h f -> generateSources p l >> buildHook hooks p l h f
-    , haddockHook = \p l h f -> generateSources p l >> haddockHook hooks p l h f
-    , replHook = \p l h f args -> generateSources p l
-                                        >> replHook hooks p l h f args
+    { buildHook = \p l h f -> generate p l >> buildHook hooks p l h f
+    , haddockHook = \p l h f -> generate p l >> haddockHook hooks p l h f
+    , replHook = \p l h f args -> generate p l >> replHook hooks p l h f args
     , sDistHook = \p maybe_l h f -> case maybe_l of
             Nothing -> error "Can't run protoc; run 'cabal configure' first."
             Just l -> do
-                        generateSources p l
+                        generate p l
                         sDistHook hooks (fudgePackageDesc l p) maybe_l h f
+    , postCopy = \a flags pkg lbi -> do
+                  let verb = fromFlag $ copyVerbosity flags
+                  let destDir = datadir (absoluteInstallDirs pkg lbi
+                                             $ fromFlag $ copyDest flags)
+                              </> protoLensImportsPrefix
+                  getProtos pkg >>= copyProtosToDataDir verb root destDir
+                  postCopy hooks a flags pkg lbi
     }
   where
-    generateSources p l = do
-        -- Applying 'root </>' does nothing if the path is already absolute.
-        files <- map (root </>) <$> getProtos p
-        generateProtos root (autogenModulesDir l) files
+    generate p l = getProtos p >>= generateSources root l
+
+-- | Generate Haskell source files for the given input .proto files.
+generateSources :: FilePath -- ^ The root directory
+                -> LocalBuildInfo
+                -> [FilePath] -- ^ Proto files relative to the root directory.
+                -> IO ()
+generateSources root l files = do
+    -- Collect import paths from build-depends of this package.
+    importDirs <- filterM doesDirectoryExist
+                     [ InstalledPackageInfo.dataDir info </> protoLensImportsPrefix
+                     | (_, c, _) <- componentsConfigs l
+                     , (_, i ) <- componentPackageDeps c
+                     , info <- lookupSourcePackageId (installedPkgs l) i
+                     ]
+    generateProtosWithImports (root : importDirs) (autogenModulesDir l)
+                              -- Applying 'root </>' does nothing if the path is already
+                              -- absolute.
+                              (map (root </>) files)
+
+-- | Copy each .proto file into the installed "data-dir" path,
+-- so that it can be included by other packages that depend on this one.
+copyProtosToDataDir :: Verbosity
+                    -> FilePath -- ^ The root for source .proto files in this
+                                -- package.
+                    -> FilePath -- ^ The final location where .proto files should
+                                -- be installed.
+                    -> [FilePath] -- ^ .proto files relative to the root
+                    -> IO ()
+copyProtosToDataDir verb root destDir files = do
+    -- Make the build more hermetic by clearing the output
+    -- directory.
+    exists <- doesDirectoryExist destDir
+    when exists $ removeDirectoryRecursive destDir
+    forM_ files $ \f -> do
+        let srcFile = root </> f
+        let destFile = destDir </> f
+        createDirectoryIfMissingVerbose verb True
+            (takeDirectory destFile)
+        installOrdinaryFile verb srcFile destFile
+
+-- | Imports are stored as $datadir/proto-lens-imports/**/*.proto.
+protoLensImportsPrefix :: FilePath
+protoLensImportsPrefix = "proto-lens-imports"
 
 -- | Add the autogen directory to the hs-source-dirs of all the targets in the
 -- .cabal file.  Used to fool 'sdist' by pointing it to the generated source
@@ -181,7 +248,21 @@ generateProtos
     -> FilePath -- ^ The output directory for the generated Haskell files.
     -> [FilePath] -- ^ The .proto files to process.
     -> IO ()
-generateProtos root output files = do
+generateProtos root = generateProtosWithImports [root]
+--
+-- | Run the proto compiler to generate Haskell files from the given .proto files.
+--
+-- Writes the generated files to the autogen directory (@dist\/build\/autogen@
+-- for Cabal, and @.stack-work\/dist\/...\/build\/autogen@ for stack).
+--
+-- Throws an exception if the @proto-lens-protoc@ executable is not on the PATH.
+generateProtosWithImports
+    :: [FilePath] -- ^ Directories under which .proto files and/or files that
+                  -- they import can be found.
+    -> FilePath -- ^ The output directory for the generated Haskell files.
+    -> [FilePath] -- ^ The .proto files to process.
+    -> IO ()
+generateProtosWithImports imports output files = do
     maybeProtoLensProtoc <- findExecutable "proto-lens-protoc"
     case maybeProtoLensProtoc of
         Nothing -> error "Couldn't find executable proto-lens-protoc."
@@ -190,6 +271,6 @@ generateProtos root output files = do
             callProcess "protoc" $
                 [ "--plugin=protoc-gen-haskell=" ++ protoLensProtoc
                 , "--haskell_out=" ++ output
-                , "--proto_path=" ++ root
                 ]
+                ++ ["--proto_path=" ++ p | p <- imports]
                 ++ files

--- a/proto-lens-protoc/src/Data/ProtoLens/Setup.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Setup.hs
@@ -57,6 +57,7 @@ import Distribution.Simple
     , simpleUserHooks
     , UserHooks(..)
     )
+import Distribution.Verbosity (Verbosity)
 import System.FilePath
     ( (</>)
     , equalFilePath
@@ -72,7 +73,6 @@ import System.Directory
     , removeDirectoryRecursive
     )
 import System.Process (callProcess)
-import Distribution.Verbosity (Verbosity)
 
 -- | This behaves the same as 'Distribution.Simple.defaultMain', but
 -- auto-generates Haskell files from the .proto files listed in
@@ -173,7 +173,7 @@ generateSources root l files = do
     importDirs <- filterM doesDirectoryExist
                      [ InstalledPackageInfo.dataDir info </> protoLensImportsPrefix
                      | (_, c, _) <- componentsConfigs l
-                     , (_, i ) <- componentPackageDeps c
+                     , (_, i) <- componentPackageDeps c
                      , info <- lookupSourcePackageId (installedPkgs l) i
                      ]
     generateProtosWithImports (root : importDirs) (autogenModulesDir l)

--- a/proto-lens-tests-dep/LICENSE
+++ b/proto-lens-tests-dep/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2016, Google Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Google Inc. nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/proto-lens-tests-dep/Setup.hs
+++ b/proto-lens-tests-dep/Setup.hs
@@ -1,0 +1,3 @@
+import Data.ProtoLens.Setup
+
+main = defaultMainGeneratingProtos "protos"

--- a/proto-lens-tests-dep/proto-lens-tests-dep.cabal
+++ b/proto-lens-tests-dep/proto-lens-tests-dep.cabal
@@ -1,0 +1,26 @@
+name:                proto-lens-tests-dep
+version:             0.1.0.1
+synopsis:            Test package dependency.
+description:
+    This package exports a .proto file which is used by proto-lens-tests
+    to test interpackage dependencies.
+    .
+    NOTE: The test needs a new package with its own .proto files,
+    rather than using the ones in proto-lens-protobuf-types
+    (google/protobuf/*.proto), since on some systems protoc has special logic
+    and can resolve imports of those files automatically.
+homepage:            https://github.com/google/proto-lens
+license:             BSD3
+license-file:        LICENSE
+author:              Judah Jacobson
+maintainer:          proto-lens@googlegroups.com
+copyright:           Google Inc.
+category:            Data
+build-type:          Custom
+cabal-version:       >=1.10
+extra-source-files: protos/test-dep/foo.proto
+
+library
+  exposed-modules:     Proto.TestDep.Foo
+  default-language: Haskell2010
+  build-depends: proto-lens-protoc, base

--- a/proto-lens-tests-dep/protos/test-dep/foo.proto
+++ b/proto-lens-tests-dep/protos/test-dep/foo.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package test_dep;
+
+message Foo {
+  int64 value = 1;
+}

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -21,6 +21,12 @@ library
   build-depends: proto-lens-arbitrary == 0.1.*
                , proto-lens == 0.2.*
                , proto-lens-protoc == 0.2.*
+               -- TODO: this is necessary to list explicitly here since when
+               -- --enable-tests is off, Cabal won't see the test-suite
+               -- `package-deps_test` that lists it, but we'll still try to
+               -- compile tests/package-deps.proto (since it's listed in
+               -- extra-source-files regardless).
+               , proto-lens-tests-dep
                , base >= 4.8 && < 4.10
                , bytestring == 0.10.*
                , text == 1.2.*
@@ -246,6 +252,21 @@ Test-Suite labels_test
                , lens-family
                , lens-family-core
                , proto-lens
+               , proto-lens-protoc
+               , proto-lens-tests
+               , test-framework-hunit
+
+Test-Suite package-deps_test
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  main-is: package-deps_test.hs
+  hs-source-dirs: tests
+  other-modules: Proto.PackageDeps
+  build-depends: base
+               , HUnit
+               , lens-family
+               , proto-lens
+               , proto-lens-tests-dep
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework-hunit

--- a/proto-lens-tests/tests/package-deps.proto
+++ b/proto-lens-tests/tests/package-deps.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+import "test-dep/foo.proto";
+
+package protobuf_types;
+
+message Bar {
+  test_dep.Foo foo = 1;
+}

--- a/proto-lens-tests/tests/package-deps_test.hs
+++ b/proto-lens-tests/tests/package-deps_test.hs
@@ -1,0 +1,17 @@
+module Main where
+
+import Data.ProtoLens (def)
+import Lens.Family2 ((&), (.~), (^.))
+import Test.Framework.Providers.HUnit (testCase)
+import Test.HUnit ((@=?))
+
+import Data.ProtoLens.TestUtil (Test, testMain)
+import Proto.PackageDeps (Bar, foo)
+import Proto.TestDep.Foo (value)
+
+main :: IO ()
+main = testMain [testWrapper]
+
+testWrapper :: Test
+testWrapper = testCase "testWrapper" $
+    42 @=? (def & foo . value .~ 42 :: Bar) ^. foo . value

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,9 +4,11 @@ packages:
 - proto-lens
 - proto-lens-descriptors
 - proto-lens-protoc
+- proto-lens-protobuf-types
 - proto-lens-arbitrary
 - proto-lens-combinators
 - proto-lens-optparse
+- proto-lens-tests-dep
 - proto-lens-tests
 - proto-lens-benchmarks
 

--- a/travis-cabal.sh
+++ b/travis-cabal.sh
@@ -11,9 +11,11 @@ PACKAGES="
     proto-lens
     proto-lens-descriptors
     proto-lens-protoc
+    proto-lens-protobuf-types
     proto-lens-arbitrary
     proto-lens-combinators
     proto-lens-optparse
+    proto-lens-tests-dep
     proto-lens-tests
     proto-lens-benchmarks
 "


### PR DESCRIPTION
Also adds the `proto-lens-protobuf-types` package which includes
`Proto.Google.Protobuf.{Any,Duration,Wrappers}`.

This change allows one Haskell package to generate bindings for `foo.proto`,
and another package to generate bindings for `bar.proto`, where
`bar.proto` imports `foo.proto`.

Under the hood, each package copies its `.proto` files into
`$datadir/proto-lens-imports`, so that other packages can find
and use them when compiling their own `.proto` files.

Note: a minor corner case is not handled correctly: if a test or
benchmark requires va .proto that imports from another package,
the *library* also needs to specify that dependency.  See
`proto-lens-tests.cabal` for more details.