### PR TITLE
Add Data.ProtoLens.Any for storing arbitrary Messages.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v0.2.2.0
+- Add `Data.ProtoLens.Any` for packing/unpacking messages to `Any`.
+- Improve the behavior of oneof fields by generating sum types
+
 ## v0.2.1.0
 - Include `base`'s modules in the reexport list.
 - Use custom-setup in packages that depend on `proto-lens-protoc`.

--- a/proto-lens-descriptors/proto-lens-descriptors.cabal
+++ b/proto-lens-descriptors/proto-lens-descriptors.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-descriptors
-version:             0.2.1.0
+version:             0.2.2.0
 synopsis:            Protocol buffers for describing the definitions of messages.
 description:
     This package provides definitions for the 'proto-lens' package
@@ -28,5 +28,5 @@ library
     , lens-labels == 0.1.*
     -- Specify an exact version of `proto-lens`, since it's tied closely
     -- to the generated code.
-    , proto-lens == 0.2.1.0
+    , proto-lens == 0.2.2.0
     , text == 1.2.*

--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -91,6 +91,7 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                       :: Data.ProtoLens.FieldDescriptor CodeGeneratorRequest
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.compiler.CodeGeneratorRequest")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, fileToGenerate__field_descriptor),
                     (Data.ProtoLens.Tag 2, parameter__field_descriptor),
@@ -152,6 +153,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
                       :: Data.ProtoLens.FieldDescriptor CodeGeneratorResponse
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.compiler.CodeGeneratorResponse")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, error__field_descriptor),
                     (Data.ProtoLens.Tag 15, file__field_descriptor)])
@@ -247,6 +249,8 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
                       :: Data.ProtoLens.FieldDescriptor CodeGeneratorResponse'File
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack
+                   "google.protobuf.compiler.CodeGeneratorResponse.File")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, name__field_descriptor),
                     (Data.ProtoLens.Tag 2, insertionPoint__field_descriptor),

--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor.hs
@@ -206,6 +206,7 @@ instance Data.ProtoLens.Message DescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.DescriptorProto")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, name__field_descriptor),
                     (Data.ProtoLens.Tag 2, field__field_descriptor),
@@ -295,6 +296,7 @@ instance Data.ProtoLens.Message DescriptorProto'ExtensionRange
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto'ExtensionRange
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.DescriptorProto.ExtensionRange")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, start__field_descriptor),
                     (Data.ProtoLens.Tag 2, end__field_descriptor)])
@@ -365,6 +367,7 @@ instance Data.ProtoLens.Message DescriptorProto'ReservedRange where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto'ReservedRange
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.DescriptorProto.ReservedRange")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, start__field_descriptor),
                     (Data.ProtoLens.Tag 2, end__field_descriptor)])
@@ -447,6 +450,7 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor EnumDescriptorProto
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.EnumDescriptorProto")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, name__field_descriptor),
                     (Data.ProtoLens.Tag 2, value__field_descriptor),
@@ -529,6 +533,7 @@ instance Data.ProtoLens.Message EnumOptions where
                       :: Data.ProtoLens.FieldDescriptor EnumOptions
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.EnumOptions")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 2, allowAlias__field_descriptor),
                     (Data.ProtoLens.Tag 3, deprecated__field_descriptor),
@@ -623,6 +628,7 @@ instance Data.ProtoLens.Message EnumValueDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor EnumValueDescriptorProto
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.EnumValueDescriptorProto")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, name__field_descriptor),
                     (Data.ProtoLens.Tag 2, number__field_descriptor),
@@ -683,6 +689,7 @@ instance Data.ProtoLens.Message EnumValueOptions where
                       :: Data.ProtoLens.FieldDescriptor EnumValueOptions
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.EnumValueOptions")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, deprecated__field_descriptor),
                     (Data.ProtoLens.Tag 999, uninterpretedOption__field_descriptor)])
@@ -949,6 +956,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FieldDescriptorProto
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.FieldDescriptorProto")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, name__field_descriptor),
                     (Data.ProtoLens.Tag 3, number__field_descriptor),
@@ -1406,6 +1414,7 @@ instance Data.ProtoLens.Message FieldOptions where
                       :: Data.ProtoLens.FieldDescriptor FieldOptions
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.FieldOptions")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, ctype__field_descriptor),
                     (Data.ProtoLens.Tag 2, packed__field_descriptor),
@@ -1784,6 +1793,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.FileDescriptorProto")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, name__field_descriptor),
                     (Data.ProtoLens.Tag 2, package__field_descriptor),
@@ -1836,6 +1846,7 @@ instance Data.ProtoLens.Message FileDescriptorSet where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorSet
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.FileDescriptorSet")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, file__field_descriptor)])
                 (Data.Map.fromList [("file", file__field_descriptor)])
@@ -2197,6 +2208,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.FileOptions")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, javaPackage__field_descriptor),
                     (Data.ProtoLens.Tag 8, javaOuterClassname__field_descriptor),
@@ -2311,6 +2323,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo where
                       :: Data.ProtoLens.FieldDescriptor GeneratedCodeInfo
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.GeneratedCodeInfo")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, annotation__field_descriptor)])
                 (Data.Map.fromList [("annotation", annotation__field_descriptor)])
@@ -2419,6 +2432,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                       :: Data.ProtoLens.FieldDescriptor GeneratedCodeInfo'Annotation
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.GeneratedCodeInfo.Annotation")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, path__field_descriptor),
                     (Data.ProtoLens.Tag 2, sourceFile__field_descriptor),
@@ -2553,6 +2567,7 @@ instance Data.ProtoLens.Message MessageOptions where
                       :: Data.ProtoLens.FieldDescriptor MessageOptions
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.MessageOptions")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, messageSetWireFormat__field_descriptor),
                     (Data.ProtoLens.Tag 2,
@@ -2729,6 +2744,7 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor MethodDescriptorProto
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.MethodDescriptorProto")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, name__field_descriptor),
                     (Data.ProtoLens.Tag 2, inputType__field_descriptor),
@@ -2794,6 +2810,7 @@ instance Data.ProtoLens.Message MethodOptions where
                       :: Data.ProtoLens.FieldDescriptor MethodOptions
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.MethodOptions")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 33, deprecated__field_descriptor),
                     (Data.ProtoLens.Tag 999, uninterpretedOption__field_descriptor)])
@@ -2836,6 +2853,7 @@ instance Data.ProtoLens.Message OneofDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor OneofDescriptorProto
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.OneofDescriptorProto")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, name__field_descriptor)])
                 (Data.Map.fromList [("name", name__field_descriptor)])
@@ -2917,6 +2935,7 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor ServiceDescriptorProto
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.ServiceDescriptorProto")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, name__field_descriptor),
                     (Data.ProtoLens.Tag 2, method__field_descriptor),
@@ -2976,6 +2995,7 @@ instance Data.ProtoLens.Message ServiceOptions where
                       :: Data.ProtoLens.FieldDescriptor ServiceOptions
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.ServiceOptions")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 33, deprecated__field_descriptor),
                     (Data.ProtoLens.Tag 999, uninterpretedOption__field_descriptor)])
@@ -3008,6 +3028,7 @@ instance Data.ProtoLens.Message SourceCodeInfo where
                       :: Data.ProtoLens.FieldDescriptor SourceCodeInfo
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.SourceCodeInfo")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, location__field_descriptor)])
                 (Data.Map.fromList [("location", location__field_descriptor)])
@@ -3127,6 +3148,7 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                       :: Data.ProtoLens.FieldDescriptor SourceCodeInfo'Location
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.SourceCodeInfo.Location")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, path__field_descriptor),
                     (Data.ProtoLens.Tag 2, span__field_descriptor),
@@ -3317,6 +3339,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                       :: Data.ProtoLens.FieldDescriptor UninterpretedOption
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.UninterpretedOption")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 2, name__field_descriptor),
                     (Data.ProtoLens.Tag 3, identifierValue__field_descriptor),
@@ -3381,6 +3404,7 @@ instance Data.ProtoLens.Message UninterpretedOption'NamePart where
                       :: Data.ProtoLens.FieldDescriptor UninterpretedOption'NamePart
               in
               Data.ProtoLens.MessageDescriptor
+                (Data.Text.pack "google.protobuf.UninterpretedOption.NamePart")
                 (Data.Map.fromList
                    [(Data.ProtoLens.Tag 1, namePart__field_descriptor),
                     (Data.ProtoLens.Tag 2, isExtension__field_descriptor)])

--- a/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
+++ b/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-protobuf-types
-version:             0.2.1.0
+version:             0.2.2.0
 synopsis:            Basic protocol buffer message types.
 description:
     This package provides bindings standard protocol message types,
@@ -25,7 +25,13 @@ custom-setup
                , proto-lens-protoc == 0.2.*
 
 library
-  exposed-modules:     Proto.Google.Protobuf.Any
-                       Proto.Google.Protobuf.Duration
-                       Proto.Google.Protobuf.Wrappers
-  build-depends: proto-lens-protoc == 0.2.*
+  hs-source-dirs:     src
+  exposed-modules:    Data.ProtoLens.Any
+                      Proto.Google.Protobuf.Any
+                      Proto.Google.Protobuf.Duration
+                      Proto.Google.Protobuf.Wrappers
+  build-depends: base >= 4.8 && < 4.10
+               , lens-family
+               , proto-lens >= 0.2.2.0 && < 0.3
+               , proto-lens-protoc == 0.2.*
+               , text == 1.2.*

--- a/proto-lens-protobuf-types/src/Data/ProtoLens/Any.hs
+++ b/proto-lens-protobuf-types/src/Data/ProtoLens/Any.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Data.ProtoLens.Any
+    ( Any
+    , pack
+    , packWithPrefix
+    , unpack
+    , UnpackError(..)
+    ) where
+
+import Control.Exception (Exception(..))
+import Data.Monoid ((<>))
+import Data.Text (Text, breakOnEnd)
+import Data.Typeable (Typeable)
+import Data.ProtoLens
+    ( decodeMessage
+    , def
+    , encodeMessage
+    , Message(..)
+    , MessageDescriptor(..)
+    )
+import Lens.Family2 ((&), (.~), (^.))
+import Proto.Google.Protobuf.Any
+
+-- | Packs the given message into an 'Any' using the default type URL prefix
+-- "type.googleapis.com".
+pack :: forall a . Message a => a -> Any
+pack = packWithPrefix googleApisPrefix
+
+googleApisPrefix :: Text
+googleApisPrefix = "type.googleapis.com"
+
+
+-- | Packs the given message into an 'Any' using the given type URL prefix.
+packWithPrefix :: forall a . Message a => Text -> a -> Any
+packWithPrefix prefix x =
+    def & typeUrl .~ (prefix <> "/" <> name)
+        & value .~ encodeMessage x
+  where
+    name = messageName (descriptor :: MessageDescriptor a)
+
+
+data UnpackError
+    = DifferentType
+        { expectedMessageType :: Text -- ^ The expected @packagename.messagename@
+        , actualUrl :: Text -- ^ The typeUrl in the 'Any' being unpacked
+        }
+    | DecodingError String  -- ^ The error from decodeMessage
+    deriving (Show, Eq, Typeable)
+
+instance Exception UnpackError
+
+-- | Unpacks the given 'Any' into the given message type.  Returns 'Nothing'
+-- if the type doesn't match or parsing the payload has failed.
+--
+-- Ignores the type URL prefix.
+unpack :: forall a . Message a => Any -> Either UnpackError a
+unpack a
+    | expectedName /= snd (breakOnEnd "/" $ a ^. typeUrl)
+        = Left DifferentType
+              { expectedMessageType = expectedName
+              , actualUrl = a ^. typeUrl
+              }
+    | otherwise = case decodeMessage (a ^. value) of
+        Left e -> Left $ DecodingError e
+        Right x -> Right x
+  where
+    expectedName = messageName (descriptor :: MessageDescriptor a)

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-protoc
-version:             0.2.1.0
+version:             0.2.2.0
 synopsis:            Protocol buffer compiler for the proto-lens library.
 description:
   Turn protocol buffer files (.proto) into Haskell files (.hs) which
@@ -47,8 +47,8 @@ library
         , lens-family == 1.2.*
         , lens-labels == 0.1.*
         , process >= 1.2 && < 1.5
-        , proto-lens == 0.2.1.0
-        , proto-lens-descriptors == 0.2.1.0
+        , proto-lens == 0.2.2.0
+        , proto-lens-descriptors == 0.2.2.0
         , text == 1.2.*
     reexported-modules:
         -- Modules that are needed by the generated Haskell files.
@@ -82,8 +82,8 @@ executable proto-lens-protoc
       , lens-family == 1.2.*
       -- Specify an exact version of `proto-lens`, since it's tied closely
       -- to the generated code.
-      , proto-lens == 0.2.1.0
-      , proto-lens-descriptors == 0.2.1.0
+      , proto-lens == 0.2.2.0
+      , proto-lens-descriptors == 0.2.2.0
       , text == 1.2.*
   hs-source-dirs:      src
   other-modules:

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -289,3 +289,22 @@ Test-Suite package-deps_test
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework-hunit
+
+Test-Suite any_test
+  default-language: Haskell2010
+  type: exitcode-stdio-1.0
+  main-is: any_test.hs
+  hs-source-dirs: tests
+  other-modules: Proto.Any
+  build-depends: base
+               , HUnit
+               , lens-family
+               , proto-lens
+               , proto-lens-arbitrary
+               , proto-lens-protobuf-types
+               , proto-lens-protoc
+               , proto-lens-tests
+               , QuickCheck
+               , test-framework
+               , test-framework-hunit
+               , text

--- a/proto-lens-tests/src/Data/ProtoLens/TestUtil.hs
+++ b/proto-lens-tests/src/Data/ProtoLens/TestUtil.hs
@@ -14,6 +14,7 @@ module Data.ProtoLens.TestUtil(
     Data(..),
     tagged,
     varInt,
+    toStrictByteString,
     keyed,
     keyedInt,
     keyedStr,
@@ -34,6 +35,7 @@ module Data.ProtoLens.TestUtil(
 import Data.ProtoLens
 import Data.ProtoLens.Arbitrary
 
+import qualified Data.ByteString as B
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as L
 import qualified Data.Text.Lazy as LT
@@ -164,3 +166,6 @@ braced :: String -> Doc -> Doc
 braced k v = (PrettyPrint.text k <+> char '{')
               $+$ nest 2 v
               $+$ PrettyPrint.char '}'
+
+toStrictByteString :: Builder.Builder -> B.ByteString
+toStrictByteString = L.toStrict . Builder.toLazyByteString

--- a/proto-lens-tests/tests/any.proto
+++ b/proto-lens-tests/tests/any.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package test.any;
+
+message Foo {
+  int32 a = 1;
+  string b = 2;
+}
+
+message Bar {
+  int32 a = 1;
+  string b = 2;
+}

--- a/proto-lens-tests/tests/any_test.hs
+++ b/proto-lens-tests/tests/any_test.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Main (main) where
+
+import Data.ProtoLens
+import Data.ProtoLens.Any
+import Data.ProtoLens.Arbitrary (ArbitraryMessage(..))
+import Proto.Google.Protobuf.Any (typeUrl, value)
+import Lens.Family2 ((&), (.~), (^.))
+import Test.Framework.Providers.HUnit (testCase)
+import Test.HUnit ((@=?))
+import qualified Data.Text as Text
+import Test.QuickCheck ((===), counterexample, listOf, elements)
+
+import Data.ProtoLens.TestUtil
+import Proto.Any
+
+main :: IO ()
+main = testMain
+    [ testCase "pack/unpack" $ do
+          let foo = def & a .~ 42 & b .~ "hello" :: Foo
+          let any1 = pack foo
+          "type.googleapis.com/test.any.Foo" @=? (any1 ^. typeUrl)
+          encodeMessage foo @=? (any1 ^. value)
+          -- Unpacking to the right type succeeds
+          Right foo @=? unpack any1
+          -- Unpacking to the wrong type fails
+          Left DifferentType{} <- return (unpack any1 :: Either UnpackError Bar)
+          -- Unpacking with the wrong package name fails
+          let any2 = any1 & typeUrl .~ "type.googleapis.com/blah.Foo"
+          Left DifferentType{} <- return (unpack any2 :: Either UnpackError Foo)
+          -- Unpacking with invalid byte data fails
+          -- Foo expects a string for field #2
+          let any3 = any1 & value .~ toStrictByteString (tagged 2 (VarInt 42))
+          Left (DecodingError _) <- return (unpack any3 :: Either UnpackError Foo)
+          return ()
+    , testProperty "packWithPrefix/unpack" $ \(ArbitraryMessage (foo :: Foo)) -> do
+          -- Generate a random prefix containing in particular URL separation
+          -- characters.  Make sure that no matter the prefix, "unpack"
+          -- recognizes the message name.
+          prefix <- Text.pack <$> listOf (elements "abc12./")
+          return $ counterexample ("prefix=" ++ show prefix) $
+              Right foo === unpack (packWithPrefix prefix foo)
+    ]

--- a/proto-lens-tests/tests/proto3_test.hs
+++ b/proto-lens-tests/tests/proto3_test.hs
@@ -9,9 +9,7 @@ module Main where
 
 import Data.ProtoLens
 import Lens.Family2 ((&), (.~), (^.))
-import qualified Data.ByteString as B
 import qualified Data.ByteString.Builder as Builder
-import qualified Data.ByteString.Lazy as Lazy
 import Data.Monoid ((<>))
 import Proto.Proto3
     ( Foo
@@ -85,7 +83,7 @@ main = testMain
     ]
   , testGroup "Strings"
     [ deserializeFrom "bytes"
-        (Just $ def & bytes .~ built invalidUtf8 :: Maybe Strings)
+        (Just $ def & bytes .~ toStrictByteString invalidUtf8 :: Maybe Strings)
         $ tagged 1 $ Lengthy invalidUtf8
     , deserializeFrom "string"
         (Nothing :: Maybe Strings)
@@ -110,6 +108,3 @@ main = testMain
 
 invalidUtf8 :: Builder.Builder
 invalidUtf8 = Builder.word8 0xc3 <> Builder.word8 0x28
-
-built :: Builder.Builder -> B.ByteString
-built = Lazy.toStrict . Builder.toLazyByteString

--- a/proto-lens/proto-lens.cabal
+++ b/proto-lens/proto-lens.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens
-version:             0.2.1.0
+version:             0.2.2.0
 synopsis:            A lens-based implementation of protocol buffers in Haskell.
 description:
   The proto-lens library provides to protocol buffers using modern

--- a/proto-lens/src/Data/ProtoLens/Message.hs
+++ b/proto-lens/src/Data/ProtoLens/Message.hs
@@ -51,7 +51,11 @@ class Default msg => Message msg where
 
 -- | The description of a particular protocol buffer message type.
 data MessageDescriptor msg = MessageDescriptor
-    { fieldsByTag :: Map Tag (FieldDescriptor msg)
+    {  messageName :: T.Text
+      -- ^ A unique identifier for this type, of the format
+      -- @"packagename.messagename"@.
+    , fieldsByTag :: Map Tag (FieldDescriptor msg)
+      -- ^ The fields of the proto, indexed by their (integer) tag.
     , fieldsByTextFormatName :: Map String (FieldDescriptor msg)
       -- ^ This map is keyed by the name of the field used for text format protos.
       -- This is just the field name for every field except for group fields,


### PR DESCRIPTION
Fixes #22.

Provides simple `pack` and `unpack` functions.  Since the `unpack` operation
is partial (and has multiple types of "failure"), I wasn't sure how to fit it
into a `Lens`; so I left that alone for the time being.

I turned this into a minor version bump.  It does add a new field to
`MessageDescriptor` which usually requires a major bump; but since that field
is internal to codegen, it shouldn't break any individual users.