### PR TITLE
Prepare for releasing proto-lens-0.2.2.0.

### DIFF
--- a/proto-lens-descriptors/Changelog.md
+++ b/proto-lens-descriptors/Changelog.md
@@ -1,6 +1,8 @@
 # Changelog for `proto-lens-descriptors`
 
 # Unreleased changes
+
+# v0.2.2.0
 - Bump the dependency on `base` to support `ghc-8.2.1`.
 - Track latest changes in `proto-lens-protoc`.
 

--- a/proto-lens-descriptors/proto-lens-descriptors.cabal
+++ b/proto-lens-descriptors/proto-lens-descriptors.cabal
@@ -27,7 +27,7 @@ library
     , data-default-class >= 0.0 && < 0.2
     , lens-family == 1.2.*
     , lens-labels == 0.1.*
-    -- Specify an exact version of `proto-lens`, since it's tied closely
-    -- to the generated code.
-    , proto-lens == 0.2.2.0
+    -- Specify a more precise version of `proto-lens`, since it depends on
+    -- the exact definition of the Message class.
+    , proto-lens == 0.2.2.*
     , text == 1.2.*

--- a/proto-lens-protobuf-types/Changelog.md
+++ b/proto-lens-protobuf-types/Changelog.md
@@ -1,8 +1,10 @@
 # Changelog for `proto-lens-protobuf-types`
 
 ## Unreleased changes
+
+## v0.2.2.0
 - Add the `Data.ProtoLens.Any` module for storing arbitrary Messages (#88).
 - Bump the dependency on `base` to support `ghc-8.2.1`.
 
-## 0.2.1.0
+## v0.2.1.0
 Initial version.

--- a/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
+++ b/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
@@ -33,6 +33,6 @@ library
                       Proto.Google.Protobuf.Wrappers
   build-depends: base >= 4.8 && < 4.11
                , lens-family
-               , proto-lens >= 0.2.2.0 && < 0.3
-               , proto-lens-protoc == 0.2.*
+               , proto-lens >= 0.2.2 && < 0.3
+               , proto-lens-protoc >= 0.2.2 && < 0.3
                , text == 1.2.*

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -1,12 +1,16 @@
 # Changelog for `proto-lens-protoc`
 
 ## Unreleased changes
+
+## v0.2.2.0
 - Bump the dependency on `base` to support `ghc-8.2.1` and `Cabal-2.0`.
+- Bump the dependency for `haskell-src-exts-0.19`.
 - Improve the semantics of oneof fields, and add a lens to access the
   underlying sum type.
 - Generate Ord instances for all exported datatypes.
 - Print a better error message when missing `protoc` or `proto-lens-protoc`.
 - Expose message names to support `Data.ProtoLens.Any`.
+- CamelCase the names of Haskell message types.
 
 ## v0.2.1.0 and older
 See `Changelog.md` for `proto-lens`.

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -48,8 +48,10 @@ library
         , lens-family == 1.2.*
         , lens-labels == 0.1.*
         , process >= 1.2 && < 1.5
-        , proto-lens == 0.2.2.0
-        , proto-lens-descriptors == 0.2.2.0
+        -- Specify a more precise version of `proto-lens`, since it depends on
+        -- the exact definition of the Message class.
+        , proto-lens == 0.2.2.*
+        , proto-lens-descriptors == 0.2.2.*
         , text == 1.2.*
     reexported-modules:
         -- Modules that are needed by the generated Haskell files.
@@ -81,10 +83,10 @@ executable proto-lens-protoc
       , filepath >= 1.4 && < 1.6
       , haskell-src-exts >= 1.17 && < 1.20
       , lens-family == 1.2.*
-      -- Specify an exact version of `proto-lens`, since it's tied closely
-      -- to the generated code.
-      , proto-lens == 0.2.2.0
-      , proto-lens-descriptors == 0.2.2.0
+      -- Specify a more precise version of `proto-lens`, since it depends on
+      -- the exact definition of the Message class.
+      , proto-lens == 0.2.2.*
+      , proto-lens-descriptors == 0.2.2.*
       , text == 1.2.*
   hs-source-dirs:      src
   other-modules:

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -1,6 +1,8 @@
 # Changelog for `proto-lens`
 
 ## Unreleased changes
+
+## v0.2.2.0
 - Bump the dependency on `base` to support `ghc-8.2.1`.
 
 ## v0.2.1.0


### PR DESCRIPTION
- Update the changelogs (including updated changes to `proto-lens-protoc`).
- Make `proto-lens`, `proto-lens-descriptors` and `proto-lens-protobuf-types`
  depend on `0.2.2.*` rather than `0.2.2.0`.  That should make it easier
  to make bugfix package releases without updating all three packages in
  lockstep.