### PR TITLE
Sum types for oneof fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ will generate the haskell files `Proto/Project/{Foo,Bar}.hs`.
 # Current differences from the standard
 
 - Services are not supported.
-- `oneof` fields are treated the same as `optional` fields.
 - Extensions (proto2-only) are not supported.  `Any` messages (the proto3
   equivalent) can be used, but don't have any custom API support like in the C++
   libraries.

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
@@ -54,7 +54,9 @@ equalP = Syntax.EqualP ()
 type ConDecl = Syntax.ConDecl ()
 
 conDecl :: Name -> [Type] -> ConDecl
-conDecl = Syntax.ConDecl ()
+conDecl constructorName paramTypes
+    = Syntax.ConDecl () constructorName $
+        fmap tyBang paramTypes
 
 recDecl :: Name -> [(Name, Type)] -> ConDecl
 recDecl dataName fields
@@ -102,6 +104,14 @@ type Exp = Syntax.Exp ()
 
 let' :: [Decl] -> Exp -> Exp
 let' ds e = Syntax.Let () (Syntax.BDecls () ds) e
+
+type Alt = Syntax.Alt ()
+
+case' :: Exp -> [Alt] -> Exp
+case' = Syntax.Case ()
+
+alt :: Pat -> Exp -> Alt
+alt p e = Syntax.Alt () p (Syntax.UnGuardedRhs () e) Nothing
 
 stringExp :: String -> Exp
 stringExp = Syntax.Lit () . string

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -12,6 +12,8 @@ module Data.ProtoLens.Compiler.Definitions
     ( Env
     , Definition(..)
     , MessageInfo(..)
+    , OneofInfo(..)
+    , OneofFieldInfo(..)
     , FieldInfo(..)
     , EnumInfo(..)
     , EnumValueInfo(..)
@@ -25,7 +27,7 @@ import Data.Char (isUpper, toUpper)
 import Data.Int (Int32)
 import Data.List (mapAccumL)
 import qualified Data.Map as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe, isJust, isNothing)
 import Data.Monoid
 import qualified Data.Set as Set
 import Data.String (fromString)
@@ -40,10 +42,13 @@ import Proto.Google.Protobuf.Descriptor
     , FileDescriptorProto
     , enumType
     , field
+    , maybe'oneofIndex
     , messageType
     , name
     , nestedType
     , number
+    , oneofDecl
+    , oneofIndex
     , package
     , typeName
     , value
@@ -76,6 +81,7 @@ data MessageInfo n = MessageInfo
     , messageDescriptor :: DescriptorProto
     , messageFields :: [FieldInfo]
       -- ^ The Haskell names for each field.
+    , messageOneofFields :: [OneofInfo]
       -- This list corresponds 1-1 with "field" in messageDescriptor.
     } deriving Functor
 
@@ -88,6 +94,18 @@ data FieldInfo = FieldInfo
       -- ^ The Haskell name of this internal record field.  Unique within each
       -- module.
     , fieldDescriptor :: FieldDescriptorProto
+    , oneofFieldInfo :: Maybe OneofFieldInfo
+    }
+
+data OneofInfo = OneofInfo
+    { oneofTypeName :: String
+    , oneofRecordFieldName :: Name
+    , oneofFieldInfos :: [FieldInfo]
+    }
+
+data OneofFieldInfo = OneofFieldInfo
+    { oneofConstructorName :: Name
+    , oneofEnclosingFieldName :: Name
     }
 
 -- | All the information needed to define or use a proto enum type.
@@ -150,25 +168,47 @@ messageDefs protoPrefix hsPrefix d
     = thisDef : subDefs
   where
     protoName = d ^. name
-    hsName = unpack $ capitalize $ d ^. name
+    hsName n = unpack $ capitalize $ n
     thisDef = (protoPrefix <> protoName
               , Message MessageInfo
-                  { messageName = fromString $ hsPrefix ++ hsName
+                  { messageName = fromString $ hsPrefix ++ hsName (d ^. name)
                   , messageDescriptor = d
-                  , messageFields =
-                      [ FieldInfo
-                          { overloadedField = n
-                          , recordFieldName = fromString $ "_" ++ hsPrefix' ++ n
-                          , fieldDescriptor = f
-                          }
-                      | f <- d ^. field
-                      , let n = fieldName (f ^. name)
+                  , messageFields = extractFields (\f -> isNothing(f ^. maybe'oneofIndex))
+                  , messageOneofFields =
+                      [ oneofInfo (o ^. name) i
+                      | (i, o) <- (zip [0..] (d ^. oneofDecl)) -- oneofs
                       ]
                   })
     subDefs = messageAndEnumDefs protoPrefix' hsPrefix'
                   (d ^. nestedType) (d ^. enumType)
     protoPrefix' = protoPrefix <> protoName <> "."
-    hsPrefix' = hsPrefix ++ hsName ++ "'"
+    hsPrefix' = hsPrefix ++ hsName (d ^. name) ++ "'"
+    extractFields p = [ fieldInfo n f
+                      | f <- (d ^. field), p f
+                      , let n = fieldName (f ^. name)
+                      ]
+    recFieldName name = fromString $ "_" ++ hsPrefix' ++ name
+    fieldInfo name descriptor = FieldInfo
+        { overloadedField = name
+        , recordFieldName = recFieldName name
+        , fieldDescriptor = descriptor
+        , oneofFieldInfo = Nothing
+        }
+    oneofInfo name idx =
+        let typename = hsPrefix' ++ hsName name
+            encFieldName = recFieldName $ fieldName name
+        in OneofInfo
+               { oneofTypeName = typename
+               , oneofRecordFieldName = encFieldName
+               , oneofFieldInfos =
+                     [ fieldInfo { oneofFieldInfo = Just $ OneofFieldInfo
+                         { oneofConstructorName = fromString $ typename ++ "'" ++ overloadedField fieldInfo
+                         , oneofEnclosingFieldName = encFieldName
+                         }
+                       }
+                     | fieldInfo <- extractFields (\f -> elem idx (f ^. maybe'oneofIndex))
+                     ]
+               }
 
 -- | Get the name in Haskell of a proto field, taking care of camel casing and
 -- clashes with language keywords.

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -27,7 +27,7 @@ import Data.Char (isUpper, toUpper)
 import Data.Int (Int32)
 import Data.List (mapAccumL)
 import qualified Data.Map as Map
-import Data.Maybe (fromMaybe, isJust, isNothing)
+import Data.Maybe (fromMaybe, isNothing)
 import Data.Monoid
 import qualified Data.Set as Set
 import Data.String (fromString)
@@ -48,7 +48,6 @@ import Proto.Google.Protobuf.Descriptor
     , nestedType
     , number
     , oneofDecl
-    , oneofIndex
     , package
     , typeName
     , value
@@ -187,26 +186,26 @@ messageDefs protoPrefix hsPrefix d
                       | f <- (d ^. field), p f
                       , let n = fieldName (f ^. name)
                       ]
-    recFieldName name = fromString $ "_" ++ hsPrefix' ++ name
-    fieldInfo name descriptor = FieldInfo
-        { overloadedField = name
-        , recordFieldName = recFieldName name
+    recFieldName n = fromString $ "_" ++ hsPrefix' ++ n
+    fieldInfo n descriptor = FieldInfo
+        { overloadedField = n
+        , recordFieldName = recFieldName n
         , fieldDescriptor = descriptor
         , oneofFieldInfo = Nothing
         }
-    oneofInfo name idx =
-        let typename = hsPrefix' ++ hsName name
-            encFieldName = recFieldName $ fieldName name
+    oneofInfo n idx =
+        let typename = hsPrefix' ++ hsName n
+            encFieldName = recFieldName $ fieldName n
         in OneofInfo
                { oneofTypeName = typename
                , oneofRecordFieldName = encFieldName
                , oneofFieldInfos =
-                     [ fieldInfo { oneofFieldInfo = Just $ OneofFieldInfo
-                         { oneofConstructorName = fromString $ typename ++ "'" ++ overloadedField fieldInfo
+                     [ info { oneofFieldInfo = Just $ OneofFieldInfo
+                         { oneofConstructorName = fromString $ typename ++ "'" ++ overloadedField info
                          , oneofEnclosingFieldName = encFieldName
                          }
                        }
-                     | fieldInfo <- extractFields (\f -> elem idx (f ^. maybe'oneofIndex))
+                     | info <- extractFields (\f -> elem idx (f ^. maybe'oneofIndex))
                      ]
                }
 

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -171,7 +171,7 @@ messageDefs protoPrefix hsPrefix d
                                   | (i, o) <- (zip [0..] (d ^. oneofDecl))
                                   , let (fs, oo) = oneofInfo (o ^. name) i
                                   ]
-    allFields = extractFields (\f -> isNothing(f ^. maybe'oneofIndex)) ++ ooFields
+    allFields = extractFields (\f -> isNothing (f ^. maybe'oneofIndex)) ++ ooFields
 
     thisDef = (protoPrefix <> protoName
               , Message MessageInfo

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -588,7 +588,7 @@ oneofFieldAccessor (OneofFieldInfo consName encName) =
                     (pApp "Prelude.Just" [pApp (unQual consName) [pVar "x__val"]])
                     ("Prelude.Just" @@ "x__val")
                 , alt
-                    (pVar "otherwise")
+                    (pVar "_otherwise")
                     (con "Prelude.Nothing")
                 ]
         setter = lambda ["x__", "y__"]

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -85,6 +85,20 @@ Test-Suite map_test
                , proto-lens-tests
                , test-framework
 
+Test-Suite oneof_test
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  main-is: oneof_test.hs
+  hs-source-dirs: tests
+  other-modules: Proto.Oneof
+  build-depends: base
+               , bytestring
+               , lens-family
+               , proto-lens
+               , proto-lens-protoc
+               , proto-lens-tests
+               , test-framework
+
 Test-Suite optional_test
   default-language: Haskell2010
   type: exitcode-stdio-1.0

--- a/proto-lens-tests/tests/oneof.proto
+++ b/proto-lens-tests/tests/oneof.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+
+package oneof_test;
+option java_package = "oneof";
+
+message Foo {
+  oneof bar {
+  	int32 baz = 1;
+  	string bippy = 2;
+  }
+}

--- a/proto-lens-tests/tests/oneof_test.hs
+++ b/proto-lens-tests/tests/oneof_test.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Proto.Oneof
+import Data.ProtoLens
+import Lens.Family2 ((&), (.~))
+import qualified Data.ByteString.Char8 as C
+import Data.ByteString.Builder (Builder, byteString)
+
+import Data.ProtoLens.TestUtil
+
+defFoo :: Foo
+defFoo = def
+
+taggedValue :: String -> Builder
+taggedValue = tagged 2 . Lengthy . byteString . C.pack
+
+
+main :: IO ()
+main = testMain
+    [ serializeTo "default" defFoo "" mempty
+    , serializeTo "to first oneof field"
+        (defFoo & bippy .~ "querty" & baz .~ 42)
+        "baz: 42"
+        (tagged 1 $ VarInt 42)
+    , serializeTo "to second oneof field"
+        (defFoo & baz .~ 42 & bippy .~ "querty")
+        "bippy: \"querty\""
+        (tagged 2 $ Lengthy "querty")
+    -- Check that we can tolerate missing keys and values.
+    , deserializeFrom "from first oneof field"
+        (Just $ defFoo & baz .~ 42)
+        $ tagged 1 $ VarInt $ 42
+    , deserializeFrom "from second oneof field"
+        (Just $ defFoo & bippy .~ "querty")
+        $ tagged 2 $ Lengthy "querty"
+    ]

--- a/proto-lens-tests/tests/proto3.proto
+++ b/proto-lens-tests/tests/proto3.proto
@@ -8,6 +8,7 @@ message Foo {
   oneof bar {
     float c = 3;
     bytes d = 4;
+    Sub s = 8;
   }
 
   message Sub {

--- a/proto-lens-tests/tests/proto3_test.hs
+++ b/proto-lens-tests/tests/proto3_test.hs
@@ -8,7 +8,6 @@
 module Main where
 
 import Data.ProtoLens
-import Data.Int
 import Lens.Family2 ((&), (.~), (^.))
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Builder as Builder
@@ -73,7 +72,7 @@ main = testMain
         , testCase "message" $ do
             Just 42 @=? ((def :: Foo) & s .~ (def :: Foo'Sub) & c .~ 42) ^. maybe'c
             Nothing @=? ((def :: Foo) & s .~ (def :: Foo'Sub) & c .~ 42) ^. maybe's
-            (17 :: Int32) @=? ((def :: Foo) & s .~ ((def :: Foo'Sub) & e .~ 17)) ^. s ^. e
+            17 @=? ((def :: Foo) & s . e .~ 17) ^. s . e
             let val = (def :: Foo'Sub) & e .~ 17
             Just val @=? ((def :: Foo) & s .~ val) ^. maybe's
         ]


### PR DESCRIPTION
This uses an intermediate sum type encoding for `oneof` fields. The generated lenses don't expose the sum type but rather point directly to (`Maybe`) the underlying type.

See (#21).