### PR TITLE
Export the `arbitraryMessage` function.

### DIFF
--- a/proto-lens-arbitrary/proto-lens-arbitrary.cabal
+++ b/proto-lens-arbitrary/proto-lens-arbitrary.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-arbitrary
-version:             0.1.0.3
+version:             0.1.1.0
 synopsis:            Arbitrary instances for proto-lens.
 description:
   The proto-lens-arbitrary allows generating arbitrary messages for

--- a/proto-lens-arbitrary/src/Data/ProtoLens/Arbitrary.hs
+++ b/proto-lens-arbitrary/src/Data/ProtoLens/Arbitrary.hs
@@ -9,7 +9,8 @@
 {-# LANGUAGE RankNTypes #-}
 -- | An Arbitrary instance for protocol buffer Messages to use with QuickCheck.
 module Data.ProtoLens.Arbitrary
-    ( ArbitraryMessage(..),
+    ( ArbitraryMessage(..)
+    , arbitraryMessage
     ) where
 
 import Data.ProtoLens.Message
@@ -66,8 +67,8 @@ arbitraryField (FieldDescriptor _ ftd fa) = case fa of
 
 arbitraryFieldValue :: FieldTypeDescriptor value -> Gen value
 arbitraryFieldValue ftd = case ftd of
-    MessageField -> unArbitraryMessage <$> arbitrary
-    GroupField -> unArbitraryMessage <$> arbitrary
+    MessageField -> arbitraryMessage
+    GroupField -> arbitraryMessage
     -- For enum fields, all we know is that the value is an instance of
     -- MessageEnum, meaning we can only use fromEnum, toEnum, or maybeToEnum. So
     -- we must rely on the instance of Arbitrary for Int and filter out only the
@@ -119,7 +120,7 @@ shrinkField (FieldDescriptor _ ftd fa) = case fa of
 
 shrinkFieldValue :: FieldTypeDescriptor value -> value -> [value]
 shrinkFieldValue ftd = case ftd of
-    MessageField -> map unArbitraryMessage . shrink . ArbitraryMessage
+    MessageField -> shrinkMessage
     GroupField -> map unArbitraryMessage . shrink . ArbitraryMessage
     -- Shrink to the 0-equivalent Enum value if it's both a valid Enum value
     -- and the value isn't already 0.


### PR DESCRIPTION
Bumps the version to proto-lens-arbitrary-0.1.1.0.

It's fairly useful on its own for anywhere you want a
`Gen MyProtoMessage`; for example, when defining your own
custom `Arbitrary` instances for types that contain protobufs.

Also use `arbitraryMessage/shrinkMessage` a little more directly
in the internal implementation.