### PR TITLE
Include `base`'s modules in the reexport list.

### DIFF
--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -55,7 +55,10 @@ library
         -- For forwards compatibility, reexport them as new module names so that
         -- other packages don't accidentally write non-generated code that
         -- relies on these modules being reexported by proto-lens-protoc.
-          Data.ByteString as Data.ProtoLens.Reexport.Data.ByteString
+          Prelude as Data.ProtoLens.Reexport.Prelude
+        , Data.Int as Data.ProtoLens.Reexport.Data.Int
+        , Data.Word as Data.ProtoLens.Reexport.Data.Word
+        , Data.ByteString as Data.ProtoLens.Reexport.Data.ByteString
         , Data.Default.Class as Data.ProtoLens.Reexport.Data.Default.Class
         , Data.Map as Data.ProtoLens.Reexport.Data.Map
         , Data.ProtoLens as Data.ProtoLens.Reexport.Data.ProtoLens

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -79,20 +79,18 @@ generateModule modName imports syntaxType modifyImport definitions importedEnv
               ["ScopedTypeVariables", "DataKinds", "TypeFamilies",
                "UndecidableInstances",
                "MultiParamTypeClasses", "FlexibleContexts", "FlexibleInstances",
-               "PatternSynonyms", "MagicHash"]
+               "PatternSynonyms", "MagicHash", "NoImplicitPrelude"]
               -- Allow unused imports in case we don't import anything from
               -- Data.Text, Data.Int, etc.
           , optionsGhcPragma "-fno-warn-unused-imports"
           ]
-          (map importSimple
-              -- Note: we import Prelude explicitly to make it qualified.
-              [ "Prelude", "Data.Int", "Data.Word"]
-            ++ map (modifyImport . importSimple)
-                [ "Data.ProtoLens", "Data.ProtoLens.Message.Enum"
-                , "Lens.Family2", "Lens.Family2.Unchecked", "Data.Default.Class"
-                , "Data.Text",  "Data.Map" , "Data.ByteString"
-                , "Lens.Labels"
-                ]
+          (map (modifyImport . importSimple)
+              [ "Prelude", "Data.Int", "Data.Word"
+              , "Data.ProtoLens", "Data.ProtoLens.Message.Enum"
+              , "Lens.Family2", "Lens.Family2.Unchecked", "Data.Default.Class"
+              , "Data.Text",  "Data.Map" , "Data.ByteString"
+              , "Lens.Labels"
+              ]
             ++ map importSimple imports)
           (concatMap generateDecls (Map.elems definitions)
            ++ concatMap generateFieldDecls allFieldNames)


### PR DESCRIPTION
This makes their treatment a little more consistent with other modules,
and allows `proto-lens-protoc` to be self-sufficient as a build-depends
(for example, in proto-only packages such as `proto-lens-protobuf-types`).