### PR TITLE
Add individual Changelogs for all the packages.

### DIFF
--- a/lens-labels/Changelog.md
+++ b/lens-labels/Changelog.md
@@ -1,0 +1,12 @@
+# Changelog for `lens-labels`
+
+## Unreleased changes
+- Bump the dependency on `base` to support `ghc-8.2.1`.
+- Build against the new API of `GHC.OverloadedLabels` on newer versions of
+  GHC.
+
+## v0.1.0.1
+- Make the build `-Wall`-clean.
+
+## v0.1.0.0
+- Initial release.

--- a/lens-labels/lens-labels.cabal
+++ b/lens-labels/lens-labels.cabal
@@ -12,6 +12,7 @@ copyright:           Google Inc.
 category:            Data
 build-type:          Simple
 cabal-version:       >=1.10
+extra-source-files:  Changelog.md
 
 library
   exposed-modules:     Lens.Labels

--- a/proto-lens-arbitrary/Changelog.md
+++ b/proto-lens-arbitrary/Changelog.md
@@ -1,0 +1,21 @@
+# Changelog for `proto-lens-arbitrary`
+
+## Unreleased changes
+- Bump the dependency on `base` to support `ghc-8.2.1`.
+
+## 0.1.1.0
+- Export the `arbitraryMessage` function (#93).
+
+## 0.1.0.3
+- Bump the dependency for `QuickCheck-2.10`.
+- Make the build `-Wall`-clean.
+
+## 0.1.0.2
+- Bump the dependency for `QuickCheck-2.9`.
+
+## 0.1.0.1
+- Bump the dependency on `base` to support ghc-8.0.
+
+## 0.1.0.0
+Initial version.
+

--- a/proto-lens-arbitrary/proto-lens-arbitrary.cabal
+++ b/proto-lens-arbitrary/proto-lens-arbitrary.cabal
@@ -14,6 +14,7 @@ copyright:           Google Inc.
 category:            Data
 build-type:          Simple
 cabal-version:       >=1.8
+extra-source-files:  Changelog.md
 
 library
   hs-source-dirs: src

--- a/proto-lens-combinators/Changelog.md
+++ b/proto-lens-combinators/Changelog.md
@@ -1,0 +1,24 @@
+# Changelog for `proto-lens-combinators`
+
+## Unreleased changes
+- Bump the dependency on `base` to support `ghc-8.2.1`.
+
+## 0.1.0.7
+- Use a `custom-setup` clause.
+
+## 0.1.0.6
+- Bump the dependency for `proto-lens-0.2`.
+- Use modules from `lens-family-core` instead of `lens-family` to improve type
+  inference.
+
+## 0.1.0.4
+- Bump the dependency for `data-default-class-0.1`.
+
+## 0.1.0.2
+- Explicitly depend on the `proto-lens` library in the unit test.
+
+## 0.1.0.1
+- Bump the dependencies on `base` and `transformers` to support `ghc-8.0`.
+
+## 0.1.0.0
+Initial version.

--- a/proto-lens-combinators/proto-lens-combinators.cabal
+++ b/proto-lens-combinators/proto-lens-combinators.cabal
@@ -14,6 +14,7 @@ category:            Data
 build-type:          Custom
 cabal-version:       >=1.10
 extra-source-files:  tests/combinators.proto
+extra-source-files:  Changelog.md
 
 custom-setup
   setup-depends: base >= 4.8 && < 4.11

--- a/proto-lens-descriptors/Changelog.md
+++ b/proto-lens-descriptors/Changelog.md
@@ -1,0 +1,8 @@
+# Changelog for `proto-lens-descriptors`
+
+# Unreleased changes
+- Bump the dependency on `base` to support `ghc-8.2.1`.
+- Track latest changes in `proto-lens-protoc`.
+
+## v0.2.1.0 and older
+See `Changelog.md` for `proto-lens`.

--- a/proto-lens-descriptors/proto-lens-descriptors.cabal
+++ b/proto-lens-descriptors/proto-lens-descriptors.cabal
@@ -12,6 +12,7 @@ copyright:           Google Inc.
 category:            Data
 build-type:          Simple
 cabal-version:       >=1.10
+extra-source-files:  Changelog.md
 
 library
   hs-source-dirs:      src

--- a/proto-lens-optparse/Changelog.md
+++ b/proto-lens-optparse/Changelog.md
@@ -1,0 +1,18 @@
+# Changelog for `proto-lens-optparse`
+
+## Unreleased changes
+- Bump the dependency on `base` to support `ghc-8.2.1`.
+
+## 0.1.0.3
+- Bump the dependency for `optparse-applicative-0.14`.
+
+## 0.1.0.2
+- Bump the dependencies for `optparse-applicative-0.13` and
+  `proto-lens-0.2`.
+
+## 0.1.0.1
+- Bump the dependency on `base` to support `ghc-8.0`.
+
+
+## 0.1.0.0
+Initial version.

--- a/proto-lens-optparse/proto-lens-optparse.cabal
+++ b/proto-lens-optparse/proto-lens-optparse.cabal
@@ -15,6 +15,7 @@ copyright:           Google Inc.
 category:            Data
 build-type:          Simple
 cabal-version:       >=1.8
+extra-source-files:  Changelog.md
 
 library
   hs-source-dirs: src

--- a/proto-lens-protobuf-types/Changelog.md
+++ b/proto-lens-protobuf-types/Changelog.md
@@ -1,0 +1,8 @@
+# Changelog for `proto-lens-protobuf-types`
+
+## Unreleased changes
+- Add the `Data.ProtoLens.Any` module for storing arbitrary Messages (#88).
+- Bump the dependency on `base` to support `ghc-8.2.1`.
+
+## 0.2.1.0
+Initial version.

--- a/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
+++ b/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
@@ -15,6 +15,7 @@ category:            Data
 build-type:          Custom
 cabal-version:       >=1.8
 extra-source-files:
+    Changelog.md
     proto-src/google/protobuf/any.proto
     proto-src/google/protobuf/duration.proto
     proto-src/google/protobuf/wrappers.proto

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -1,0 +1,12 @@
+# Changelog for `proto-lens-protoc`
+
+## Unreleased changes
+- Bump the dependency on `base` to support `ghc-8.2.1` and `Cabal-2.0`.
+- Improve the semantics of oneof fields, and add a lens to access the
+  underlying sum type.
+- Generate Ord instances for all exported datatypes.
+- Print a better error message when missing `protoc` or `proto-lens-protoc`.
+- Expose message names to support `Data.ProtoLens.Any`.
+
+## v0.2.1.0 and older
+See `Changelog.md` for `proto-lens`.

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -15,6 +15,7 @@ copyright:           Google Inc.
 category:            Data
 build-type:          Simple
 cabal-version:       >=1.21
+extra-source-files:  Changelog.md
 
 -- Work around stack bug, since we don't want to build the library
 -- during bootstrapping:

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -1,8 +1,7 @@
-# ChangeLog
+# Changelog for `proto-lens`
 
-## v0.2.2.0
-- Add `Data.ProtoLens.Any` for packing/unpacking messages to `Any`.
-- Improve the behavior of oneof fields by generating sum types
+## Unreleased changes
+- Bump the dependency on `base` to support `ghc-8.2.1`.
 
 ## v0.2.1.0
 - Include `base`'s modules in the reexport list.

--- a/proto-lens/proto-lens.cabal
+++ b/proto-lens/proto-lens.cabal
@@ -20,6 +20,7 @@ copyright:           Google Inc.
 category:            Data
 build-type:          Simple
 cabal-version:       >=1.8
+extra-source-files:  Changelog.md
 
 library
   hs-source-dirs: src


### PR DESCRIPTION
Previously we had a top-level file that tracked all the packages.  However,
their versions are drifting; packages like `proto-lens-arbitrary` only need
minor version bumps, while `proto-lens`/`proto-lens-protoc` need major bumps.
Additionally, I'd like to relax the dependencies between `proto-lens`,
`proto-lens-protoc` and `proto-lens-descriptors`.  So it makes sense to start
tracking everything separately.