### PR TITLE
Add a lens for internal "oneof" sum types.

### DIFF
--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -31,7 +31,7 @@ module Data.ProtoLens.Compiler.Definitions
 
 import Data.Char (isUpper, toUpper)
 import Data.Int (Int32)
-import Data.List (mapAccumL, foldl')
+import Data.List (mapAccumL)
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
 import Data.Monoid

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -12,9 +12,10 @@ module Data.ProtoLens.Compiler.Definitions
     ( Env
     , Definition(..)
     , MessageInfo(..)
-    , OneofInfo(..)
-    , OneofFieldInfo(..)
     , FieldInfo(..)
+    , OneofInfo(..)
+    , OneofCase(..)
+    , FieldName(..)
     , EnumInfo(..)
     , EnumValueInfo(..)
     , qualifyEnv
@@ -25,9 +26,9 @@ module Data.ProtoLens.Compiler.Definitions
 
 import Data.Char (isUpper, toUpper)
 import Data.Int (Int32)
-import Data.List (mapAccumL)
+import Data.List (mapAccumL, foldl')
 import qualified Data.Map as Map
-import Data.Maybe (fromMaybe, isNothing)
+import Data.Maybe (fromMaybe)
 import Data.Monoid
 import qualified Data.Set as Set
 import Data.String (fromString)
@@ -78,32 +79,45 @@ data Definition n = Message (MessageInfo n) | Enum (EnumInfo n)
 data MessageInfo n = MessageInfo
     { messageName :: n  -- ^ Haskell type name
     , messageDescriptor :: DescriptorProto
-    , messageFields :: [FieldInfo]
-      -- ^ The Haskell names for each field.
+    , messageFields :: [FieldInfo] -- ^ Fields not belonging to a oneof.
     , messageOneofFields :: [OneofInfo]
-      -- This list corresponds 1-1 with "field" in messageDescriptor.
+      -- ^ The oneofs in this message, associated with the fields that
+      --   belong to them.
     } deriving Functor
 
 -- | Information about a single field of a proto message.
 data FieldInfo = FieldInfo
-    { overloadedField :: String
-      -- ^ The Haskell overloaded name of this field; may be shared between two
-      -- different message data types.
-    , recordFieldName :: Name
-      -- ^ The Haskell name of this internal record field.  Unique within each
-      -- module.
-    , fieldDescriptor :: FieldDescriptorProto
-    , oneofFieldInfo :: Maybe OneofFieldInfo
+    { fieldDescriptor  :: FieldDescriptorProto
+    , plainFieldName :: FieldName
     }
 
 data OneofInfo = OneofInfo
-    { oneofTypeName :: String
-    , oneofRecordFieldName :: Name
+    { oneofFieldName :: FieldName
+    , oneofTypeName :: Name
+      -- ^ The name of the sum type corresponding to this oneof.
+    , oneofCases :: [OneofCase]
+      -- ^ The individual fields that make up this oneof.
     }
 
-data OneofFieldInfo = OneofFieldInfo
-    { oneofConstructorName :: Name
-    , oneofEnclosingFieldName :: Name
+data OneofCase = OneofCase
+    { caseField :: FieldInfo
+    , caseConstructorName :: Name
+        -- ^ The constructor for building a 'oneofTypeName' from the
+        -- value in this field.
+    }
+
+data FieldName = FieldName
+    { overloadedName :: String
+      -- ^ The overloaded name of lenses that access this field.
+      -- For example, if the field is called "foo_bar" in the .proto
+      -- then @overloadedName == "fooBar"@ and we might generate
+      -- @fooBar@ and/or @maybe'fooBar@ lenses to access the data.
+      --
+      -- May be shared between two different message data types in the same
+      -- module.
+    , haskellRecordFieldName :: Name
+      -- ^ The Haskell name of this internal record field; for example,
+      -- "_Foo'Bar'baz.  Unique within each module.
     }
 
 -- | All the information needed to define or use a proto enum type.
@@ -135,7 +149,7 @@ qualifyEnv m = mapEnv (qual m)
 unqualifyEnv :: Env Name -> Env QName
 unqualifyEnv = mapEnv unQual
 
--- | Look up the type definition for a given field.
+-- | Look up the Haskell name for the type of a given field (message or enum).
 definedFieldType :: FieldDescriptorProto -> Env QName -> Definition QName
 definedFieldType fd env = fromMaybe err $ Map.lookup (fd ^. typeName) env
   where
@@ -163,52 +177,60 @@ messageAndEnumDefs protoPrefix hsPrefix messages enums
 messageDefs :: Text -> String -> DescriptorProto
             -> [(Text, Definition Name)]
 messageDefs protoPrefix hsPrefix d
-    = thisDef : subDefs
+    = (protoName, thisDef)
+          : messageAndEnumDefs
+                (protoName <> ".")
+                hsPrefix'
+                (d ^. nestedType)
+                (d ^. enumType)
   where
-    protoName = d ^. name
-    hsName n = unpack $ capitalize $ n
-    (ooFields, ooInfos) = mconcat [ (fs, [oo])
-                                  | (i, o) <- (zip [0..] (d ^. oneofDecl))
-                                  , let (fs, oo) = oneofInfo (o ^. name) i
-                                  ]
-    allFields = extractFields (\f -> isNothing (f ^. maybe'oneofIndex)) ++ ooFields
-
-    thisDef = (protoPrefix <> protoName
-              , Message MessageInfo
-                  { messageName = fromString $ hsPrefix ++ hsName (d ^. name)
-                  , messageDescriptor = d
-                  , messageFields = allFields
-                  , messageOneofFields = ooInfos
-                  })
-    subDefs = messageAndEnumDefs protoPrefix' hsPrefix'
-                  (d ^. nestedType) (d ^. enumType)
-    protoPrefix' = protoPrefix <> protoName <> "."
+    protoName = protoPrefix <> d ^. name
     hsPrefix' = hsPrefix ++ hsName (d ^. name) ++ "'"
-    extractFields p = [ fieldInfo n f
-                      | f <- (d ^. field), p f
-                      , let n = fieldName (f ^. name)
-                      ]
-    recFieldName n = fromString $ "_" ++ hsPrefix' ++ n
-    fieldInfo n descriptor = FieldInfo
-        { overloadedField = n
-        , recordFieldName = recFieldName n
-        , fieldDescriptor = descriptor
-        , oneofFieldInfo = Nothing
-        }
-    oneofInfo n idx =
-        let typename = hsPrefix' ++ hsName n
-            encFieldName = recFieldName $ fieldName n
-            oneofFields = [ info { oneofFieldInfo = Just $ OneofFieldInfo
-                                    { oneofConstructorName = fromString $ typename ++ "'" ++ overloadedField info
-                                    , oneofEnclosingFieldName = encFieldName
-                                    }
-                                 }
-                          | info <- extractFields (\f -> elem idx (f ^. maybe'oneofIndex))
-                          ]
-        in (oneofFields, OneofInfo
-               { oneofTypeName = typename
-               , oneofRecordFieldName = encFieldName
-               })
+    hsName n = unpack $ capitalize $ n
+    allFields = collectFieldsByOneofIndex (d ^. field)
+    thisDef =
+        Message MessageInfo
+            { messageName = fromString $ hsPrefix ++ hsName (d ^. name)
+            , messageDescriptor = d
+            , messageFields =
+                  map fieldInfo $ Map.findWithDefault [] Nothing allFields
+            , messageOneofFields =
+                  map (uncurry oneofInfo)
+                      $ zip [0..] $ map (^. name) $ d ^. oneofDecl
+            }
+    fieldInfo f = FieldInfo f $ mkFieldName $ f ^. name
+    mkFieldName n = FieldName
+                    { overloadedName = n'
+                    , haskellRecordFieldName = fromString $ "_" ++ hsPrefix' ++ n'
+                    }
+      where
+        n' = fieldName n
+    oneofInfo :: Int32 -> Text -> OneofInfo
+    oneofInfo idx n = OneofInfo
+                        { oneofFieldName = mkFieldName n
+                        , oneofTypeName = fromString $ hsPrefix' ++ hsName n
+                        , oneofCases = map oneofCase
+                                          $ Map.findWithDefault [] (Just idx)
+                                              allFields
+                        }
+    oneofCase f = OneofCase
+                        { caseField = fieldInfo f
+                        , caseConstructorName =
+                              -- Note: oneof case constructors aren't prefixed
+                              -- by the oneof name; field names (even inside
+                              -- of a oneof) are unique within a message.
+                              fromString $ hsPrefix' ++ hsName (f ^. name)
+                        }
+
+
+-- | Group fields by the index of the oneof field that they belong to.
+-- (Or 'Nothing' if they don't belong to a oneof.)
+collectFieldsByOneofIndex
+    :: [FieldDescriptorProto] -> Map.Map (Maybe Int32) [FieldDescriptorProto]
+collectFieldsByOneofIndex =
+    fmap reverse
+    . foldl' (\m f -> Map.insertWith (++) (f ^. maybe'oneofIndex) [f] m)
+           Map.empty
 
 -- | Get the name in Haskell of a proto field, taking care of camel casing and
 -- clashes with language keywords.
@@ -216,7 +238,6 @@ fieldName :: Text -> String
 fieldName = unpack . disambiguate . camelCase
   where
     disambiguate s
-        -- TODO: use a more comprehensive blacklist of Haskell keywords.
         | s `Set.member` reservedKeywords = s <> "'"
         | otherwise = s
 

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -93,17 +93,17 @@ generateModule modName imports syntaxType modifyImport definitions importedEnv
               ]
             ++ map importSimple imports)
           (concatMap generateDecls (Map.toList definitions)
-           ++ concatMap generateFieldDecls allFieldNames)
+           ++ concatMap generateFieldDecls allLensNames)
   where
     env = Map.union (unqualifyEnv definitions) importedEnv
     generateDecls (protoName, Message m)
         = generateMessageDecls syntaxType env (stripDotPrefix protoName) m
     generateDecls (_, Enum e) = generateEnumDecls e
-    allFieldNames = F.toList $ Set.fromList
-        [ fieldSymbol i
+    allLensNames = F.toList $ Set.fromList
+        [ lensSymbol inst
         | Message m <- Map.elems definitions
-        , f <- messageFields m
-        , i <- fieldInstances (lensInfo syntaxType env f)
+        , info <- allMessageFields syntaxType env m
+        , inst <- recordFieldLenses info
         ]
     -- The Env uses the convention that Message names are prefixed with '.'
     -- (since that's how the FileDescriptorProto refers to them).
@@ -111,6 +111,11 @@ generateModule modName imports syntaxType modifyImport definitions importedEnv
     stripDotPrefix s
         | Just ('.', s') <- T.uncons s = s'
         | otherwise = s
+
+allMessageFields :: SyntaxType -> Env QName -> MessageInfo Name -> [RecordField]
+allMessageFields syntaxType env info =
+    map (plainRecordField syntaxType env) (messageFields info)
+        ++ map (oneofRecordField env) (messageOneofFields info)
 
 importSimple :: ModuleName -> ImportDecl ()
 importSimple m = ImportDecl
@@ -140,11 +145,8 @@ generateMessageDecls syntaxType env protoName info =
     -- }
     [ dataDecl dataName
         [recDecl dataName $
-                  [ (recordFieldName f, internalType (lensInfo syntaxType env f))
-                  | f@(FieldInfo _ _ _ Nothing) <- fields
-                  ] ++
-                  [ (ooFieldName, "Prelude.Maybe" @@ (fromString ooTypeName))
-                  | OneofInfo ooTypeName ooFieldName <- oneofFields
+                  [ (recordFieldName f, recordFieldType f)
+                  | f <- allFields
                   ]
         ]
         ["Prelude.Show", "Prelude.Eq"]
@@ -159,15 +161,15 @@ generateMessageDecls syntaxType env protoName info =
     --        }
     -- haskell: data Foo'Bar = Foo'Bar'c !Prelude.Float
     --                       | Foo'Bar's !Sub
-    [ dataDecl (fromString ooTypeName)
-      [ conDecl consName [internalType (lensInfo syntaxType env f)]
-      | f @ (FieldInfo _ _ desc (Just (OneofFieldInfo consName _))) <- fields
-      , elem idx (desc ^. maybe'oneofIndex)
+    [ dataDecl (oneofTypeName oneofInfo)
+      [ conDecl consName [hsFieldType env $ fieldDescriptor f]
+      | c <- oneofCases oneofInfo
+      , let f = caseField c
+      , let consName = caseConstructorName c
       ]
       ["Prelude.Show", "Prelude.Eq"]
-    | (OneofInfo ooTypeName _, idx) <- zip oneofFields [0..]
+    | oneofInfo <- messageOneofFields info
     ] ++
-
 
     -- type instance (Functor f, a ~ Baz, b ~ Baz)
     --     => HasLens "foo" f Bar Bar a b where
@@ -177,11 +179,14 @@ generateMessageDecls syntaxType env protoName info =
     [ instDecl [equalP "a" t, equalP "b" t, classA "Prelude.Functor" ["f"]]
         ("Lens.Labels.HasLens" `ihApp`
             [sym, "f", dataType, dataType, "a", "b"])
-            [[match "lensOf" [pWildCard] $ fieldAccessor i]]
-    | f <- fields
-    , i <- fieldInstances (lensInfo syntaxType env f)
-    , let t = fieldTypeInstance i
-    , let sym = tyPromotedString $ fieldSymbol i
+            [[match "lensOf" [pWildCard] $
+                "Prelude.."
+                    @@ rawFieldAccessor (unQual $ recordFieldName li)
+                    @@ lensExp i]]
+    | li <- allFields
+    , i <- recordFieldLenses li
+    , let t = lensFieldType i
+    , let sym = tyPromotedString $ lensSymbol i
     ]
     ++
     -- instance Data.Default.Class.Default Bar where
@@ -190,12 +195,13 @@ generateMessageDecls syntaxType env protoName info =
         [
             [ match "def" []
                 $ recConstr (unQual dataName) $
-                      [ fieldUpdate (unQual $ recordFieldName f)
+                      [ fieldUpdate (unQual $ haskellRecordFieldName $ plainFieldName f)
                             (hsFieldDefault syntaxType env (fieldDescriptor f))
-                      | f@(FieldInfo _ _ _ Nothing) <- fields
+                      | f <- messageFields info
                       ] ++
-                      [ fieldUpdate (unQual $ fieldName) "Prelude.Nothing"
-                      | OneofInfo _ fieldName <- oneofFields
+                      [ fieldUpdate (unQual $ haskellRecordFieldName $ oneofFieldName o)
+                            "Prelude.Nothing"
+                      | o <- messageOneofFields info
                       ]
             ]
         ]
@@ -205,7 +211,8 @@ generateMessageDecls syntaxType env protoName info =
     ]
   where
     dataType = tyCon $ unQual dataName
-    MessageInfo { messageName = dataName, messageFields = fields, messageOneofFields = oneofFields } = info
+    MessageInfo { messageName = dataName } = info
+    allFields = allMessageFields syntaxType env info
 
 generateEnumDecls :: EnumInfo Name -> [Decl]
 generateEnumDecls info =
@@ -369,103 +376,144 @@ generateFieldDecls xStr =
 
 ------------------------------------------
 
--- | The Haskell types and lenses for an individual field of a message.
--- This is used to generate both the data record Decl and the instances of
--- HasField.
-data LensInfo = LensInfo
-    { internalType :: Type  -- ^ Internal type in the record
-    , fieldInstances :: [FieldInstanceInfo]  -- ^ All instances of Field/HasField
+-- | An individual field of the Haskell type corresponding to a proto message.
+data RecordField = RecordField
+    { recordFieldName :: Name  -- ^ The Haskell name of this field (unique
+                               --   within the module).
+    , recordFieldType :: Type  -- ^ Internal type in the record
+    , recordFieldLenses :: [LensInstance]
+        -- ^ All of the (overloaded) lenses accessing this record field.
     }
 
-data FieldInstanceInfo = FieldInstanceInfo
-    { fieldSymbol :: String      -- ^ The name of the Symbol corresponding to
-                                 --   this field.
-    , fieldTypeInstance :: Type  -- ^ The type instance for Field, i.e.,
-                                 --     type instance Field "foo" Bar = ...
-    , fieldAccessor :: Exp       -- ^ The value of the "field" lens for this
-                                 --   field, i.e.,
-                                 --     field _ = ...
+-- | An instance of HasLens for a particualr field.
+data LensInstance = LensInstance
+    { lensSymbol :: String
+          -- ^ The overloaded name for this lens.
+    , lensFieldType :: Type
+          -- ^ The type pointed to from this lens.
+    , lensExp :: Exp
+        -- ^ A lens from the recordFieldType to the lensFieldType; i.e.,
+        -- from how it's actually stored in the Haskell record to how the
+        -- lens views it.
     }
 
 -- | Compile information about the record field type and type/class instances
 -- for this particular field.
-lensInfo :: SyntaxType -> Env QName -> FieldInfo -> LensInfo
-lensInfo syntaxType env f = case fd ^. label of
+plainRecordField :: SyntaxType -> Env QName -> FieldInfo -> RecordField
+plainRecordField syntaxType env f = case fd ^. label of
     -- data Foo = Foo { _Foo_bar :: Bar }
     -- type instance Field "bar" Foo = Bar
-    FieldDescriptorProto'LABEL_REQUIRED -> LensInfo baseType
-                  [FieldInstanceInfo
-                      { fieldSymbol = baseName
-                      , fieldTypeInstance = baseType
-                      , fieldAccessor = rawAccessor
+    FieldDescriptorProto'LABEL_REQUIRED
+        -> recordField baseType
+                  [LensInstance
+                      { lensSymbol = baseName
+                      , lensFieldType = baseType
+                      , lensExp = rawAccessor
                       }]
     FieldDescriptorProto'LABEL_OPTIONAL
         | isDefaultingOptional syntaxType fd
-              -> LensInfo baseType
-                    [FieldInstanceInfo
-                      { fieldSymbol = baseName
-                      , fieldTypeInstance = baseType
-                      , fieldAccessor = rawAccessor
+              -> recordField baseType
+                    [LensInstance
+                      { lensSymbol = baseName
+                      , lensFieldType = baseType
+                      , lensExp = rawAccessor
                       }]
-        | Just info <- oneofFieldInfo f
-              -> LensInfo baseType
-                    [FieldInstanceInfo
-                      { fieldSymbol = baseName
-                      , fieldTypeInstance = baseType
-                      , fieldAccessor = maybeAccessor
+    -- data Foo = Foo { _Foo_bar :: Maybe Bar }
+    -- type instance Field "bar" Foo = Bar
+    -- type instance Field "maybe'bar" Foo = Maybe Bar
+        | otherwise ->
+              recordField maybeType
+                  [LensInstance
+                      { lensSymbol = baseName
+                      , lensFieldType = baseType
+                      , lensExp = maybeAccessor
                       }
-                    , FieldInstanceInfo
-                      { fieldSymbol = maybeName
-                      , fieldTypeInstance = "Prelude.Maybe" @@ baseType
-                      , fieldAccessor = oneofFieldAccessor info
+                  , LensInstance
+                      { lensSymbol = "maybe'" ++ baseName
+                      , lensFieldType = maybeType
+                      , lensExp = rawAccessor
                       }
-                    ]
+                  ]
     FieldDescriptorProto'LABEL_REPEATED
         -- data Foo = Foo { _Foo_bar :: Map Bar Baz }
         -- type instance Field "foo" Foo = Map Bar Baz
         | Just (k,v) <- getMapFields env fd -> let
             mapType = "Data.Map.Map" @@ hsFieldType env (fieldDescriptor k)
                                      @@ hsFieldType env (fieldDescriptor v)
-            in LensInfo mapType
-                  [FieldInstanceInfo
-                       { fieldSymbol = baseName
-                       , fieldTypeInstance = mapType
-                       , fieldAccessor = rawAccessor
+            in recordField mapType
+                  [LensInstance
+                       { lensSymbol = baseName
+                       , lensFieldType = mapType
+                       , lensExp = rawAccessor
                        }]
         -- data Foo = Foo { _Foo_bar :: [Bar] }
         -- type instance Field "bar" Foo = [Bar]
-        | otherwise -> LensInfo listType
-                  [FieldInstanceInfo
-                      { fieldSymbol = baseName
-                      , fieldTypeInstance = listType
-                      , fieldAccessor = rawAccessor
+        | otherwise -> recordField listType
+                  [LensInstance
+                      { lensSymbol = baseName
+                      , lensFieldType = listType
+                      , lensExp = rawAccessor
                       }]
-    -- data Foo = Foo { _Foo_bar :: Maybe Bar }
-    -- type instance Field "bar" Foo = Bar
-    -- type instance Field "maybe'bar" Foo = Maybe Bar
-    FieldDescriptorProto'LABEL_OPTIONAL -> LensInfo maybeType
-                  [FieldInstanceInfo
-                      { fieldSymbol = baseName
-                      , fieldTypeInstance = baseType
-                      , fieldAccessor = maybeAccessor
-                      }
-                  , FieldInstanceInfo
-                      { fieldSymbol = maybeName
-                      , fieldTypeInstance = "Prelude.Maybe" @@ baseType
-                      , fieldAccessor = rawAccessor
-                      }
-                  ]
   where
-    baseName = overloadedField f
+    recordField = RecordField (haskellRecordFieldName $ plainFieldName f)
+    baseName = overloadedName $ plainFieldName f
     fd = fieldDescriptor f
     baseType = hsFieldType env fd
-    listType = tyList baseType
     maybeType = "Prelude.Maybe" @@ baseType
-    maybeName = "maybe'" ++ baseName
-    maybeAccessor = "Prelude.." @@ fromString maybeName
-                        @@ ("Data.ProtoLens.maybeLens"
-                                @@ hsFieldValueDefault env fd)
-    rawAccessor = rawFieldAccessor $ unQual $ recordFieldName f
+    listType = tyList baseType
+    rawAccessor = "Prelude.id"
+    maybeAccessor = "Data.ProtoLens.maybeLens"
+                          @@ hsFieldValueDefault env fd
+
+
+oneofRecordField :: Env QName -> OneofInfo -> RecordField
+oneofRecordField env oneofInfo
+    = RecordField
+        { recordFieldName = haskellRecordFieldName $ oneofFieldName oneofInfo
+        , recordFieldType =
+              "Prelude.Maybe" @@ tyCon (unQual $ oneofTypeName oneofInfo)
+        , recordFieldLenses = lenses
+        }
+  where
+    lenses =
+        -- Only generate a "maybe" version of this lens,
+        -- since oneofs don't have a notion of a "default" case.
+        -- data Foo = Foo { _Foo'bar = Maybe Foo'Bar }
+        -- type instance Field "maybe'bar" Foo = Maybe Foo'Bar
+        [LensInstance
+          { lensSymbol = "maybe'" ++ overloadedName
+                                        (oneofFieldName oneofInfo)
+          , lensFieldType =
+                "Prelude.Maybe" @@ tyCon (unQual $ oneofTypeName oneofInfo)
+          , lensExp = "Prelude.id"
+          }
+         ]
+         ++ concat
+          -- Generate the same lenses for each sub-field of the oneof
+          -- as if they were proto2 optional fields.
+          -- type instance Field "bar" Foo = Bar
+          -- type instance Field "maybe'bar" Foo = Maybe Bar
+            [ [ LensInstance
+                { lensSymbol = maybeName
+                , lensFieldType = "Prelude.Maybe" @@ baseType
+                , lensExp = oneofFieldAccessor c
+                }
+              , LensInstance
+                { lensSymbol = baseName
+                , lensFieldType = baseType
+                , lensExp = "Prelude.."
+                                @@ oneofFieldAccessor c
+                                @@ ("Data.ProtoLens.maybeLens"
+                                              @@ hsFieldValueDefault env
+                                                    (fieldDescriptor f))
+                }
+              ]
+            | c <- oneofCases oneofInfo
+            , let f = caseField c
+            , let baseName = overloadedName $ plainFieldName f
+            , let baseType = hsFieldType env $ fieldDescriptor f
+            , let maybeName = "maybe'" ++ baseName
+            ]
 
 -- Get the key/value types of this type, if it is really a map.
 getMapFields :: Env QName -> FieldDescriptorProto
@@ -579,29 +627,29 @@ rawFieldAccessor f = "Lens.Family2.Unchecked.lens" @@ getter @@ setter
     setter = lambda ["x__", "y__"]
                     $ recUpdate "x__" [fieldUpdate f "y__"]
 
--- | A lens to access a oneof field.
+-- | A lens to access a case of a oneof field.
 --
 -- lens
---   (\ x__ -> case _Foo'bar x__ of
---       Prelude.Just (Foo'Bar'c x__val) -> Prelude.Just x__val
+--   (\ x__ -> case x__ of
+--       Prelude.Just (Foo'c x__val) -> Prelude.Just x__val
 --       otherwise -> Prelude.Nothing)
---   (\ x__ y__ -> x__{_Foo'bar = Prelude.fmap Foo'Bar'c y__})
-oneofFieldAccessor :: OneofFieldInfo -> Exp
-oneofFieldAccessor (OneofFieldInfo consName encName) =
-        "Lens.Family2.Unchecked.lens" @@ getter @@ setter
-      where
-        getter = lambda ["x__"] $
-            case' (var (unQual encName) @@ var "x__")
-                [ alt
-                    (pApp "Prelude.Just" [pApp (unQual consName) [pVar "x__val"]])
-                    ("Prelude.Just" @@ "x__val")
-                , alt
-                    (pVar "_otherwise")
-                    (con "Prelude.Nothing")
-                ]
-        setter = lambda ["x__", "y__"]
-                    $ recUpdate "x__" [fieldUpdate (unQual encName)
-                    $ ("Prelude.fmap" @@ (con $ unQual consName) @@ "y__")]
+--   (\ _ y__ -> fmap Foo'c y__
+oneofFieldAccessor :: OneofCase -> Exp
+oneofFieldAccessor
+    OneofCase { caseConstructorName = consName }
+        = "Lens.Family2.Unchecked.lens" @@ getter @@ setter
+  where
+    getter = lambda ["x__"] $
+        case' "x__"
+            [ alt
+                (pApp "Prelude.Just" [pApp (unQual consName) ["x__val"]])
+                ("Prelude.Just" @@ "x__val")
+            , alt
+                "_otherwise"
+                "Prelude.Nothing"
+            ]
+    setter = lambda ["_", "y__"]
+                $ "Prelude.fmap" @@ con (unQual consName) @@ "y__"
 
 descriptorExpr :: SyntaxType -> Env QName -> T.Text -> MessageInfo Name -> Exp
 descriptorExpr syntaxType env protoName m
@@ -636,13 +684,14 @@ descriptorExpr syntaxType env protoName m
               ]
     fieldDescriptorVar = fromString . fieldDescriptorName
     fieldDescriptorName f
-        = fromString $ overloadedField f ++ "__field_descriptor"
+        = fromString $ overloadedName (plainFieldName f) ++ "__field_descriptor"
     fieldDescriptorVarBind n f
         = funBind
               [match (fromString $ fieldDescriptorName f) []
                   $ fieldDescriptorExpr syntaxType env n f
               ]
     fields = messageFields m
+                ++ (messageOneofFields m >>= fmap caseField . oneofCases)
 
 -- | Get the name of the field when used in a text format proto. Groups are
 -- special because their text format field name is the name of their type,
@@ -702,6 +751,9 @@ fieldAccessorExpr syntaxType env f = accessorCon @@ var (unQual hsFieldName)
                   | not (isDefaultingOptional syntaxType fd)
                       -> "maybe'" ++ overloadedField f
               _ -> overloadedField f
+
+overloadedField :: FieldInfo -> String
+overloadedField = overloadedName . plainFieldName
 
 isDefaultingOptional :: SyntaxType -> FieldDescriptorProto -> Bool
 isDefaultingOptional syntaxType f

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -94,10 +94,12 @@ Test-Suite oneof_test
   build-depends: base
                , bytestring
                , lens-family
+               , HUnit
                , proto-lens
                , proto-lens-protoc
                , proto-lens-tests
                , test-framework
+               , test-framework-hunit
 
 Test-Suite optional_test
   default-language: Haskell2010

--- a/proto-lens-tests/tests/oneof.proto
+++ b/proto-lens-tests/tests/oneof.proto
@@ -5,7 +5,18 @@ option java_package = "oneof";
 
 message Foo {
   oneof bar {
-  	int32 baz = 1;
-  	string bippy = 2;
+    int32 baz = 1;
+    string bippy = 2;
+  }
+  oneof bar2 {
+    int32 baz2 = 3;
+  }
+}
+
+// A message with the same field names as Foo; tests that the record
+// field names don't clash.
+message DupeFieldNames {
+  oneof bar {
+    int32 baz = 1;
   }
 }

--- a/proto-lens-tests/tests/oneof_test.hs
+++ b/proto-lens-tests/tests/oneof_test.hs
@@ -3,9 +3,11 @@ module Main where
 
 import Proto.Oneof
 import Data.ProtoLens
-import Lens.Family2 ((&), (.~))
 import qualified Data.ByteString.Char8 as C
 import Data.ByteString.Builder (Builder, byteString)
+import Lens.Family2 ((&), (.~), view)
+import Test.Framework.Providers.HUnit (testCase)
+import Test.HUnit
 
 import Data.ProtoLens.TestUtil
 
@@ -30,8 +32,24 @@ main = testMain
     -- Check that we can tolerate missing keys and values.
     , deserializeFrom "from first oneof field"
         (Just $ defFoo & baz .~ 42)
-        $ tagged 1 $ VarInt $ 42
+        $ tagged 1 $ VarInt 42
     , deserializeFrom "from second oneof field"
         (Just $ defFoo & bippy .~ "querty")
         $ tagged 2 $ Lengthy "querty"
+    , testCase "oneof accessor" $ do
+        Nothing @=? view maybe'bar defFoo
+        Just (Foo'Baz 42) @=? view maybe'bar (defFoo & baz .~ 42)
+        Just (Foo'Bippy "querty") @=? view maybe'bar (defFoo & bippy .~ "querty")
+        42 @=? view baz (defFoo & maybe'bar .~ Just (Foo'Baz 42))
+        Just 42 @=? view maybe'baz (defFoo & maybe'bar .~ Just (Foo'Baz 42))
+        Nothing @=? view maybe'bippy (defFoo & maybe'bar .~ Just (Foo'Baz 42))
+    , testCase "dupe field names" $ do
+        Just (DupeFieldNames'Baz 42) @=?
+            view maybe'bar (def & baz .~ 42 :: DupeFieldNames)
+    , testCase "set another oneof" $ do
+        Just (Foo'Baz2 42) @=? view maybe'bar2 (def & baz2 .~ 42 :: Foo)
+    , serializeTo "to another oneof"
+        (defFoo & baz2 .~ 42)
+        "baz2: 42"
+        (tagged 3 $ VarInt 42)
     ]


### PR DESCRIPTION
Resolves #21.

Also refactors (again) the logic around codegen for fields and oneofs, as a follow-up
to #85 which created that sum type in the first place.  (In part, it reverts
code structure to an earlier version of that PR.)

Suppose we have

    message Foo {
      oneof bar {
        int32 a = 1;
        int64 b = 2;
      }
    }

Then we'll generate data types:

    data Foo { _Foo'bar :: Maybe Foo'Bar }

    data Foo'Bar = Foo'A Int32 | Foo'B Int64

(Note: this changes from the previous behavior which called it Foo'bar; the
capitalization/camelcasing feels more appropriate since it's a datatype.)

and overloaded versions of the following lenses:

    maybe'bar :: Lens' Foo (Maybe Foo'Bar)
    a         :: Lens' Foo Int32
    maybe'a   :: Lens' Foo (Maybe Int32)
    b         :: Lens' Foo Int64
    maybe'b   :: Lens' Foo (Maybe Int64)

The `maybe'bar` accessor returns `Nothing` when the oneof isn't set, (or set
to an unknown case from a different version of the .proto file).  We don't
provide a straight `bar` accessor since there's no clear default between
different cases of the oneof.