### PR TITLE
Don't camel-case message names.

### DIFF
--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## v0.2.2.3
+- Don't camel-case message names.  This reverts behavior which was added
+  in v0.2.2.0.
+
 ## v0.2.2.2
 - Bump the dependency for `process-1.6`.
 

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -1,5 +1,5 @@
 name:                proto-lens-protoc
-version:             0.2.2.2
+version:             0.2.2.3
 synopsis:            Protocol buffer compiler for the proto-lens library.
 description:
   Turn protocol buffer files (.proto) into Haskell files (.hs) which

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -252,10 +252,10 @@ collectOneofFields hsPrefix d allFields
     -- Make a name that doesn't overlap with those already defined by submessages
     -- or subenums.
     hsNameUnique ns n
-        | n' `elem` ns = n' <> "'"
+        | n' `elem` ns = n' ++ "'"
         | otherwise = n'
       where
-        n' = hsName n
+        n' = hsName $ camelCase n
     -- The Haskell "type" namespace
     subdefTypes = Set.fromList $ map hsName
                     $ toListOf (nestedType . traverse . name) d
@@ -275,7 +275,7 @@ groupFieldsByOneofIndex =
     . fmap (\f -> (f ^. maybe'oneofIndex, [f]))
 
 hsName :: Text -> String
-hsName = unpack . capitalize . camelCase
+hsName = unpack . capitalize
 
 mkFieldName :: String -> Text -> FieldName
 mkFieldName hsPrefix n = FieldName

--- a/proto-lens-tests/tests/names.proto
+++ b/proto-lens-tests/tests/names.proto
@@ -72,10 +72,24 @@ message ProtoKeywords {
   optional int32 import = 11;
 }
 
-message odd_Cased_message {
+message odd_CAsed_message {
   oneof oneof_field {
     int32 oneof_case = 1;
   }
+
+  // TODO: odd_Cased_enum
+  enum odd_CAsed_enum {
+    // TODO: deFA_ult = 0;
+    DeFA_ult = 0;
+  }
+}
+
+message ABBREVName {}
+
+// TODO: odd_Cased_enum
+enum Odd_CAsed_enum {
+  // TODO: deFA_ult = 0;
+  DeFA_ult = 0;
 }
 
 // Messages whose name conflicts with a proto keyword.

--- a/proto-lens-tests/tests/names_test.hs
+++ b/proto-lens-tests/tests/names_test.hs
@@ -106,17 +106,26 @@ testHaskellKeywords = testFields "haskellKeywords" (def :: HaskellKeywords)
     , SomeLens hiding
     ]
 
+-- Don't change the name of messages and enums.  However, do still camel-case
+-- the generated oneof datatypes and constructors.
 testOddCasedMessage = testGroup "oddCasedMessage"
-    [ runTypedTest (roundTripTest "roundTrip" :: TypedTest OddCasedMessage)
+    [ runTypedTest (roundTripTest "roundTrip" :: TypedTest Odd_CAsed_message)
+    , runTypedTest (roundTripTest "roundTrip abbrev" :: TypedTest ABBREVName)
     , testCase "oneofField" $ do
           verifyLens defMsg maybe'oneofField $ Just
-                    (OddCasedMessage'OneofCase 42
-                        :: OddCasedMessage'OneofField)
+                    (Odd_CAsed_message'OneofCase 42
+                        :: Odd_CAsed_message'OneofField)
           verifyLens defMsg oneofCase 42
           verifyLens defMsg maybe'oneofCase (Just 42)
+    , testCase "enums" $ do
+          trivial (def :: Odd_CAsed_message'odd_CAsed_enum)
+          trivial (def :: Odd_CAsed_enum)
     ]
   where
-    defMsg = def :: OddCasedMessage
+    defMsg = def :: Odd_CAsed_message
+
+trivial :: (Show a, Eq a) => a -> IO ()
+trivial a = a @=? a
 
 testProtoKeywords = testFields "protoKeywords" (def :: ProtoKeywords)
     [ SomeLens required

--- a/proto-lens-tests/tests/names_test.hs
+++ b/proto-lens-tests/tests/names_test.hs
@@ -118,8 +118,8 @@ testOddCasedMessage = testGroup "oddCasedMessage"
           verifyLens defMsg oneofCase 42
           verifyLens defMsg maybe'oneofCase (Just 42)
     , testCase "enums" $ do
-          trivial (def :: Odd_CAsed_message'odd_CAsed_enum)
-          trivial (def :: Odd_CAsed_enum)
+          trivial (Odd_CAsed_message'DeFA_ult :: Odd_CAsed_message'odd_CAsed_enum)
+          trivial (DeFA_ult :: Odd_CAsed_enum)
     ]
   where
     defMsg = def :: Odd_CAsed_message


### PR DESCRIPTION
In proto-lens-protoc-0.2.2.0 we added logic to camel-case message names.
Unfortunately, that behavior turned out to be buggy; in particular, `FOOBar`
was turned into `Foobar`.  Additionally, it was inconsistent with enum names
which aren't camel-cased.

Note: we *are* still camel-casing and capitalizing the datatypes and
constructors that are generated for oneof fields.  However, the message part
is unchanged; for example, `message Foo_bar { oneof baz_a {..}}` turns into
`Foo_bar'BazA`.

In a future release we may try to improve the behavior again.  I added unit
tests to help future validation.