### PR TITLE
Improve caching for ghc-8.2.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
   - $HOME/.ghc
   - $HOME/.stack
   - $HOME/.cabal
+  # TODO: remove this after we switch to an LTS for ghc-8.2.1
+  - .stack-work/install/x86_64-linux/lts-8.23/8.2.1
 
 matrix:
   include:
@@ -47,8 +49,8 @@ install:
   - case "$BUILD" in
       stack)
         $STACK setup --no-terminal;
-        $STACK build --only-snapshot --no-terminal;
-        $STACK build --no-terminal happy;;
+        $STACK build --no-terminal happy;
+        $STACK build --only-dependencies --no-terminal;;
       cabal)
         cabal update;;
     esac


### PR DESCRIPTION
Our current build setup for ghc-8.2.1 causes dependencies to be installed
"locally" under `$PWD/.stack-work` rather than `$HOME/.stack` (which is
where snapshot packages are usually stored).  As a result, they weren't being
cached, and the build was taking much longer to complete.

This changes `.travis.yml` so that for the 8.2.1 build, we also cache
everything under `.stack-work`.  It's a little too aggressive since it also
caches the packages in this repo (`proto-lens-*`) which can lead to confusing
false positive build successes if we hit edge cases in stack.  So I'll plan to
revert this once we switch to a Stack LTS that contains ghc-8.2.1.