### PR TITLE
Fix an ambiguity between the names oneof and submessages/subenums.

### DIFF
--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## v0.2.2.1
+- Fix the case where types/constructors of oneofs overlap with those of
+  submessages or subenums, by appending `"'"` to the former when required.
+
 ## v0.2.2.0
 - Bump the dependency on `base` to support `ghc-8.2.1` and `Cabal-2.0`.
 - Bump the dependency for `haskell-src-exts-0.19`.

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-protoc
-version:             0.2.2.0
+version:             0.2.2.1
 synopsis:            Protocol buffer compiler for the proto-lens library.
 description:
   Turn protocol buffer files (.proto) into Haskell files (.hs) which

--- a/proto-lens-tests/tests/oneof.proto
+++ b/proto-lens-tests/tests/oneof.proto
@@ -20,3 +20,36 @@ message DupeFieldNames {
     int32 baz = 1;
   }
 }
+
+// It's possible for oneof types/constructors to overlap with message or enum
+// types/constructors.  In those cases we should add a trailing "'" to the
+// Haskell types corresponding to the oneof.
+message Disambiguated {
+  message MessageTypeA {
+  }
+  message MessageTypeB {
+  }
+  enum EnumType {
+    EnumCon = 0;
+  }
+
+  oneof message_type_a {
+    int32 message_type_b = 1;
+  }
+
+  oneof enum_type {
+    int32 enum_con = 2;
+  }
+}
+
+// Types and constructors are in different namespaces, so if they overlap we
+// don't need to disambiguate them.
+message NotDisambiguated {
+  enum EnumType {
+    EnumCon = 0;
+  }
+
+  oneof enum_con {
+    int32 enum_type = 1;
+  }
+}

--- a/proto-lens-tests/tests/oneof_test.hs
+++ b/proto-lens-tests/tests/oneof_test.hs
@@ -1,10 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Main where
+module Main (main) where
 
 import Proto.Oneof
 import Data.ProtoLens
-import qualified Data.ByteString.Char8 as C
-import Data.ByteString.Builder (Builder, byteString)
 import Lens.Family2 ((&), (.~), view)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.HUnit
@@ -13,10 +11,6 @@ import Data.ProtoLens.TestUtil
 
 defFoo :: Foo
 defFoo = def
-
-taggedValue :: String -> Builder
-taggedValue = tagged 2 . Lengthy . byteString . C.pack
-
 
 main :: IO ()
 main = testMain
@@ -29,6 +23,7 @@ main = testMain
         (defFoo & baz .~ 42 & bippy .~ "querty")
         "bippy: \"querty\""
         (tagged 2 $ Lengthy "querty")
+
     -- Check that we can tolerate missing keys and values.
     , deserializeFrom "from first oneof field"
         (Just $ defFoo & baz .~ 42)
@@ -36,6 +31,7 @@ main = testMain
     , deserializeFrom "from second oneof field"
         (Just $ defFoo & bippy .~ "querty")
         $ tagged 2 $ Lengthy "querty"
+
     , testCase "oneof accessor" $ do
         Nothing @=? view maybe'bar defFoo
         Just (Foo'Baz 42) @=? view maybe'bar (defFoo & baz .~ 42)
@@ -43,13 +39,37 @@ main = testMain
         42 @=? view baz (defFoo & maybe'bar .~ Just (Foo'Baz 42))
         Just 42 @=? view maybe'baz (defFoo & maybe'bar .~ Just (Foo'Baz 42))
         Nothing @=? view maybe'bippy (defFoo & maybe'bar .~ Just (Foo'Baz 42))
-    , testCase "dupe field names" $ do
+
+    , testCase "dupe field names" $
         Just (DupeFieldNames'Baz 42) @=?
             view maybe'bar (def & baz .~ 42 :: DupeFieldNames)
-    , testCase "set another oneof" $ do
+
+    , testCase "set another oneof" $
         Just (Foo'Baz2 42) @=? view maybe'bar2 (def & baz2 .~ 42 :: Foo)
     , serializeTo "to another oneof"
         (defFoo & baz2 .~ 42)
         "baz2: 42"
         (tagged 3 $ VarInt 42)
+
+    , testCase "disambiguated names" $ do
+        -- Check that we put apostrophes on oneof types and constructors when
+        -- they clash with message or enum types or constructors.
+        -- (See oneof.proto for details.)
+        -- A oneof type and constructor that overlap with a message
+        trivial (Disambiguated'MessageTypeB' 42 :: Disambiguated'MessageTypeA')
+        -- A oneof type and constructor that overlap with an enum
+        trivial (Disambiguated'EnumCon' 42 :: Disambiguated'EnumType')
+
+        -- And we don't change the message or enum types and constructors.
+        trivial (Disambiguated'MessageTypeA{} :: Disambiguated'MessageTypeA)
+        trivial (Disambiguated'MessageTypeB{} :: Disambiguated'MessageTypeB)
+        trivial (Disambiguated'EnumCon :: Disambiguated'EnumType)
+
+    , testCase "not disambiguated names" $ do
+        trivial (NotDisambiguated'EnumCon :: NotDisambiguated'EnumType)
+        trivial (NotDisambiguated'EnumType 42 :: NotDisambiguated'EnumCon)
+
     ]
+
+trivial :: (Show a, Eq a) => a -> IO ()
+trivial x = x @=? x


### PR DESCRIPTION
Also bumped `proto-lens-protoc` to `0.2.2.1` in preparation for a bugfix
release.  (The other packages are unchanged.)

The build of `tensorflow/haskell` was breaking with `proto-lens-0.2.2.0`.
Specifically, in `meta_graph.proto`:

    message CollectionDef {
      message NodeList {...}
      oneof kind {
        NodeList node_list = 1;
        ...
      }
    }

We were using the name `CollectionDef'NodeList` for both the constructor
of the submessage and the constructor of the oneof:

    data CollectionDef'NodeList = CollectionDef'NodeList{...}
    data CollectionDef'Kind = CollectionDef'NodeList NodeList
                            | ...

It turns out there's several ways the oneof's names can overlap with message
or enum names; I listed them out in `oneof_test.proto`.

This PR fixes the ambiguity by behaving similarly to the go bindings:
https://github.com/golang/protobuf/blob/master/protoc-gen-go/generator/generator.go#L1864
Specifically, if a oneof type or constructor name overlaps with another name,
then we append `"'"` to the name of the oneof.