### PR TITLE
Bump proto-lens-arbitrary to support newer QuickCheck.

### DIFF
--- a/proto-lens-arbitrary/proto-lens-arbitrary.cabal
+++ b/proto-lens-arbitrary/proto-lens-arbitrary.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-arbitrary
-version:             0.1.0.2
+version:             0.1.0.3
 synopsis:            Arbitrary instances for proto-lens.
 description:
   The proto-lens-arbitrary allows generating arbitrary messages for
@@ -24,4 +24,4 @@ library
                 , containers == 0.5.*
                 , text == 1.2.*
                 , lens-family == 1.2.*
-                , QuickCheck >= 2.8 && < 2.10
+                , QuickCheck >= 2.8 && < 2.11


### PR DESCRIPTION
Tested by manually editing `stack.yaml`, specifying the new versions in its `extra-deps`.  All tests passed.