### PR TITLE
Bump dependency to haskell-src-exts-0.19.

### DIFF
--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -43,7 +43,7 @@ library
         , data-default-class >= 0.0 && < 0.2
         , directory >= 1.2 && < 1.4
         , filepath >= 1.4 && < 1.6
-        , haskell-src-exts >= 1.17 && < 1.19
+        , haskell-src-exts >= 1.17 && < 1.20
         , lens-family == 1.2.*
         , lens-labels == 0.1.*
         , process >= 1.2 && < 1.5
@@ -78,7 +78,7 @@ executable proto-lens-protoc
       , containers == 0.5.*
       , data-default-class >= 0.0 && < 0.2
       , filepath >= 1.4 && < 1.6
-      , haskell-src-exts >= 1.17 && < 1.19
+      , haskell-src-exts >= 1.17 && < 1.20
       , lens-family == 1.2.*
       -- Specify an exact version of `proto-lens`, since it's tied closely
       -- to the generated code.


### PR DESCRIPTION
It will most likely be in the next stack LTS.

Tested by manually editing `stack.yaml` to depend on that version.