### PR TITLE
CamelCase messages and oneof fields/types.

### DIFF
--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -214,7 +214,7 @@ messageDefs protoPrefix hsPrefix d
   where
     protoName = protoPrefix <> d ^. name
     hsPrefix' = hsPrefix ++ hsName (d ^. name) ++ "'"
-    hsName = unpack . capitalize
+    hsName = unpack . capitalize . camelCase
     allFields = collectFieldsByOneofIndex (d ^. field)
     thisDef =
         Message MessageInfo

--- a/proto-lens-tests/tests/names.proto
+++ b/proto-lens-tests/tests/names.proto
@@ -72,6 +72,12 @@ message ProtoKeywords {
   optional int32 import = 11;
 }
 
+message odd_Cased_message {
+  oneof oneof_field {
+    int32 oneof_case = 1;
+  }
+}
+
 // Messages whose name conflicts with a proto keyword.
 message syntax {
   optional int32 foo = 1;

--- a/proto-lens-tests/tests/names_test.hs
+++ b/proto-lens-tests/tests/names_test.hs
@@ -13,7 +13,7 @@ module Main where
 
 import Data.Int (Int32)
 import Data.ProtoLens (def, Message)
-import Lens.Family2 (Lens', (&), (.~), (^.))
+import Lens.Family2 (Lens', (&), view, set)
 import Prelude hiding (Maybe, maybe, map, head, span)
 import qualified Prelude
 import Test.Framework (Test, testGroup)
@@ -34,13 +34,14 @@ main = testMain
     [ testNames
     , testPreludeType
     , testHaskellKeywords
+    , testOddCasedMessage
     , testProtoKeywords
     , testProtoKeywordTypes
     , testReadReservedName
     ]
 
 testNames, testPreludeType, testHaskellKeywords, testProtoKeywords,
-    testProtoKeywordTypes, testReadReservedName :: Test
+    testOddCasedMessage, testProtoKeywordTypes, testReadReservedName :: Test
 
 -- | Test that we can get/set each individual field.
 testFields :: forall a . (Show a, Message a, Eq a)
@@ -52,7 +53,10 @@ testFields name defValue fields = testGroup name
     , runTypedTest (roundTripTest "roundTrip" :: TypedTest a)
     ]
   where
-    testField (SomeLens f) = 1 @=? (defValue & f .~ 1) ^. f
+    testField (SomeLens f) = verifyLens defValue f 1
+
+verifyLens :: (Show b, Eq b) => a -> Lens' a b -> b -> IO ()
+verifyLens x f y = y @=? view f (set f y x)
 
 -- | Wraps a Lens' (which is a higher-order type) so it can be used in a list
 -- without ImpredicativeTypes.
@@ -102,6 +106,18 @@ testHaskellKeywords = testFields "haskellKeywords" (def :: HaskellKeywords)
     , SomeLens hiding
     ]
 
+testOddCasedMessage = testGroup "oddCasedMessage"
+    [ runTypedTest (roundTripTest "roundTrip" :: TypedTest OddCasedMessage)
+    , testCase "oneofField" $ do
+          verifyLens defMsg maybe'oneofField $ Just
+                    (OddCasedMessage'OneofCase 42
+                        :: OddCasedMessage'OneofField)
+          verifyLens defMsg oneofCase 42
+          verifyLens defMsg maybe'oneofCase (Just 42)
+    ]
+  where
+    defMsg = def :: OddCasedMessage
+
 testProtoKeywords = testFields "protoKeywords" (def :: ProtoKeywords)
     [ SomeLens required
     , SomeLens message
@@ -127,5 +143,5 @@ testProtoKeywordTypes = testFields "protoKeywordTypes" (def :: ProtoKeywordTypes
 -- make sure we don't expect that apostrophe when parsing TextFormat.
 -- "import" field.
 testReadReservedName = readFrom "testReadReservedName"
-      (Just $ def & import' .~ 1 :: Prelude.Maybe HaskellKeywords)
+      (Just $ def & set import' 1 :: Prelude.Maybe HaskellKeywords)
       "import: 1"


### PR DESCRIPTION
Fixes some corner cases: previously underlines (snake_case) were preserved in
message types and oneof types and field constructors.  Instead, we should
camel case everything consistently.