### PR TITLE
Improve readability of HasLens instances.

### DIFF
--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin'Fields.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin'Fields.hs
@@ -20,21 +20,21 @@ import qualified Lens.Labels
 import qualified Proto.Google.Protobuf.Descriptor
 
 content ::
-        forall f s t a b . Lens.Labels.HasLens "content" f s t a b =>
+        forall f s t a b . Lens.Labels.HasLens f s t "content" a b =>
           Lens.Family2.LensLike f s t a b
 content
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "content")
 
 error ::
-      forall f s t a b . Lens.Labels.HasLens "error" f s t a b =>
+      forall f s t a b . Lens.Labels.HasLens f s t "error" a b =>
         Lens.Family2.LensLike f s t a b
 error
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "error")
 
 file ::
-     forall f s t a b . Lens.Labels.HasLens "file" f s t a b =>
+     forall f s t a b . Lens.Labels.HasLens f s t "file" a b =>
        Lens.Family2.LensLike f s t a b
 file
   = Lens.Labels.lensOf
@@ -42,7 +42,7 @@ file
 
 fileToGenerate ::
                forall f s t a b .
-                 Lens.Labels.HasLens "fileToGenerate" f s t a b =>
+                 Lens.Labels.HasLens f s t "fileToGenerate" a b =>
                  Lens.Family2.LensLike f s t a b
 fileToGenerate
   = Lens.Labels.lensOf
@@ -50,21 +50,21 @@ fileToGenerate
 
 insertionPoint ::
                forall f s t a b .
-                 Lens.Labels.HasLens "insertionPoint" f s t a b =>
+                 Lens.Labels.HasLens f s t "insertionPoint" a b =>
                  Lens.Family2.LensLike f s t a b
 insertionPoint
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "insertionPoint")
 
 maybe'content ::
-              forall f s t a b . Lens.Labels.HasLens "maybe'content" f s t a b =>
+              forall f s t a b . Lens.Labels.HasLens f s t "maybe'content" a b =>
                 Lens.Family2.LensLike f s t a b
 maybe'content
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'content")
 
 maybe'error ::
-            forall f s t a b . Lens.Labels.HasLens "maybe'error" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "maybe'error" a b =>
               Lens.Family2.LensLike f s t a b
 maybe'error
   = Lens.Labels.lensOf
@@ -72,7 +72,7 @@ maybe'error
 
 maybe'insertionPoint ::
                      forall f s t a b .
-                       Lens.Labels.HasLens "maybe'insertionPoint" f s t a b =>
+                       Lens.Labels.HasLens f s t "maybe'insertionPoint" a b =>
                        Lens.Family2.LensLike f s t a b
 maybe'insertionPoint
   = Lens.Labels.lensOf
@@ -80,7 +80,7 @@ maybe'insertionPoint
          (Lens.Labels.Proxy#) "maybe'insertionPoint")
 
 maybe'name ::
-           forall f s t a b . Lens.Labels.HasLens "maybe'name" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "maybe'name" a b =>
              Lens.Family2.LensLike f s t a b
 maybe'name
   = Lens.Labels.lensOf
@@ -88,28 +88,28 @@ maybe'name
 
 maybe'parameter ::
                 forall f s t a b .
-                  Lens.Labels.HasLens "maybe'parameter" f s t a b =>
+                  Lens.Labels.HasLens f s t "maybe'parameter" a b =>
                   Lens.Family2.LensLike f s t a b
 maybe'parameter
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'parameter")
 
 name ::
-     forall f s t a b . Lens.Labels.HasLens "name" f s t a b =>
+     forall f s t a b . Lens.Labels.HasLens f s t "name" a b =>
        Lens.Family2.LensLike f s t a b
 name
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "name")
 
 parameter ::
-          forall f s t a b . Lens.Labels.HasLens "parameter" f s t a b =>
+          forall f s t a b . Lens.Labels.HasLens f s t "parameter" a b =>
             Lens.Family2.LensLike f s t a b
 parameter
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "parameter")
 
 protoFile ::
-          forall f s t a b . Lens.Labels.HasLens "protoFile" f s t a b =>
+          forall f s t a b . Lens.Labels.HasLens f s t "protoFile" a b =>
             Lens.Family2.LensLike f s t a b
 protoFile
   = Lens.Labels.lensOf

--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -27,43 +27,41 @@ data CodeGeneratorRequest = CodeGeneratorRequest{_CodeGeneratorRequest'fileToGen
                                                  ![Proto.Google.Protobuf.Descriptor.FileDescriptorProto]}
                           deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ [Data.Text.Text], b ~ [Data.Text.Text],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "fileToGenerate" f CodeGeneratorRequest
-         CodeGeneratorRequest a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f CodeGeneratorRequest x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f CodeGeneratorRequest CodeGeneratorRequest x a
+         b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorRequest "fileToGenerate" ([Data.Text.Text]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'fileToGenerate
                  (\ x__ y__ -> x__{_CodeGeneratorRequest'fileToGenerate = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "parameter" f CodeGeneratorRequest
-         CodeGeneratorRequest a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorRequest "parameter" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'parameter
                  (\ x__ y__ -> x__{_CodeGeneratorRequest'parameter = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'parameter" f CodeGeneratorRequest
-         CodeGeneratorRequest a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorRequest "maybe'parameter"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'parameter
                  (\ x__ y__ -> x__{_CodeGeneratorRequest'parameter = y__}))
               Prelude.id
 
-instance (a ~
-            [Proto.Google.Protobuf.Descriptor.FileDescriptorProto],
-          b ~ [Proto.Google.Protobuf.Descriptor.FileDescriptorProto],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "protoFile" f CodeGeneratorRequest
-         CodeGeneratorRequest a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorRequest "protoFile"
+         ([Proto.Google.Protobuf.Descriptor.FileDescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'protoFile
                  (\ x__ y__ -> x__{_CodeGeneratorRequest'protoFile = y__}))
@@ -120,31 +118,32 @@ data CodeGeneratorResponse = CodeGeneratorResponse{_CodeGeneratorResponse'error
                                                    ![CodeGeneratorResponse'File]}
                            deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "error" f CodeGeneratorResponse
-         CodeGeneratorResponse a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f CodeGeneratorResponse x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f CodeGeneratorResponse CodeGeneratorResponse x
+         a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorResponse "error" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'error
                  (\ x__ y__ -> x__{_CodeGeneratorResponse'error = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'error" f CodeGeneratorResponse
-         CodeGeneratorResponse a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorResponse "maybe'error" (Prelude.Maybe Data.Text.Text)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'error
                  (\ x__ y__ -> x__{_CodeGeneratorResponse'error = y__}))
               Prelude.id
 
-instance (a ~ [CodeGeneratorResponse'File],
-          b ~ [CodeGeneratorResponse'File], Prelude.Functor f) =>
-         Lens.Labels.HasLens "file" f CodeGeneratorResponse
-         CodeGeneratorResponse a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorResponse "file" ([CodeGeneratorResponse'File]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'file
                  (\ x__ y__ -> x__{_CodeGeneratorResponse'file = y__}))
@@ -192,31 +191,32 @@ data CodeGeneratorResponse'File = CodeGeneratorResponse'File{_CodeGeneratorRespo
                                                              !(Prelude.Maybe Data.Text.Text)}
                                 deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "name" f CodeGeneratorResponse'File
-         CodeGeneratorResponse'File a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f CodeGeneratorResponse'File x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f CodeGeneratorResponse'File
+         CodeGeneratorResponse'File x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorResponse'File "name" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'name
                  (\ x__ y__ -> x__{_CodeGeneratorResponse'File'name = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'name" f CodeGeneratorResponse'File
-         CodeGeneratorResponse'File a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorResponse'File "maybe'name"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'name
                  (\ x__ y__ -> x__{_CodeGeneratorResponse'File'name = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "insertionPoint" f CodeGeneratorResponse'File
-         CodeGeneratorResponse'File a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorResponse'File "insertionPoint" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens
                  _CodeGeneratorResponse'File'insertionPoint
@@ -224,11 +224,10 @@ instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
                     x__{_CodeGeneratorResponse'File'insertionPoint = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'insertionPoint" f
-         CodeGeneratorResponse'File CodeGeneratorResponse'File a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorResponse'File "maybe'insertionPoint"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens
                  _CodeGeneratorResponse'File'insertionPoint
@@ -236,21 +235,18 @@ instance (a ~ Prelude.Maybe Data.Text.Text,
                     x__{_CodeGeneratorResponse'File'insertionPoint = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "content" f CodeGeneratorResponse'File
-         CodeGeneratorResponse'File a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorResponse'File "content" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'content
                  (\ x__ y__ -> x__{_CodeGeneratorResponse'File'content = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'content" f CodeGeneratorResponse'File
-         CodeGeneratorResponse'File a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         CodeGeneratorResponse'File "maybe'content"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'content
                  (\ x__ y__ -> x__{_CodeGeneratorResponse'File'content = y__}))

--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor'Fields.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor'Fields.hs
@@ -20,28 +20,28 @@ import qualified Lens.Labels
 
 aggregateValue ::
                forall f s t a b .
-                 Lens.Labels.HasLens "aggregateValue" f s t a b =>
+                 Lens.Labels.HasLens f s t "aggregateValue" a b =>
                  Lens.Family2.LensLike f s t a b
 aggregateValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "aggregateValue")
 
 allowAlias ::
-           forall f s t a b . Lens.Labels.HasLens "allowAlias" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "allowAlias" a b =>
              Lens.Family2.LensLike f s t a b
 allowAlias
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "allowAlias")
 
 annotation ::
-           forall f s t a b . Lens.Labels.HasLens "annotation" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "annotation" a b =>
              Lens.Family2.LensLike f s t a b
 annotation
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "annotation")
 
 begin ::
-      forall f s t a b . Lens.Labels.HasLens "begin" f s t a b =>
+      forall f s t a b . Lens.Labels.HasLens f s t "begin" a b =>
         Lens.Family2.LensLike f s t a b
 begin
   = Lens.Labels.lensOf
@@ -49,7 +49,7 @@ begin
 
 ccEnableArenas ::
                forall f s t a b .
-                 Lens.Labels.HasLens "ccEnableArenas" f s t a b =>
+                 Lens.Labels.HasLens f s t "ccEnableArenas" a b =>
                  Lens.Family2.LensLike f s t a b
 ccEnableArenas
   = Lens.Labels.lensOf
@@ -57,7 +57,7 @@ ccEnableArenas
 
 ccGenericServices ::
                   forall f s t a b .
-                    Lens.Labels.HasLens "ccGenericServices" f s t a b =>
+                    Lens.Labels.HasLens f s t "ccGenericServices" a b =>
                     Lens.Family2.LensLike f s t a b
 ccGenericServices
   = Lens.Labels.lensOf
@@ -65,7 +65,7 @@ ccGenericServices
 
 clientStreaming ::
                 forall f s t a b .
-                  Lens.Labels.HasLens "clientStreaming" f s t a b =>
+                  Lens.Labels.HasLens f s t "clientStreaming" a b =>
                   Lens.Family2.LensLike f s t a b
 clientStreaming
   = Lens.Labels.lensOf
@@ -73,70 +73,70 @@ clientStreaming
 
 csharpNamespace ::
                 forall f s t a b .
-                  Lens.Labels.HasLens "csharpNamespace" f s t a b =>
+                  Lens.Labels.HasLens f s t "csharpNamespace" a b =>
                   Lens.Family2.LensLike f s t a b
 csharpNamespace
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "csharpNamespace")
 
 ctype ::
-      forall f s t a b . Lens.Labels.HasLens "ctype" f s t a b =>
+      forall f s t a b . Lens.Labels.HasLens f s t "ctype" a b =>
         Lens.Family2.LensLike f s t a b
 ctype
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "ctype")
 
 defaultValue ::
-             forall f s t a b . Lens.Labels.HasLens "defaultValue" f s t a b =>
+             forall f s t a b . Lens.Labels.HasLens f s t "defaultValue" a b =>
                Lens.Family2.LensLike f s t a b
 defaultValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "defaultValue")
 
 dependency ::
-           forall f s t a b . Lens.Labels.HasLens "dependency" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "dependency" a b =>
              Lens.Family2.LensLike f s t a b
 dependency
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "dependency")
 
 deprecated ::
-           forall f s t a b . Lens.Labels.HasLens "deprecated" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "deprecated" a b =>
              Lens.Family2.LensLike f s t a b
 deprecated
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "deprecated")
 
 doubleValue ::
-            forall f s t a b . Lens.Labels.HasLens "doubleValue" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "doubleValue" a b =>
               Lens.Family2.LensLike f s t a b
 doubleValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "doubleValue")
 
 end ::
-    forall f s t a b . Lens.Labels.HasLens "end" f s t a b =>
+    forall f s t a b . Lens.Labels.HasLens f s t "end" a b =>
       Lens.Family2.LensLike f s t a b
 end
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "end")
 
 enumType ::
-         forall f s t a b . Lens.Labels.HasLens "enumType" f s t a b =>
+         forall f s t a b . Lens.Labels.HasLens f s t "enumType" a b =>
            Lens.Family2.LensLike f s t a b
 enumType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "enumType")
 
 extendee ::
-         forall f s t a b . Lens.Labels.HasLens "extendee" f s t a b =>
+         forall f s t a b . Lens.Labels.HasLens f s t "extendee" a b =>
            Lens.Family2.LensLike f s t a b
 extendee
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "extendee")
 
 extension ::
-          forall f s t a b . Lens.Labels.HasLens "extension" f s t a b =>
+          forall f s t a b . Lens.Labels.HasLens f s t "extension" a b =>
             Lens.Family2.LensLike f s t a b
 extension
   = Lens.Labels.lensOf
@@ -144,28 +144,28 @@ extension
 
 extensionRange ::
                forall f s t a b .
-                 Lens.Labels.HasLens "extensionRange" f s t a b =>
+                 Lens.Labels.HasLens f s t "extensionRange" a b =>
                  Lens.Family2.LensLike f s t a b
 extensionRange
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "extensionRange")
 
 field ::
-      forall f s t a b . Lens.Labels.HasLens "field" f s t a b =>
+      forall f s t a b . Lens.Labels.HasLens f s t "field" a b =>
         Lens.Family2.LensLike f s t a b
 field
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "field")
 
 file ::
-     forall f s t a b . Lens.Labels.HasLens "file" f s t a b =>
+     forall f s t a b . Lens.Labels.HasLens f s t "file" a b =>
        Lens.Family2.LensLike f s t a b
 file
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "file")
 
 goPackage ::
-          forall f s t a b . Lens.Labels.HasLens "goPackage" f s t a b =>
+          forall f s t a b . Lens.Labels.HasLens f s t "goPackage" a b =>
             Lens.Family2.LensLike f s t a b
 goPackage
   = Lens.Labels.lensOf
@@ -173,21 +173,21 @@ goPackage
 
 identifierValue ::
                 forall f s t a b .
-                  Lens.Labels.HasLens "identifierValue" f s t a b =>
+                  Lens.Labels.HasLens f s t "identifierValue" a b =>
                   Lens.Family2.LensLike f s t a b
 identifierValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "identifierValue")
 
 inputType ::
-          forall f s t a b . Lens.Labels.HasLens "inputType" f s t a b =>
+          forall f s t a b . Lens.Labels.HasLens f s t "inputType" a b =>
             Lens.Family2.LensLike f s t a b
 inputType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "inputType")
 
 isExtension ::
-            forall f s t a b . Lens.Labels.HasLens "isExtension" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "isExtension" a b =>
               Lens.Family2.LensLike f s t a b
 isExtension
   = Lens.Labels.lensOf
@@ -195,7 +195,7 @@ isExtension
 
 javaGenerateEqualsAndHash ::
                           forall f s t a b .
-                            Lens.Labels.HasLens "javaGenerateEqualsAndHash" f s t a b =>
+                            Lens.Labels.HasLens f s t "javaGenerateEqualsAndHash" a b =>
                             Lens.Family2.LensLike f s t a b
 javaGenerateEqualsAndHash
   = Lens.Labels.lensOf
@@ -204,7 +204,7 @@ javaGenerateEqualsAndHash
 
 javaGenericServices ::
                     forall f s t a b .
-                      Lens.Labels.HasLens "javaGenericServices" f s t a b =>
+                      Lens.Labels.HasLens f s t "javaGenericServices" a b =>
                       Lens.Family2.LensLike f s t a b
 javaGenericServices
   = Lens.Labels.lensOf
@@ -213,7 +213,7 @@ javaGenericServices
 
 javaMultipleFiles ::
                   forall f s t a b .
-                    Lens.Labels.HasLens "javaMultipleFiles" f s t a b =>
+                    Lens.Labels.HasLens f s t "javaMultipleFiles" a b =>
                     Lens.Family2.LensLike f s t a b
 javaMultipleFiles
   = Lens.Labels.lensOf
@@ -221,14 +221,14 @@ javaMultipleFiles
 
 javaOuterClassname ::
                    forall f s t a b .
-                     Lens.Labels.HasLens "javaOuterClassname" f s t a b =>
+                     Lens.Labels.HasLens f s t "javaOuterClassname" a b =>
                      Lens.Family2.LensLike f s t a b
 javaOuterClassname
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "javaOuterClassname")
 
 javaPackage ::
-            forall f s t a b . Lens.Labels.HasLens "javaPackage" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "javaPackage" a b =>
               Lens.Family2.LensLike f s t a b
 javaPackage
   = Lens.Labels.lensOf
@@ -236,7 +236,7 @@ javaPackage
 
 javaStringCheckUtf8 ::
                     forall f s t a b .
-                      Lens.Labels.HasLens "javaStringCheckUtf8" f s t a b =>
+                      Lens.Labels.HasLens f s t "javaStringCheckUtf8" a b =>
                       Lens.Family2.LensLike f s t a b
 javaStringCheckUtf8
   = Lens.Labels.lensOf
@@ -244,28 +244,28 @@ javaStringCheckUtf8
          (Lens.Labels.Proxy#) "javaStringCheckUtf8")
 
 jsonName ::
-         forall f s t a b . Lens.Labels.HasLens "jsonName" f s t a b =>
+         forall f s t a b . Lens.Labels.HasLens f s t "jsonName" a b =>
            Lens.Family2.LensLike f s t a b
 jsonName
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "jsonName")
 
 jstype ::
-       forall f s t a b . Lens.Labels.HasLens "jstype" f s t a b =>
+       forall f s t a b . Lens.Labels.HasLens f s t "jstype" a b =>
          Lens.Family2.LensLike f s t a b
 jstype
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "jstype")
 
 label ::
-      forall f s t a b . Lens.Labels.HasLens "label" f s t a b =>
+      forall f s t a b . Lens.Labels.HasLens f s t "label" a b =>
         Lens.Family2.LensLike f s t a b
 label
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "label")
 
 lazy ::
-     forall f s t a b . Lens.Labels.HasLens "lazy" f s t a b =>
+     forall f s t a b . Lens.Labels.HasLens f s t "lazy" a b =>
        Lens.Family2.LensLike f s t a b
 lazy
   = Lens.Labels.lensOf
@@ -273,7 +273,7 @@ lazy
 
 leadingComments ::
                 forall f s t a b .
-                  Lens.Labels.HasLens "leadingComments" f s t a b =>
+                  Lens.Labels.HasLens f s t "leadingComments" a b =>
                   Lens.Family2.LensLike f s t a b
 leadingComments
   = Lens.Labels.lensOf
@@ -281,7 +281,7 @@ leadingComments
 
 leadingDetachedComments ::
                         forall f s t a b .
-                          Lens.Labels.HasLens "leadingDetachedComments" f s t a b =>
+                          Lens.Labels.HasLens f s t "leadingDetachedComments" a b =>
                           Lens.Family2.LensLike f s t a b
 leadingDetachedComments
   = Lens.Labels.lensOf
@@ -289,14 +289,14 @@ leadingDetachedComments
          (Lens.Labels.Proxy#) "leadingDetachedComments")
 
 location ::
-         forall f s t a b . Lens.Labels.HasLens "location" f s t a b =>
+         forall f s t a b . Lens.Labels.HasLens f s t "location" a b =>
            Lens.Family2.LensLike f s t a b
 location
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "location")
 
 mapEntry ::
-         forall f s t a b . Lens.Labels.HasLens "mapEntry" f s t a b =>
+         forall f s t a b . Lens.Labels.HasLens f s t "mapEntry" a b =>
            Lens.Family2.LensLike f s t a b
 mapEntry
   = Lens.Labels.lensOf
@@ -304,7 +304,7 @@ mapEntry
 
 maybe'aggregateValue ::
                      forall f s t a b .
-                       Lens.Labels.HasLens "maybe'aggregateValue" f s t a b =>
+                       Lens.Labels.HasLens f s t "maybe'aggregateValue" a b =>
                        Lens.Family2.LensLike f s t a b
 maybe'aggregateValue
   = Lens.Labels.lensOf
@@ -313,14 +313,14 @@ maybe'aggregateValue
 
 maybe'allowAlias ::
                  forall f s t a b .
-                   Lens.Labels.HasLens "maybe'allowAlias" f s t a b =>
+                   Lens.Labels.HasLens f s t "maybe'allowAlias" a b =>
                    Lens.Family2.LensLike f s t a b
 maybe'allowAlias
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'allowAlias")
 
 maybe'begin ::
-            forall f s t a b . Lens.Labels.HasLens "maybe'begin" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "maybe'begin" a b =>
               Lens.Family2.LensLike f s t a b
 maybe'begin
   = Lens.Labels.lensOf
@@ -328,7 +328,7 @@ maybe'begin
 
 maybe'ccEnableArenas ::
                      forall f s t a b .
-                       Lens.Labels.HasLens "maybe'ccEnableArenas" f s t a b =>
+                       Lens.Labels.HasLens f s t "maybe'ccEnableArenas" a b =>
                        Lens.Family2.LensLike f s t a b
 maybe'ccEnableArenas
   = Lens.Labels.lensOf
@@ -337,7 +337,7 @@ maybe'ccEnableArenas
 
 maybe'ccGenericServices ::
                         forall f s t a b .
-                          Lens.Labels.HasLens "maybe'ccGenericServices" f s t a b =>
+                          Lens.Labels.HasLens f s t "maybe'ccGenericServices" a b =>
                           Lens.Family2.LensLike f s t a b
 maybe'ccGenericServices
   = Lens.Labels.lensOf
@@ -346,7 +346,7 @@ maybe'ccGenericServices
 
 maybe'clientStreaming ::
                       forall f s t a b .
-                        Lens.Labels.HasLens "maybe'clientStreaming" f s t a b =>
+                        Lens.Labels.HasLens f s t "maybe'clientStreaming" a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'clientStreaming
   = Lens.Labels.lensOf
@@ -355,7 +355,7 @@ maybe'clientStreaming
 
 maybe'csharpNamespace ::
                       forall f s t a b .
-                        Lens.Labels.HasLens "maybe'csharpNamespace" f s t a b =>
+                        Lens.Labels.HasLens f s t "maybe'csharpNamespace" a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'csharpNamespace
   = Lens.Labels.lensOf
@@ -363,7 +363,7 @@ maybe'csharpNamespace
          (Lens.Labels.Proxy#) "maybe'csharpNamespace")
 
 maybe'ctype ::
-            forall f s t a b . Lens.Labels.HasLens "maybe'ctype" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "maybe'ctype" a b =>
               Lens.Family2.LensLike f s t a b
 maybe'ctype
   = Lens.Labels.lensOf
@@ -371,7 +371,7 @@ maybe'ctype
 
 maybe'defaultValue ::
                    forall f s t a b .
-                     Lens.Labels.HasLens "maybe'defaultValue" f s t a b =>
+                     Lens.Labels.HasLens f s t "maybe'defaultValue" a b =>
                      Lens.Family2.LensLike f s t a b
 maybe'defaultValue
   = Lens.Labels.lensOf
@@ -379,7 +379,7 @@ maybe'defaultValue
 
 maybe'deprecated ::
                  forall f s t a b .
-                   Lens.Labels.HasLens "maybe'deprecated" f s t a b =>
+                   Lens.Labels.HasLens f s t "maybe'deprecated" a b =>
                    Lens.Family2.LensLike f s t a b
 maybe'deprecated
   = Lens.Labels.lensOf
@@ -387,14 +387,14 @@ maybe'deprecated
 
 maybe'doubleValue ::
                   forall f s t a b .
-                    Lens.Labels.HasLens "maybe'doubleValue" f s t a b =>
+                    Lens.Labels.HasLens f s t "maybe'doubleValue" a b =>
                     Lens.Family2.LensLike f s t a b
 maybe'doubleValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'doubleValue")
 
 maybe'end ::
-          forall f s t a b . Lens.Labels.HasLens "maybe'end" f s t a b =>
+          forall f s t a b . Lens.Labels.HasLens f s t "maybe'end" a b =>
             Lens.Family2.LensLike f s t a b
 maybe'end
   = Lens.Labels.lensOf
@@ -402,7 +402,7 @@ maybe'end
 
 maybe'extendee ::
                forall f s t a b .
-                 Lens.Labels.HasLens "maybe'extendee" f s t a b =>
+                 Lens.Labels.HasLens f s t "maybe'extendee" a b =>
                  Lens.Family2.LensLike f s t a b
 maybe'extendee
   = Lens.Labels.lensOf
@@ -410,7 +410,7 @@ maybe'extendee
 
 maybe'goPackage ::
                 forall f s t a b .
-                  Lens.Labels.HasLens "maybe'goPackage" f s t a b =>
+                  Lens.Labels.HasLens f s t "maybe'goPackage" a b =>
                   Lens.Family2.LensLike f s t a b
 maybe'goPackage
   = Lens.Labels.lensOf
@@ -418,7 +418,7 @@ maybe'goPackage
 
 maybe'identifierValue ::
                       forall f s t a b .
-                        Lens.Labels.HasLens "maybe'identifierValue" f s t a b =>
+                        Lens.Labels.HasLens f s t "maybe'identifierValue" a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'identifierValue
   = Lens.Labels.lensOf
@@ -427,7 +427,7 @@ maybe'identifierValue
 
 maybe'inputType ::
                 forall f s t a b .
-                  Lens.Labels.HasLens "maybe'inputType" f s t a b =>
+                  Lens.Labels.HasLens f s t "maybe'inputType" a b =>
                   Lens.Family2.LensLike f s t a b
 maybe'inputType
   = Lens.Labels.lensOf
@@ -435,7 +435,7 @@ maybe'inputType
 
 maybe'javaGenerateEqualsAndHash ::
                                 forall f s t a b .
-                                  Lens.Labels.HasLens "maybe'javaGenerateEqualsAndHash" f s t a b =>
+                                  Lens.Labels.HasLens f s t "maybe'javaGenerateEqualsAndHash" a b =>
                                   Lens.Family2.LensLike f s t a b
 maybe'javaGenerateEqualsAndHash
   = Lens.Labels.lensOf
@@ -444,7 +444,7 @@ maybe'javaGenerateEqualsAndHash
 
 maybe'javaGenericServices ::
                           forall f s t a b .
-                            Lens.Labels.HasLens "maybe'javaGenericServices" f s t a b =>
+                            Lens.Labels.HasLens f s t "maybe'javaGenericServices" a b =>
                             Lens.Family2.LensLike f s t a b
 maybe'javaGenericServices
   = Lens.Labels.lensOf
@@ -453,7 +453,7 @@ maybe'javaGenericServices
 
 maybe'javaMultipleFiles ::
                         forall f s t a b .
-                          Lens.Labels.HasLens "maybe'javaMultipleFiles" f s t a b =>
+                          Lens.Labels.HasLens f s t "maybe'javaMultipleFiles" a b =>
                           Lens.Family2.LensLike f s t a b
 maybe'javaMultipleFiles
   = Lens.Labels.lensOf
@@ -462,7 +462,7 @@ maybe'javaMultipleFiles
 
 maybe'javaOuterClassname ::
                          forall f s t a b .
-                           Lens.Labels.HasLens "maybe'javaOuterClassname" f s t a b =>
+                           Lens.Labels.HasLens f s t "maybe'javaOuterClassname" a b =>
                            Lens.Family2.LensLike f s t a b
 maybe'javaOuterClassname
   = Lens.Labels.lensOf
@@ -471,7 +471,7 @@ maybe'javaOuterClassname
 
 maybe'javaPackage ::
                   forall f s t a b .
-                    Lens.Labels.HasLens "maybe'javaPackage" f s t a b =>
+                    Lens.Labels.HasLens f s t "maybe'javaPackage" a b =>
                     Lens.Family2.LensLike f s t a b
 maybe'javaPackage
   = Lens.Labels.lensOf
@@ -479,7 +479,7 @@ maybe'javaPackage
 
 maybe'javaStringCheckUtf8 ::
                           forall f s t a b .
-                            Lens.Labels.HasLens "maybe'javaStringCheckUtf8" f s t a b =>
+                            Lens.Labels.HasLens f s t "maybe'javaStringCheckUtf8" a b =>
                             Lens.Family2.LensLike f s t a b
 maybe'javaStringCheckUtf8
   = Lens.Labels.lensOf
@@ -488,28 +488,28 @@ maybe'javaStringCheckUtf8
 
 maybe'jsonName ::
                forall f s t a b .
-                 Lens.Labels.HasLens "maybe'jsonName" f s t a b =>
+                 Lens.Labels.HasLens f s t "maybe'jsonName" a b =>
                  Lens.Family2.LensLike f s t a b
 maybe'jsonName
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'jsonName")
 
 maybe'jstype ::
-             forall f s t a b . Lens.Labels.HasLens "maybe'jstype" f s t a b =>
+             forall f s t a b . Lens.Labels.HasLens f s t "maybe'jstype" a b =>
                Lens.Family2.LensLike f s t a b
 maybe'jstype
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'jstype")
 
 maybe'label ::
-            forall f s t a b . Lens.Labels.HasLens "maybe'label" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "maybe'label" a b =>
               Lens.Family2.LensLike f s t a b
 maybe'label
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'label")
 
 maybe'lazy ::
-           forall f s t a b . Lens.Labels.HasLens "maybe'lazy" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "maybe'lazy" a b =>
              Lens.Family2.LensLike f s t a b
 maybe'lazy
   = Lens.Labels.lensOf
@@ -517,7 +517,7 @@ maybe'lazy
 
 maybe'leadingComments ::
                       forall f s t a b .
-                        Lens.Labels.HasLens "maybe'leadingComments" f s t a b =>
+                        Lens.Labels.HasLens f s t "maybe'leadingComments" a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'leadingComments
   = Lens.Labels.lensOf
@@ -526,7 +526,7 @@ maybe'leadingComments
 
 maybe'mapEntry ::
                forall f s t a b .
-                 Lens.Labels.HasLens "maybe'mapEntry" f s t a b =>
+                 Lens.Labels.HasLens f s t "maybe'mapEntry" a b =>
                  Lens.Family2.LensLike f s t a b
 maybe'mapEntry
   = Lens.Labels.lensOf
@@ -534,7 +534,7 @@ maybe'mapEntry
 
 maybe'messageSetWireFormat ::
                            forall f s t a b .
-                             Lens.Labels.HasLens "maybe'messageSetWireFormat" f s t a b =>
+                             Lens.Labels.HasLens f s t "maybe'messageSetWireFormat" a b =>
                              Lens.Family2.LensLike f s t a b
 maybe'messageSetWireFormat
   = Lens.Labels.lensOf
@@ -542,7 +542,7 @@ maybe'messageSetWireFormat
          (Lens.Labels.Proxy#) "maybe'messageSetWireFormat")
 
 maybe'name ::
-           forall f s t a b . Lens.Labels.HasLens "maybe'name" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "maybe'name" a b =>
              Lens.Family2.LensLike f s t a b
 maybe'name
   = Lens.Labels.lensOf
@@ -550,7 +550,7 @@ maybe'name
 
 maybe'negativeIntValue ::
                        forall f s t a b .
-                         Lens.Labels.HasLens "maybe'negativeIntValue" f s t a b =>
+                         Lens.Labels.HasLens f s t "maybe'negativeIntValue" a b =>
                          Lens.Family2.LensLike f s t a b
 maybe'negativeIntValue
   = Lens.Labels.lensOf
@@ -559,7 +559,7 @@ maybe'negativeIntValue
 
 maybe'noStandardDescriptorAccessor ::
                                    forall f s t a b .
-                                     Lens.Labels.HasLens "maybe'noStandardDescriptorAccessor" f s t
+                                     Lens.Labels.HasLens f s t "maybe'noStandardDescriptorAccessor"
                                        a b =>
                                      Lens.Family2.LensLike f s t a b
 maybe'noStandardDescriptorAccessor
@@ -568,7 +568,7 @@ maybe'noStandardDescriptorAccessor
          (Lens.Labels.Proxy#) "maybe'noStandardDescriptorAccessor")
 
 maybe'number ::
-             forall f s t a b . Lens.Labels.HasLens "maybe'number" f s t a b =>
+             forall f s t a b . Lens.Labels.HasLens f s t "maybe'number" a b =>
                Lens.Family2.LensLike f s t a b
 maybe'number
   = Lens.Labels.lensOf
@@ -576,7 +576,7 @@ maybe'number
 
 maybe'objcClassPrefix ::
                       forall f s t a b .
-                        Lens.Labels.HasLens "maybe'objcClassPrefix" f s t a b =>
+                        Lens.Labels.HasLens f s t "maybe'objcClassPrefix" a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'objcClassPrefix
   = Lens.Labels.lensOf
@@ -585,7 +585,7 @@ maybe'objcClassPrefix
 
 maybe'oneofIndex ::
                  forall f s t a b .
-                   Lens.Labels.HasLens "maybe'oneofIndex" f s t a b =>
+                   Lens.Labels.HasLens f s t "maybe'oneofIndex" a b =>
                    Lens.Family2.LensLike f s t a b
 maybe'oneofIndex
   = Lens.Labels.lensOf
@@ -593,14 +593,14 @@ maybe'oneofIndex
 
 maybe'optimizeFor ::
                   forall f s t a b .
-                    Lens.Labels.HasLens "maybe'optimizeFor" f s t a b =>
+                    Lens.Labels.HasLens f s t "maybe'optimizeFor" a b =>
                     Lens.Family2.LensLike f s t a b
 maybe'optimizeFor
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'optimizeFor")
 
 maybe'options ::
-              forall f s t a b . Lens.Labels.HasLens "maybe'options" f s t a b =>
+              forall f s t a b . Lens.Labels.HasLens f s t "maybe'options" a b =>
                 Lens.Family2.LensLike f s t a b
 maybe'options
   = Lens.Labels.lensOf
@@ -608,21 +608,21 @@ maybe'options
 
 maybe'outputType ::
                  forall f s t a b .
-                   Lens.Labels.HasLens "maybe'outputType" f s t a b =>
+                   Lens.Labels.HasLens f s t "maybe'outputType" a b =>
                    Lens.Family2.LensLike f s t a b
 maybe'outputType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'outputType")
 
 maybe'package ::
-              forall f s t a b . Lens.Labels.HasLens "maybe'package" f s t a b =>
+              forall f s t a b . Lens.Labels.HasLens f s t "maybe'package" a b =>
                 Lens.Family2.LensLike f s t a b
 maybe'package
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'package")
 
 maybe'packed ::
-             forall f s t a b . Lens.Labels.HasLens "maybe'packed" f s t a b =>
+             forall f s t a b . Lens.Labels.HasLens f s t "maybe'packed" a b =>
                Lens.Family2.LensLike f s t a b
 maybe'packed
   = Lens.Labels.lensOf
@@ -630,7 +630,7 @@ maybe'packed
 
 maybe'positiveIntValue ::
                        forall f s t a b .
-                         Lens.Labels.HasLens "maybe'positiveIntValue" f s t a b =>
+                         Lens.Labels.HasLens f s t "maybe'positiveIntValue" a b =>
                          Lens.Family2.LensLike f s t a b
 maybe'positiveIntValue
   = Lens.Labels.lensOf
@@ -639,7 +639,7 @@ maybe'positiveIntValue
 
 maybe'pyGenericServices ::
                         forall f s t a b .
-                          Lens.Labels.HasLens "maybe'pyGenericServices" f s t a b =>
+                          Lens.Labels.HasLens f s t "maybe'pyGenericServices" a b =>
                           Lens.Family2.LensLike f s t a b
 maybe'pyGenericServices
   = Lens.Labels.lensOf
@@ -648,7 +648,7 @@ maybe'pyGenericServices
 
 maybe'serverStreaming ::
                       forall f s t a b .
-                        Lens.Labels.HasLens "maybe'serverStreaming" f s t a b =>
+                        Lens.Labels.HasLens f s t "maybe'serverStreaming" a b =>
                         Lens.Family2.LensLike f s t a b
 maybe'serverStreaming
   = Lens.Labels.lensOf
@@ -657,7 +657,7 @@ maybe'serverStreaming
 
 maybe'sourceCodeInfo ::
                      forall f s t a b .
-                       Lens.Labels.HasLens "maybe'sourceCodeInfo" f s t a b =>
+                       Lens.Labels.HasLens f s t "maybe'sourceCodeInfo" a b =>
                        Lens.Family2.LensLike f s t a b
 maybe'sourceCodeInfo
   = Lens.Labels.lensOf
@@ -666,14 +666,14 @@ maybe'sourceCodeInfo
 
 maybe'sourceFile ::
                  forall f s t a b .
-                   Lens.Labels.HasLens "maybe'sourceFile" f s t a b =>
+                   Lens.Labels.HasLens f s t "maybe'sourceFile" a b =>
                    Lens.Family2.LensLike f s t a b
 maybe'sourceFile
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'sourceFile")
 
 maybe'start ::
-            forall f s t a b . Lens.Labels.HasLens "maybe'start" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "maybe'start" a b =>
               Lens.Family2.LensLike f s t a b
 maybe'start
   = Lens.Labels.lensOf
@@ -681,14 +681,14 @@ maybe'start
 
 maybe'stringValue ::
                   forall f s t a b .
-                    Lens.Labels.HasLens "maybe'stringValue" f s t a b =>
+                    Lens.Labels.HasLens f s t "maybe'stringValue" a b =>
                     Lens.Family2.LensLike f s t a b
 maybe'stringValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'stringValue")
 
 maybe'syntax ::
-             forall f s t a b . Lens.Labels.HasLens "maybe'syntax" f s t a b =>
+             forall f s t a b . Lens.Labels.HasLens f s t "maybe'syntax" a b =>
                Lens.Family2.LensLike f s t a b
 maybe'syntax
   = Lens.Labels.lensOf
@@ -696,7 +696,7 @@ maybe'syntax
 
 maybe'trailingComments ::
                        forall f s t a b .
-                         Lens.Labels.HasLens "maybe'trailingComments" f s t a b =>
+                         Lens.Labels.HasLens f s t "maybe'trailingComments" a b =>
                          Lens.Family2.LensLike f s t a b
 maybe'trailingComments
   = Lens.Labels.lensOf
@@ -704,7 +704,7 @@ maybe'trailingComments
          (Lens.Labels.Proxy#) "maybe'trailingComments")
 
 maybe'type' ::
-            forall f s t a b . Lens.Labels.HasLens "maybe'type'" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "maybe'type'" a b =>
               Lens.Family2.LensLike f s t a b
 maybe'type'
   = Lens.Labels.lensOf
@@ -712,14 +712,14 @@ maybe'type'
 
 maybe'typeName ::
                forall f s t a b .
-                 Lens.Labels.HasLens "maybe'typeName" f s t a b =>
+                 Lens.Labels.HasLens f s t "maybe'typeName" a b =>
                  Lens.Family2.LensLike f s t a b
 maybe'typeName
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'typeName")
 
 maybe'weak ::
-           forall f s t a b . Lens.Labels.HasLens "maybe'weak" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "maybe'weak" a b =>
              Lens.Family2.LensLike f s t a b
 maybe'weak
   = Lens.Labels.lensOf
@@ -727,7 +727,7 @@ maybe'weak
 
 messageSetWireFormat ::
                      forall f s t a b .
-                       Lens.Labels.HasLens "messageSetWireFormat" f s t a b =>
+                       Lens.Labels.HasLens f s t "messageSetWireFormat" a b =>
                        Lens.Family2.LensLike f s t a b
 messageSetWireFormat
   = Lens.Labels.lensOf
@@ -735,28 +735,28 @@ messageSetWireFormat
          (Lens.Labels.Proxy#) "messageSetWireFormat")
 
 messageType ::
-            forall f s t a b . Lens.Labels.HasLens "messageType" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "messageType" a b =>
               Lens.Family2.LensLike f s t a b
 messageType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "messageType")
 
 method ::
-       forall f s t a b . Lens.Labels.HasLens "method" f s t a b =>
+       forall f s t a b . Lens.Labels.HasLens f s t "method" a b =>
          Lens.Family2.LensLike f s t a b
 method
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "method")
 
 name ::
-     forall f s t a b . Lens.Labels.HasLens "name" f s t a b =>
+     forall f s t a b . Lens.Labels.HasLens f s t "name" a b =>
        Lens.Family2.LensLike f s t a b
 name
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "name")
 
 namePart ::
-         forall f s t a b . Lens.Labels.HasLens "namePart" f s t a b =>
+         forall f s t a b . Lens.Labels.HasLens f s t "namePart" a b =>
            Lens.Family2.LensLike f s t a b
 namePart
   = Lens.Labels.lensOf
@@ -764,14 +764,14 @@ namePart
 
 negativeIntValue ::
                  forall f s t a b .
-                   Lens.Labels.HasLens "negativeIntValue" f s t a b =>
+                   Lens.Labels.HasLens f s t "negativeIntValue" a b =>
                    Lens.Family2.LensLike f s t a b
 negativeIntValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "negativeIntValue")
 
 nestedType ::
-           forall f s t a b . Lens.Labels.HasLens "nestedType" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "nestedType" a b =>
              Lens.Family2.LensLike f s t a b
 nestedType
   = Lens.Labels.lensOf
@@ -779,7 +779,7 @@ nestedType
 
 noStandardDescriptorAccessor ::
                              forall f s t a b .
-                               Lens.Labels.HasLens "noStandardDescriptorAccessor" f s t a b =>
+                               Lens.Labels.HasLens f s t "noStandardDescriptorAccessor" a b =>
                                Lens.Family2.LensLike f s t a b
 noStandardDescriptorAccessor
   = Lens.Labels.lensOf
@@ -787,7 +787,7 @@ noStandardDescriptorAccessor
          (Lens.Labels.Proxy#) "noStandardDescriptorAccessor")
 
 number ::
-       forall f s t a b . Lens.Labels.HasLens "number" f s t a b =>
+       forall f s t a b . Lens.Labels.HasLens f s t "number" a b =>
          Lens.Family2.LensLike f s t a b
 number
   = Lens.Labels.lensOf
@@ -795,63 +795,63 @@ number
 
 objcClassPrefix ::
                 forall f s t a b .
-                  Lens.Labels.HasLens "objcClassPrefix" f s t a b =>
+                  Lens.Labels.HasLens f s t "objcClassPrefix" a b =>
                   Lens.Family2.LensLike f s t a b
 objcClassPrefix
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "objcClassPrefix")
 
 oneofDecl ::
-          forall f s t a b . Lens.Labels.HasLens "oneofDecl" f s t a b =>
+          forall f s t a b . Lens.Labels.HasLens f s t "oneofDecl" a b =>
             Lens.Family2.LensLike f s t a b
 oneofDecl
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "oneofDecl")
 
 oneofIndex ::
-           forall f s t a b . Lens.Labels.HasLens "oneofIndex" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "oneofIndex" a b =>
              Lens.Family2.LensLike f s t a b
 oneofIndex
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "oneofIndex")
 
 optimizeFor ::
-            forall f s t a b . Lens.Labels.HasLens "optimizeFor" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "optimizeFor" a b =>
               Lens.Family2.LensLike f s t a b
 optimizeFor
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "optimizeFor")
 
 options ::
-        forall f s t a b . Lens.Labels.HasLens "options" f s t a b =>
+        forall f s t a b . Lens.Labels.HasLens f s t "options" a b =>
           Lens.Family2.LensLike f s t a b
 options
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "options")
 
 outputType ::
-           forall f s t a b . Lens.Labels.HasLens "outputType" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "outputType" a b =>
              Lens.Family2.LensLike f s t a b
 outputType
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "outputType")
 
 package ::
-        forall f s t a b . Lens.Labels.HasLens "package" f s t a b =>
+        forall f s t a b . Lens.Labels.HasLens f s t "package" a b =>
           Lens.Family2.LensLike f s t a b
 package
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "package")
 
 packed ::
-       forall f s t a b . Lens.Labels.HasLens "packed" f s t a b =>
+       forall f s t a b . Lens.Labels.HasLens f s t "packed" a b =>
          Lens.Family2.LensLike f s t a b
 packed
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "packed")
 
 path ::
-     forall f s t a b . Lens.Labels.HasLens "path" f s t a b =>
+     forall f s t a b . Lens.Labels.HasLens f s t "path" a b =>
        Lens.Family2.LensLike f s t a b
 path
   = Lens.Labels.lensOf
@@ -859,7 +859,7 @@ path
 
 positiveIntValue ::
                  forall f s t a b .
-                   Lens.Labels.HasLens "positiveIntValue" f s t a b =>
+                   Lens.Labels.HasLens f s t "positiveIntValue" a b =>
                    Lens.Family2.LensLike f s t a b
 positiveIntValue
   = Lens.Labels.lensOf
@@ -867,7 +867,7 @@ positiveIntValue
 
 publicDependency ::
                  forall f s t a b .
-                   Lens.Labels.HasLens "publicDependency" f s t a b =>
+                   Lens.Labels.HasLens f s t "publicDependency" a b =>
                    Lens.Family2.LensLike f s t a b
 publicDependency
   = Lens.Labels.lensOf
@@ -875,21 +875,21 @@ publicDependency
 
 pyGenericServices ::
                   forall f s t a b .
-                    Lens.Labels.HasLens "pyGenericServices" f s t a b =>
+                    Lens.Labels.HasLens f s t "pyGenericServices" a b =>
                     Lens.Family2.LensLike f s t a b
 pyGenericServices
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "pyGenericServices")
 
 reservedName ::
-             forall f s t a b . Lens.Labels.HasLens "reservedName" f s t a b =>
+             forall f s t a b . Lens.Labels.HasLens f s t "reservedName" a b =>
                Lens.Family2.LensLike f s t a b
 reservedName
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "reservedName")
 
 reservedRange ::
-              forall f s t a b . Lens.Labels.HasLens "reservedRange" f s t a b =>
+              forall f s t a b . Lens.Labels.HasLens f s t "reservedRange" a b =>
                 Lens.Family2.LensLike f s t a b
 reservedRange
   = Lens.Labels.lensOf
@@ -897,14 +897,14 @@ reservedRange
 
 serverStreaming ::
                 forall f s t a b .
-                  Lens.Labels.HasLens "serverStreaming" f s t a b =>
+                  Lens.Labels.HasLens f s t "serverStreaming" a b =>
                   Lens.Family2.LensLike f s t a b
 serverStreaming
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "serverStreaming")
 
 service ::
-        forall f s t a b . Lens.Labels.HasLens "service" f s t a b =>
+        forall f s t a b . Lens.Labels.HasLens f s t "service" a b =>
           Lens.Family2.LensLike f s t a b
 service
   = Lens.Labels.lensOf
@@ -912,42 +912,42 @@ service
 
 sourceCodeInfo ::
                forall f s t a b .
-                 Lens.Labels.HasLens "sourceCodeInfo" f s t a b =>
+                 Lens.Labels.HasLens f s t "sourceCodeInfo" a b =>
                  Lens.Family2.LensLike f s t a b
 sourceCodeInfo
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "sourceCodeInfo")
 
 sourceFile ::
-           forall f s t a b . Lens.Labels.HasLens "sourceFile" f s t a b =>
+           forall f s t a b . Lens.Labels.HasLens f s t "sourceFile" a b =>
              Lens.Family2.LensLike f s t a b
 sourceFile
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "sourceFile")
 
 span ::
-     forall f s t a b . Lens.Labels.HasLens "span" f s t a b =>
+     forall f s t a b . Lens.Labels.HasLens f s t "span" a b =>
        Lens.Family2.LensLike f s t a b
 span
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "span")
 
 start ::
-      forall f s t a b . Lens.Labels.HasLens "start" f s t a b =>
+      forall f s t a b . Lens.Labels.HasLens f s t "start" a b =>
         Lens.Family2.LensLike f s t a b
 start
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "start")
 
 stringValue ::
-            forall f s t a b . Lens.Labels.HasLens "stringValue" f s t a b =>
+            forall f s t a b . Lens.Labels.HasLens f s t "stringValue" a b =>
               Lens.Family2.LensLike f s t a b
 stringValue
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "stringValue")
 
 syntax ::
-       forall f s t a b . Lens.Labels.HasLens "syntax" f s t a b =>
+       forall f s t a b . Lens.Labels.HasLens f s t "syntax" a b =>
          Lens.Family2.LensLike f s t a b
 syntax
   = Lens.Labels.lensOf
@@ -955,21 +955,21 @@ syntax
 
 trailingComments ::
                  forall f s t a b .
-                   Lens.Labels.HasLens "trailingComments" f s t a b =>
+                   Lens.Labels.HasLens f s t "trailingComments" a b =>
                    Lens.Family2.LensLike f s t a b
 trailingComments
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "trailingComments")
 
 type' ::
-      forall f s t a b . Lens.Labels.HasLens "type'" f s t a b =>
+      forall f s t a b . Lens.Labels.HasLens f s t "type'" a b =>
         Lens.Family2.LensLike f s t a b
 type'
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "type'")
 
 typeName ::
-         forall f s t a b . Lens.Labels.HasLens "typeName" f s t a b =>
+         forall f s t a b . Lens.Labels.HasLens f s t "typeName" a b =>
            Lens.Family2.LensLike f s t a b
 typeName
   = Lens.Labels.lensOf
@@ -977,7 +977,7 @@ typeName
 
 uninterpretedOption ::
                     forall f s t a b .
-                      Lens.Labels.HasLens "uninterpretedOption" f s t a b =>
+                      Lens.Labels.HasLens f s t "uninterpretedOption" a b =>
                       Lens.Family2.LensLike f s t a b
 uninterpretedOption
   = Lens.Labels.lensOf
@@ -985,14 +985,14 @@ uninterpretedOption
          (Lens.Labels.Proxy#) "uninterpretedOption")
 
 value ::
-      forall f s t a b . Lens.Labels.HasLens "value" f s t a b =>
+      forall f s t a b . Lens.Labels.HasLens f s t "value" a b =>
         Lens.Family2.LensLike f s t a b
 value
   = Lens.Labels.lensOf
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "value")
 
 weak ::
-     forall f s t a b . Lens.Labels.HasLens "weak" f s t a b =>
+     forall f s t a b . Lens.Labels.HasLens f s t "weak" a b =>
        Lens.Family2.LensLike f s t a b
 weak
   = Lens.Labels.lensOf
@@ -1000,7 +1000,7 @@ weak
 
 weakDependency ::
                forall f s t a b .
-                 Lens.Labels.HasLens "weakDependency" f s t a b =>
+                 Lens.Labels.HasLens f s t "weakDependency" a b =>
                  Lens.Family2.LensLike f s t a b
 weakDependency
   = Lens.Labels.lensOf

--- a/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens-descriptors/src/Proto/Google/Protobuf/Descriptor.hs
@@ -33,121 +33,104 @@ data DescriptorProto = DescriptorProto{_DescriptorProto'name ::
                                        _DescriptorProto'reservedName :: ![Data.Text.Text]}
                      deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "name" f DescriptorProto DescriptorProto a b
-         where
-        lensOf _
+instance (Lens.Labels.HasLens' f DescriptorProto x a, a ~ b) =>
+         Lens.Labels.HasLens f DescriptorProto DescriptorProto x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "name" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'name
                  (\ x__ y__ -> x__{_DescriptorProto'name = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'name" f DescriptorProto DescriptorProto
-         a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "maybe'name" (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'name
                  (\ x__ y__ -> x__{_DescriptorProto'name = y__}))
               Prelude.id
 
-instance (a ~ [FieldDescriptorProto], b ~ [FieldDescriptorProto],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "field" f DescriptorProto DescriptorProto a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "field" ([FieldDescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'field
                  (\ x__ y__ -> x__{_DescriptorProto'field = y__}))
               Prelude.id
 
-instance (a ~ [FieldDescriptorProto], b ~ [FieldDescriptorProto],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "extension" f DescriptorProto DescriptorProto a
-         b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "extension" ([FieldDescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'extension
                  (\ x__ y__ -> x__{_DescriptorProto'extension = y__}))
               Prelude.id
 
-instance (a ~ [DescriptorProto], b ~ [DescriptorProto],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "nestedType" f DescriptorProto DescriptorProto
-         a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "nestedType" ([DescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'nestedType
                  (\ x__ y__ -> x__{_DescriptorProto'nestedType = y__}))
               Prelude.id
 
-instance (a ~ [EnumDescriptorProto], b ~ [EnumDescriptorProto],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "enumType" f DescriptorProto DescriptorProto a
-         b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "enumType" ([EnumDescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'enumType
                  (\ x__ y__ -> x__{_DescriptorProto'enumType = y__}))
               Prelude.id
 
-instance (a ~ [DescriptorProto'ExtensionRange],
-          b ~ [DescriptorProto'ExtensionRange], Prelude.Functor f) =>
-         Lens.Labels.HasLens "extensionRange" f DescriptorProto
-         DescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "extensionRange" ([DescriptorProto'ExtensionRange])
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'extensionRange
                  (\ x__ y__ -> x__{_DescriptorProto'extensionRange = y__}))
               Prelude.id
 
-instance (a ~ [OneofDescriptorProto], b ~ [OneofDescriptorProto],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "oneofDecl" f DescriptorProto DescriptorProto a
-         b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "oneofDecl" ([OneofDescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'oneofDecl
                  (\ x__ y__ -> x__{_DescriptorProto'oneofDecl = y__}))
               Prelude.id
 
-instance (a ~ MessageOptions, b ~ MessageOptions,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "options" f DescriptorProto DescriptorProto a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "options" (MessageOptions) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'options
                  (\ x__ y__ -> x__{_DescriptorProto'options = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
-instance (a ~ Prelude.Maybe MessageOptions,
-          b ~ Prelude.Maybe MessageOptions, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'options" f DescriptorProto
-         DescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "maybe'options" (Prelude.Maybe MessageOptions)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'options
                  (\ x__ y__ -> x__{_DescriptorProto'options = y__}))
               Prelude.id
 
-instance (a ~ [DescriptorProto'ReservedRange],
-          b ~ [DescriptorProto'ReservedRange], Prelude.Functor f) =>
-         Lens.Labels.HasLens "reservedRange" f DescriptorProto
-         DescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "reservedRange" ([DescriptorProto'ReservedRange])
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'reservedRange
                  (\ x__ y__ -> x__{_DescriptorProto'reservedRange = y__}))
               Prelude.id
 
-instance (a ~ [Data.Text.Text], b ~ [Data.Text.Text],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "reservedName" f DescriptorProto
-         DescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto "reservedName" ([Data.Text.Text]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'reservedName
                  (\ x__ y__ -> x__{_DescriptorProto'reservedName = y__}))
@@ -282,41 +265,42 @@ data DescriptorProto'ExtensionRange = DescriptorProto'ExtensionRange{_Descriptor
                                                                          Data.Int.Int32)}
                                     deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "start" f DescriptorProto'ExtensionRange
-         DescriptorProto'ExtensionRange a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f DescriptorProto'ExtensionRange x
+            a,
+          a ~ b) =>
+         Lens.Labels.HasLens f DescriptorProto'ExtensionRange
+         DescriptorProto'ExtensionRange x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto'ExtensionRange "start" (Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'ExtensionRange'start
                  (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'start = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Int.Int32,
-          b ~ Prelude.Maybe Data.Int.Int32, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'start" f DescriptorProto'ExtensionRange
-         DescriptorProto'ExtensionRange a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto'ExtensionRange "maybe'start"
+         (Prelude.Maybe Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'ExtensionRange'start
                  (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'start = y__}))
               Prelude.id
 
-instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "end" f DescriptorProto'ExtensionRange
-         DescriptorProto'ExtensionRange a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto'ExtensionRange "end" (Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'ExtensionRange'end
                  (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'end = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Int.Int32,
-          b ~ Prelude.Maybe Data.Int.Int32, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'end" f DescriptorProto'ExtensionRange
-         DescriptorProto'ExtensionRange a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto'ExtensionRange "maybe'end"
+         (Prelude.Maybe Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'ExtensionRange'end
                  (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'end = y__}))
@@ -366,41 +350,41 @@ data DescriptorProto'ReservedRange = DescriptorProto'ReservedRange{_DescriptorPr
                                                                    !(Prelude.Maybe Data.Int.Int32)}
                                    deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "start" f DescriptorProto'ReservedRange
-         DescriptorProto'ReservedRange a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f DescriptorProto'ReservedRange x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f DescriptorProto'ReservedRange
+         DescriptorProto'ReservedRange x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto'ReservedRange "start" (Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'start
                  (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'start = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Int.Int32,
-          b ~ Prelude.Maybe Data.Int.Int32, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'start" f DescriptorProto'ReservedRange
-         DescriptorProto'ReservedRange a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto'ReservedRange "maybe'start"
+         (Prelude.Maybe Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'start
                  (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'start = y__}))
               Prelude.id
 
-instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "end" f DescriptorProto'ReservedRange
-         DescriptorProto'ReservedRange a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto'ReservedRange "end" (Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'end
                  (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'end = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Int.Int32,
-          b ~ Prelude.Maybe Data.Int.Int32, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'end" f DescriptorProto'ReservedRange
-         DescriptorProto'ReservedRange a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         DescriptorProto'ReservedRange "maybe'end"
+         (Prelude.Maybe Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'end
                  (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'end = y__}))
@@ -449,50 +433,48 @@ data EnumDescriptorProto = EnumDescriptorProto{_EnumDescriptorProto'name
                                                !(Prelude.Maybe EnumOptions)}
                          deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "name" f EnumDescriptorProto
-         EnumDescriptorProto a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f EnumDescriptorProto x a, a ~ b) =>
+         Lens.Labels.HasLens f EnumDescriptorProto EnumDescriptorProto x a b
+         where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumDescriptorProto "name" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumDescriptorProto'name
                  (\ x__ y__ -> x__{_EnumDescriptorProto'name = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'name" f EnumDescriptorProto
-         EnumDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumDescriptorProto "maybe'name" (Prelude.Maybe Data.Text.Text)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumDescriptorProto'name
                  (\ x__ y__ -> x__{_EnumDescriptorProto'name = y__}))
               Prelude.id
 
-instance (a ~ [EnumValueDescriptorProto],
-          b ~ [EnumValueDescriptorProto], Prelude.Functor f) =>
-         Lens.Labels.HasLens "value" f EnumDescriptorProto
-         EnumDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumDescriptorProto "value" ([EnumValueDescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumDescriptorProto'value
                  (\ x__ y__ -> x__{_EnumDescriptorProto'value = y__}))
               Prelude.id
 
-instance (a ~ EnumOptions, b ~ EnumOptions, Prelude.Functor f) =>
-         Lens.Labels.HasLens "options" f EnumDescriptorProto
-         EnumDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumDescriptorProto "options" (EnumOptions) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumDescriptorProto'options
                  (\ x__ y__ -> x__{_EnumDescriptorProto'options = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
-instance (a ~ Prelude.Maybe EnumOptions,
-          b ~ Prelude.Maybe EnumOptions, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'options" f EnumDescriptorProto
-         EnumDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumDescriptorProto "maybe'options" (Prelude.Maybe EnumOptions)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumDescriptorProto'options
                  (\ x__ y__ -> x__{_EnumDescriptorProto'options = y__}))
@@ -548,49 +530,45 @@ data EnumOptions = EnumOptions{_EnumOptions'allowAlias ::
                                _EnumOptions'uninterpretedOption :: ![UninterpretedOption]}
                  deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "allowAlias" f EnumOptions EnumOptions a b
-         where
-        lensOf _
+instance (Lens.Labels.HasLens' f EnumOptions x a, a ~ b) =>
+         Lens.Labels.HasLens f EnumOptions EnumOptions x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f EnumOptions
+         "allowAlias" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumOptions'allowAlias
                  (\ x__ y__ -> x__{_EnumOptions'allowAlias = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'allowAlias" f EnumOptions EnumOptions a
-         b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f EnumOptions
+         "maybe'allowAlias" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumOptions'allowAlias
                  (\ x__ y__ -> x__{_EnumOptions'allowAlias = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "deprecated" f EnumOptions EnumOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f EnumOptions
+         "deprecated" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumOptions'deprecated
                  (\ x__ y__ -> x__{_EnumOptions'deprecated = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'deprecated" f EnumOptions EnumOptions a
-         b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f EnumOptions
+         "maybe'deprecated" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumOptions'deprecated
                  (\ x__ y__ -> x__{_EnumOptions'deprecated = y__}))
               Prelude.id
 
-instance (a ~ [UninterpretedOption], b ~ [UninterpretedOption],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "uninterpretedOption" f EnumOptions EnumOptions
-         a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f EnumOptions
+         "uninterpretedOption" ([UninterpretedOption]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumOptions'uninterpretedOption
                  (\ x__ y__ -> x__{_EnumOptions'uninterpretedOption = y__}))
@@ -649,61 +627,58 @@ data EnumValueDescriptorProto = EnumValueDescriptorProto{_EnumValueDescriptorPro
                                                          !(Prelude.Maybe EnumValueOptions)}
                               deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "name" f EnumValueDescriptorProto
-         EnumValueDescriptorProto a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f EnumValueDescriptorProto x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f EnumValueDescriptorProto
+         EnumValueDescriptorProto x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumValueDescriptorProto "name" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'name
                  (\ x__ y__ -> x__{_EnumValueDescriptorProto'name = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'name" f EnumValueDescriptorProto
-         EnumValueDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumValueDescriptorProto "maybe'name"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'name
                  (\ x__ y__ -> x__{_EnumValueDescriptorProto'name = y__}))
               Prelude.id
 
-instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "number" f EnumValueDescriptorProto
-         EnumValueDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumValueDescriptorProto "number" (Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'number
                  (\ x__ y__ -> x__{_EnumValueDescriptorProto'number = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Int.Int32,
-          b ~ Prelude.Maybe Data.Int.Int32, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'number" f EnumValueDescriptorProto
-         EnumValueDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumValueDescriptorProto "maybe'number"
+         (Prelude.Maybe Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'number
                  (\ x__ y__ -> x__{_EnumValueDescriptorProto'number = y__}))
               Prelude.id
 
-instance (a ~ EnumValueOptions, b ~ EnumValueOptions,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "options" f EnumValueDescriptorProto
-         EnumValueDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumValueDescriptorProto "options" (EnumValueOptions) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'options
                  (\ x__ y__ -> x__{_EnumValueDescriptorProto'options = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
-instance (a ~ Prelude.Maybe EnumValueOptions,
-          b ~ Prelude.Maybe EnumValueOptions, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'options" f EnumValueDescriptorProto
-         EnumValueDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumValueDescriptorProto "maybe'options"
+         (Prelude.Maybe EnumValueOptions) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'options
                  (\ x__ y__ -> x__{_EnumValueDescriptorProto'options = y__}))
@@ -760,30 +735,31 @@ data EnumValueOptions = EnumValueOptions{_EnumValueOptions'deprecated
                                          ![UninterpretedOption]}
                       deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "deprecated" f EnumValueOptions
-         EnumValueOptions a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f EnumValueOptions x a, a ~ b) =>
+         Lens.Labels.HasLens f EnumValueOptions EnumValueOptions x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumValueOptions "deprecated" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumValueOptions'deprecated
                  (\ x__ y__ -> x__{_EnumValueOptions'deprecated = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'deprecated" f EnumValueOptions
-         EnumValueOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumValueOptions "maybe'deprecated" (Prelude.Maybe Prelude.Bool)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumValueOptions'deprecated
                  (\ x__ y__ -> x__{_EnumValueOptions'deprecated = y__}))
               Prelude.id
 
-instance (a ~ [UninterpretedOption], b ~ [UninterpretedOption],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "uninterpretedOption" f EnumValueOptions
-         EnumValueOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         EnumValueOptions "uninterpretedOption" ([UninterpretedOption])
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _EnumValueOptions'uninterpretedOption
                  (\ x__ y__ -> x__{_EnumValueOptions'uninterpretedOption = y__}))
@@ -845,200 +821,177 @@ data FieldDescriptorProto = FieldDescriptorProto{_FieldDescriptorProto'name
                                                  !(Prelude.Maybe FieldOptions)}
                           deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "name" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f FieldDescriptorProto x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f FieldDescriptorProto FieldDescriptorProto x a
+         b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "name" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'name
                  (\ x__ y__ -> x__{_FieldDescriptorProto'name = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'name" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "maybe'name" (Prelude.Maybe Data.Text.Text)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'name
                  (\ x__ y__ -> x__{_FieldDescriptorProto'name = y__}))
               Prelude.id
 
-instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "number" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "number" (Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'number
                  (\ x__ y__ -> x__{_FieldDescriptorProto'number = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Int.Int32,
-          b ~ Prelude.Maybe Data.Int.Int32, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'number" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "maybe'number" (Prelude.Maybe Data.Int.Int32)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'number
                  (\ x__ y__ -> x__{_FieldDescriptorProto'number = y__}))
               Prelude.id
 
-instance (a ~ FieldDescriptorProto'Label,
-          b ~ FieldDescriptorProto'Label, Prelude.Functor f) =>
-         Lens.Labels.HasLens "label" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "label" (FieldDescriptorProto'Label) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'label
                  (\ x__ y__ -> x__{_FieldDescriptorProto'label = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
-instance (a ~ Prelude.Maybe FieldDescriptorProto'Label,
-          b ~ Prelude.Maybe FieldDescriptorProto'Label, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'label" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "maybe'label"
+         (Prelude.Maybe FieldDescriptorProto'Label) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'label
                  (\ x__ y__ -> x__{_FieldDescriptorProto'label = y__}))
               Prelude.id
 
-instance (a ~ FieldDescriptorProto'Type,
-          b ~ FieldDescriptorProto'Type, Prelude.Functor f) =>
-         Lens.Labels.HasLens "type'" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "type'" (FieldDescriptorProto'Type) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'type'
                  (\ x__ y__ -> x__{_FieldDescriptorProto'type' = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
-instance (a ~ Prelude.Maybe FieldDescriptorProto'Type,
-          b ~ Prelude.Maybe FieldDescriptorProto'Type, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'type'" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "maybe'type'"
+         (Prelude.Maybe FieldDescriptorProto'Type) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'type'
                  (\ x__ y__ -> x__{_FieldDescriptorProto'type' = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "typeName" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "typeName" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'typeName
                  (\ x__ y__ -> x__{_FieldDescriptorProto'typeName = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'typeName" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "maybe'typeName"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'typeName
                  (\ x__ y__ -> x__{_FieldDescriptorProto'typeName = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "extendee" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "extendee" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'extendee
                  (\ x__ y__ -> x__{_FieldDescriptorProto'extendee = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'extendee" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "maybe'extendee"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'extendee
                  (\ x__ y__ -> x__{_FieldDescriptorProto'extendee = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "defaultValue" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "defaultValue" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'defaultValue
                  (\ x__ y__ -> x__{_FieldDescriptorProto'defaultValue = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'defaultValue" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "maybe'defaultValue"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'defaultValue
                  (\ x__ y__ -> x__{_FieldDescriptorProto'defaultValue = y__}))
               Prelude.id
 
-instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "oneofIndex" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "oneofIndex" (Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'oneofIndex
                  (\ x__ y__ -> x__{_FieldDescriptorProto'oneofIndex = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Int.Int32,
-          b ~ Prelude.Maybe Data.Int.Int32, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'oneofIndex" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "maybe'oneofIndex"
+         (Prelude.Maybe Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'oneofIndex
                  (\ x__ y__ -> x__{_FieldDescriptorProto'oneofIndex = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "jsonName" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "jsonName" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'jsonName
                  (\ x__ y__ -> x__{_FieldDescriptorProto'jsonName = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'jsonName" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "maybe'jsonName"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'jsonName
                  (\ x__ y__ -> x__{_FieldDescriptorProto'jsonName = y__}))
               Prelude.id
 
-instance (a ~ FieldOptions, b ~ FieldOptions, Prelude.Functor f) =>
-         Lens.Labels.HasLens "options" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "options" (FieldOptions) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'options
                  (\ x__ y__ -> x__{_FieldDescriptorProto'options = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
-instance (a ~ Prelude.Maybe FieldOptions,
-          b ~ Prelude.Maybe FieldOptions, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'options" f FieldDescriptorProto
-         FieldDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FieldDescriptorProto "maybe'options" (Prelude.Maybe FieldOptions)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldDescriptorProto'options
                  (\ x__ y__ -> x__{_FieldDescriptorProto'options = y__}))
@@ -1451,122 +1404,109 @@ data FieldOptions = FieldOptions{_FieldOptions'ctype ::
                                  _FieldOptions'uninterpretedOption :: ![UninterpretedOption]}
                   deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ FieldOptions'CType, b ~ FieldOptions'CType,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "ctype" f FieldOptions FieldOptions a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f FieldOptions x a, a ~ b) =>
+         Lens.Labels.HasLens f FieldOptions FieldOptions x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "ctype" (FieldOptions'CType) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'ctype
                  (\ x__ y__ -> x__{_FieldOptions'ctype = y__}))
               (Data.ProtoLens.maybeLens FieldOptions'STRING)
 
-instance (a ~ Prelude.Maybe FieldOptions'CType,
-          b ~ Prelude.Maybe FieldOptions'CType, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'ctype" f FieldOptions FieldOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "maybe'ctype" (Prelude.Maybe FieldOptions'CType) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'ctype
                  (\ x__ y__ -> x__{_FieldOptions'ctype = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "packed" f FieldOptions FieldOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "packed" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'packed
                  (\ x__ y__ -> x__{_FieldOptions'packed = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'packed" f FieldOptions FieldOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "maybe'packed" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'packed
                  (\ x__ y__ -> x__{_FieldOptions'packed = y__}))
               Prelude.id
 
-instance (a ~ FieldOptions'JSType, b ~ FieldOptions'JSType,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "jstype" f FieldOptions FieldOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "jstype" (FieldOptions'JSType) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'jstype
                  (\ x__ y__ -> x__{_FieldOptions'jstype = y__}))
               (Data.ProtoLens.maybeLens FieldOptions'JS_NORMAL)
 
-instance (a ~ Prelude.Maybe FieldOptions'JSType,
-          b ~ Prelude.Maybe FieldOptions'JSType, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'jstype" f FieldOptions FieldOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "maybe'jstype" (Prelude.Maybe FieldOptions'JSType) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'jstype
                  (\ x__ y__ -> x__{_FieldOptions'jstype = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "lazy" f FieldOptions FieldOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "lazy" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'lazy
                  (\ x__ y__ -> x__{_FieldOptions'lazy = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'lazy" f FieldOptions FieldOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "maybe'lazy" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'lazy
                  (\ x__ y__ -> x__{_FieldOptions'lazy = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "deprecated" f FieldOptions FieldOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "deprecated" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'deprecated
                  (\ x__ y__ -> x__{_FieldOptions'deprecated = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'deprecated" f FieldOptions FieldOptions
-         a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "maybe'deprecated" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'deprecated
                  (\ x__ y__ -> x__{_FieldOptions'deprecated = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "weak" f FieldOptions FieldOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "weak" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'weak
                  (\ x__ y__ -> x__{_FieldOptions'weak = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'weak" f FieldOptions FieldOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "maybe'weak" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'weak
                  (\ x__ y__ -> x__{_FieldOptions'weak = y__}))
               Prelude.id
 
-instance (a ~ [UninterpretedOption], b ~ [UninterpretedOption],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "uninterpretedOption" f FieldOptions
-         FieldOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FieldOptions
+         "uninterpretedOption" ([UninterpretedOption]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FieldOptions'uninterpretedOption
                  (\ x__ y__ -> x__{_FieldOptions'uninterpretedOption = y__}))
@@ -1794,170 +1734,147 @@ data FileDescriptorProto = FileDescriptorProto{_FileDescriptorProto'name
                                                !(Prelude.Maybe Data.Text.Text)}
                          deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "name" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f FileDescriptorProto x a, a ~ b) =>
+         Lens.Labels.HasLens f FileDescriptorProto FileDescriptorProto x a b
+         where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "name" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'name
                  (\ x__ y__ -> x__{_FileDescriptorProto'name = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'name" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "maybe'name" (Prelude.Maybe Data.Text.Text)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'name
                  (\ x__ y__ -> x__{_FileDescriptorProto'name = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "package" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "package" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'package
                  (\ x__ y__ -> x__{_FileDescriptorProto'package = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'package" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "maybe'package" (Prelude.Maybe Data.Text.Text)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'package
                  (\ x__ y__ -> x__{_FileDescriptorProto'package = y__}))
               Prelude.id
 
-instance (a ~ [Data.Text.Text], b ~ [Data.Text.Text],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "dependency" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "dependency" ([Data.Text.Text]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'dependency
                  (\ x__ y__ -> x__{_FileDescriptorProto'dependency = y__}))
               Prelude.id
 
-instance (a ~ [Data.Int.Int32], b ~ [Data.Int.Int32],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "publicDependency" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "publicDependency" ([Data.Int.Int32]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'publicDependency
                  (\ x__ y__ -> x__{_FileDescriptorProto'publicDependency = y__}))
               Prelude.id
 
-instance (a ~ [Data.Int.Int32], b ~ [Data.Int.Int32],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "weakDependency" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "weakDependency" ([Data.Int.Int32]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'weakDependency
                  (\ x__ y__ -> x__{_FileDescriptorProto'weakDependency = y__}))
               Prelude.id
 
-instance (a ~ [DescriptorProto], b ~ [DescriptorProto],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "messageType" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "messageType" ([DescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'messageType
                  (\ x__ y__ -> x__{_FileDescriptorProto'messageType = y__}))
               Prelude.id
 
-instance (a ~ [EnumDescriptorProto], b ~ [EnumDescriptorProto],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "enumType" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "enumType" ([EnumDescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'enumType
                  (\ x__ y__ -> x__{_FileDescriptorProto'enumType = y__}))
               Prelude.id
 
-instance (a ~ [ServiceDescriptorProto],
-          b ~ [ServiceDescriptorProto], Prelude.Functor f) =>
-         Lens.Labels.HasLens "service" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "service" ([ServiceDescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'service
                  (\ x__ y__ -> x__{_FileDescriptorProto'service = y__}))
               Prelude.id
 
-instance (a ~ [FieldDescriptorProto], b ~ [FieldDescriptorProto],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "extension" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "extension" ([FieldDescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'extension
                  (\ x__ y__ -> x__{_FileDescriptorProto'extension = y__}))
               Prelude.id
 
-instance (a ~ FileOptions, b ~ FileOptions, Prelude.Functor f) =>
-         Lens.Labels.HasLens "options" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "options" (FileOptions) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'options
                  (\ x__ y__ -> x__{_FileDescriptorProto'options = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
-instance (a ~ Prelude.Maybe FileOptions,
-          b ~ Prelude.Maybe FileOptions, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'options" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "maybe'options" (Prelude.Maybe FileOptions)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'options
                  (\ x__ y__ -> x__{_FileDescriptorProto'options = y__}))
               Prelude.id
 
-instance (a ~ SourceCodeInfo, b ~ SourceCodeInfo,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "sourceCodeInfo" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "sourceCodeInfo" (SourceCodeInfo) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'sourceCodeInfo
                  (\ x__ y__ -> x__{_FileDescriptorProto'sourceCodeInfo = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
-instance (a ~ Prelude.Maybe SourceCodeInfo,
-          b ~ Prelude.Maybe SourceCodeInfo, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'sourceCodeInfo" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "maybe'sourceCodeInfo"
+         (Prelude.Maybe SourceCodeInfo) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'sourceCodeInfo
                  (\ x__ y__ -> x__{_FileDescriptorProto'sourceCodeInfo = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "syntax" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "syntax" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'syntax
                  (\ x__ y__ -> x__{_FileDescriptorProto'syntax = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'syntax" f FileDescriptorProto
-         FileDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorProto "maybe'syntax" (Prelude.Maybe Data.Text.Text)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorProto'syntax
                  (\ x__ y__ -> x__{_FileDescriptorProto'syntax = y__}))
@@ -2111,11 +2028,14 @@ data FileDescriptorSet = FileDescriptorSet{_FileDescriptorSet'file
                                            :: ![FileDescriptorProto]}
                        deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ [FileDescriptorProto], b ~ [FileDescriptorProto],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "file" f FileDescriptorSet FileDescriptorSet a
-         b where
-        lensOf _
+instance (Lens.Labels.HasLens' f FileDescriptorSet x a, a ~ b) =>
+         Lens.Labels.HasLens f FileDescriptorSet FileDescriptorSet x a b
+         where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         FileDescriptorSet "file" ([FileDescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileDescriptorSet'file
                  (\ x__ y__ -> x__{_FileDescriptorSet'file = y__}))
@@ -2161,282 +2081,238 @@ data FileOptions = FileOptions{_FileOptions'javaPackage ::
                                _FileOptions'uninterpretedOption :: ![UninterpretedOption]}
                  deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "javaPackage" f FileOptions FileOptions a b
-         where
-        lensOf _
+instance (Lens.Labels.HasLens' f FileOptions x a, a ~ b) =>
+         Lens.Labels.HasLens f FileOptions FileOptions x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "javaPackage" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'javaPackage
                  (\ x__ y__ -> x__{_FileOptions'javaPackage = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'javaPackage" f FileOptions FileOptions a
-         b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'javaPackage" (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'javaPackage
                  (\ x__ y__ -> x__{_FileOptions'javaPackage = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "javaOuterClassname" f FileOptions FileOptions
-         a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "javaOuterClassname" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'javaOuterClassname
                  (\ x__ y__ -> x__{_FileOptions'javaOuterClassname = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'javaOuterClassname" f FileOptions
-         FileOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'javaOuterClassname" (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'javaOuterClassname
                  (\ x__ y__ -> x__{_FileOptions'javaOuterClassname = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "javaMultipleFiles" f FileOptions FileOptions a
-         b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "javaMultipleFiles" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'javaMultipleFiles
                  (\ x__ y__ -> x__{_FileOptions'javaMultipleFiles = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'javaMultipleFiles" f FileOptions
-         FileOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'javaMultipleFiles" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'javaMultipleFiles
                  (\ x__ y__ -> x__{_FileOptions'javaMultipleFiles = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "javaGenerateEqualsAndHash" f FileOptions
-         FileOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "javaGenerateEqualsAndHash" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'javaGenerateEqualsAndHash
                  (\ x__ y__ -> x__{_FileOptions'javaGenerateEqualsAndHash = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'javaGenerateEqualsAndHash" f FileOptions
-         FileOptions a b where
-        lensOf _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaGenerateEqualsAndHash
-                 (\ x__ y__ -> x__{_FileOptions'javaGenerateEqualsAndHash = y__}))
-              Prelude.id
-
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "javaStringCheckUtf8" f FileOptions FileOptions
-         a b where
-        lensOf _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaStringCheckUtf8
-                 (\ x__ y__ -> x__{_FileOptions'javaStringCheckUtf8 = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
-
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'javaStringCheckUtf8" f FileOptions
-         FileOptions a b where
-        lensOf _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaStringCheckUtf8
-                 (\ x__ y__ -> x__{_FileOptions'javaStringCheckUtf8 = y__}))
-              Prelude.id
-
-instance (a ~ FileOptions'OptimizeMode,
-          b ~ FileOptions'OptimizeMode, Prelude.Functor f) =>
-         Lens.Labels.HasLens "optimizeFor" f FileOptions FileOptions a b
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'javaGenerateEqualsAndHash" (Prelude.Maybe Prelude.Bool)
          where
-        lensOf _
+        lensOf' _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _FileOptions'javaGenerateEqualsAndHash
+                 (\ x__ y__ -> x__{_FileOptions'javaGenerateEqualsAndHash = y__}))
+              Prelude.id
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "javaStringCheckUtf8" (Prelude.Bool) where
+        lensOf' _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _FileOptions'javaStringCheckUtf8
+                 (\ x__ y__ -> x__{_FileOptions'javaStringCheckUtf8 = y__}))
+              (Data.ProtoLens.maybeLens Prelude.False)
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'javaStringCheckUtf8" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _FileOptions'javaStringCheckUtf8
+                 (\ x__ y__ -> x__{_FileOptions'javaStringCheckUtf8 = y__}))
+              Prelude.id
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "optimizeFor" (FileOptions'OptimizeMode) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'optimizeFor
                  (\ x__ y__ -> x__{_FileOptions'optimizeFor = y__}))
               (Data.ProtoLens.maybeLens FileOptions'SPEED)
 
-instance (a ~ Prelude.Maybe FileOptions'OptimizeMode,
-          b ~ Prelude.Maybe FileOptions'OptimizeMode, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'optimizeFor" f FileOptions FileOptions a
-         b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'optimizeFor" (Prelude.Maybe FileOptions'OptimizeMode) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'optimizeFor
                  (\ x__ y__ -> x__{_FileOptions'optimizeFor = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "goPackage" f FileOptions FileOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "goPackage" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'goPackage
                  (\ x__ y__ -> x__{_FileOptions'goPackage = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'goPackage" f FileOptions FileOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'goPackage" (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'goPackage
                  (\ x__ y__ -> x__{_FileOptions'goPackage = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "ccGenericServices" f FileOptions FileOptions a
-         b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "ccGenericServices" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'ccGenericServices
                  (\ x__ y__ -> x__{_FileOptions'ccGenericServices = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'ccGenericServices" f FileOptions
-         FileOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'ccGenericServices" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'ccGenericServices
                  (\ x__ y__ -> x__{_FileOptions'ccGenericServices = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "javaGenericServices" f FileOptions FileOptions
-         a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "javaGenericServices" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'javaGenericServices
                  (\ x__ y__ -> x__{_FileOptions'javaGenericServices = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'javaGenericServices" f FileOptions
-         FileOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'javaGenericServices" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'javaGenericServices
                  (\ x__ y__ -> x__{_FileOptions'javaGenericServices = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "pyGenericServices" f FileOptions FileOptions a
-         b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "pyGenericServices" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'pyGenericServices
                  (\ x__ y__ -> x__{_FileOptions'pyGenericServices = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'pyGenericServices" f FileOptions
-         FileOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'pyGenericServices" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'pyGenericServices
                  (\ x__ y__ -> x__{_FileOptions'pyGenericServices = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "deprecated" f FileOptions FileOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "deprecated" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'deprecated
                  (\ x__ y__ -> x__{_FileOptions'deprecated = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'deprecated" f FileOptions FileOptions a
-         b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'deprecated" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'deprecated
                  (\ x__ y__ -> x__{_FileOptions'deprecated = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "ccEnableArenas" f FileOptions FileOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "ccEnableArenas" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'ccEnableArenas
                  (\ x__ y__ -> x__{_FileOptions'ccEnableArenas = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'ccEnableArenas" f FileOptions
-         FileOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'ccEnableArenas" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'ccEnableArenas
                  (\ x__ y__ -> x__{_FileOptions'ccEnableArenas = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "objcClassPrefix" f FileOptions FileOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "objcClassPrefix" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'objcClassPrefix
                  (\ x__ y__ -> x__{_FileOptions'objcClassPrefix = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'objcClassPrefix" f FileOptions
-         FileOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'objcClassPrefix" (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'objcClassPrefix
                  (\ x__ y__ -> x__{_FileOptions'objcClassPrefix = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "csharpNamespace" f FileOptions FileOptions a b
-         where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "csharpNamespace" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'csharpNamespace
                  (\ x__ y__ -> x__{_FileOptions'csharpNamespace = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'csharpNamespace" f FileOptions
-         FileOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "maybe'csharpNamespace" (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'csharpNamespace
                  (\ x__ y__ -> x__{_FileOptions'csharpNamespace = y__}))
               Prelude.id
 
-instance (a ~ [UninterpretedOption], b ~ [UninterpretedOption],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "uninterpretedOption" f FileOptions FileOptions
-         a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f FileOptions
+         "uninterpretedOption" ([UninterpretedOption]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _FileOptions'uninterpretedOption
                  (\ x__ y__ -> x__{_FileOptions'uninterpretedOption = y__}))
@@ -2691,11 +2567,15 @@ data GeneratedCodeInfo = GeneratedCodeInfo{_GeneratedCodeInfo'annotation
                                            :: ![GeneratedCodeInfo'Annotation]}
                        deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ [GeneratedCodeInfo'Annotation],
-          b ~ [GeneratedCodeInfo'Annotation], Prelude.Functor f) =>
-         Lens.Labels.HasLens "annotation" f GeneratedCodeInfo
-         GeneratedCodeInfo a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f GeneratedCodeInfo x a, a ~ b) =>
+         Lens.Labels.HasLens f GeneratedCodeInfo GeneratedCodeInfo x a b
+         where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         GeneratedCodeInfo "annotation" ([GeneratedCodeInfo'Annotation])
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'annotation
                  (\ x__ y__ -> x__{_GeneratedCodeInfo'annotation = y__}))
@@ -2731,73 +2611,68 @@ data GeneratedCodeInfo'Annotation = GeneratedCodeInfo'Annotation{_GeneratedCodeI
                                                                  :: !(Prelude.Maybe Data.Int.Int32)}
                                   deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ [Data.Int.Int32], b ~ [Data.Int.Int32],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "path" f GeneratedCodeInfo'Annotation
-         GeneratedCodeInfo'Annotation a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f GeneratedCodeInfo'Annotation x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f GeneratedCodeInfo'Annotation
+         GeneratedCodeInfo'Annotation x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         GeneratedCodeInfo'Annotation "path" ([Data.Int.Int32]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'path
                  (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'path = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "sourceFile" f GeneratedCodeInfo'Annotation
-         GeneratedCodeInfo'Annotation a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         GeneratedCodeInfo'Annotation "sourceFile" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens
                  _GeneratedCodeInfo'Annotation'sourceFile
                  (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'sourceFile = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'sourceFile" f
-         GeneratedCodeInfo'Annotation GeneratedCodeInfo'Annotation a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         GeneratedCodeInfo'Annotation "maybe'sourceFile"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens
                  _GeneratedCodeInfo'Annotation'sourceFile
                  (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'sourceFile = y__}))
               Prelude.id
 
-instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "begin" f GeneratedCodeInfo'Annotation
-         GeneratedCodeInfo'Annotation a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         GeneratedCodeInfo'Annotation "begin" (Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'begin
                  (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'begin = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Int.Int32,
-          b ~ Prelude.Maybe Data.Int.Int32, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'begin" f GeneratedCodeInfo'Annotation
-         GeneratedCodeInfo'Annotation a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         GeneratedCodeInfo'Annotation "maybe'begin"
+         (Prelude.Maybe Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'begin
                  (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'begin = y__}))
               Prelude.id
 
-instance (a ~ Data.Int.Int32, b ~ Data.Int.Int32,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "end" f GeneratedCodeInfo'Annotation
-         GeneratedCodeInfo'Annotation a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         GeneratedCodeInfo'Annotation "end" (Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'end
                  (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'end = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Int.Int32,
-          b ~ Prelude.Maybe Data.Int.Int32, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'end" f GeneratedCodeInfo'Annotation
-         GeneratedCodeInfo'Annotation a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         GeneratedCodeInfo'Annotation "maybe'end"
+         (Prelude.Maybe Data.Int.Int32) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'end
                  (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'end = y__}))
@@ -2869,29 +2744,29 @@ data MessageOptions = MessageOptions{_MessageOptions'messageSetWireFormat
                                      _MessageOptions'uninterpretedOption :: ![UninterpretedOption]}
                     deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "messageSetWireFormat" f MessageOptions
-         MessageOptions a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f MessageOptions x a, a ~ b) =>
+         Lens.Labels.HasLens f MessageOptions MessageOptions x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f MessageOptions
+         "messageSetWireFormat" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MessageOptions'messageSetWireFormat
                  (\ x__ y__ -> x__{_MessageOptions'messageSetWireFormat = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'messageSetWireFormat" f MessageOptions
-         MessageOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f MessageOptions
+         "maybe'messageSetWireFormat" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MessageOptions'messageSetWireFormat
                  (\ x__ y__ -> x__{_MessageOptions'messageSetWireFormat = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "noStandardDescriptorAccessor" f MessageOptions
-         MessageOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f MessageOptions
+         "noStandardDescriptorAccessor" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens
                  _MessageOptions'noStandardDescriptorAccessor
@@ -2899,61 +2774,52 @@ instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
                     x__{_MessageOptions'noStandardDescriptorAccessor = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'noStandardDescriptorAccessor" f
-         MessageOptions MessageOptions a b where
-        lensOf _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _MessageOptions'noStandardDescriptorAccessor
-                 (\ x__ y__ ->
-                    x__{_MessageOptions'noStandardDescriptorAccessor = y__}))
-              Prelude.id
-
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "deprecated" f MessageOptions MessageOptions a
-         b where
-        lensOf _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MessageOptions'deprecated
-                 (\ x__ y__ -> x__{_MessageOptions'deprecated = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
-
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'deprecated" f MessageOptions
-         MessageOptions a b where
-        lensOf _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MessageOptions'deprecated
-                 (\ x__ y__ -> x__{_MessageOptions'deprecated = y__}))
-              Prelude.id
-
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "mapEntry" f MessageOptions MessageOptions a b
+instance Prelude.Functor f => Lens.Labels.HasLens' f MessageOptions
+         "maybe'noStandardDescriptorAccessor" (Prelude.Maybe Prelude.Bool)
          where
-        lensOf _
+        lensOf' _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens
+                 _MessageOptions'noStandardDescriptorAccessor
+                 (\ x__ y__ ->
+                    x__{_MessageOptions'noStandardDescriptorAccessor = y__}))
+              Prelude.id
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f MessageOptions
+         "deprecated" (Prelude.Bool) where
+        lensOf' _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _MessageOptions'deprecated
+                 (\ x__ y__ -> x__{_MessageOptions'deprecated = y__}))
+              (Data.ProtoLens.maybeLens Prelude.False)
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f MessageOptions
+         "maybe'deprecated" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
+          = (Prelude..)
+              (Lens.Family2.Unchecked.lens _MessageOptions'deprecated
+                 (\ x__ y__ -> x__{_MessageOptions'deprecated = y__}))
+              Prelude.id
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f MessageOptions
+         "mapEntry" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MessageOptions'mapEntry
                  (\ x__ y__ -> x__{_MessageOptions'mapEntry = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'mapEntry" f MessageOptions
-         MessageOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f MessageOptions
+         "maybe'mapEntry" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MessageOptions'mapEntry
                  (\ x__ y__ -> x__{_MessageOptions'mapEntry = y__}))
               Prelude.id
 
-instance (a ~ [UninterpretedOption], b ~ [UninterpretedOption],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "uninterpretedOption" f MessageOptions
-         MessageOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f MessageOptions
+         "uninterpretedOption" ([UninterpretedOption]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MessageOptions'uninterpretedOption
                  (\ x__ y__ -> x__{_MessageOptions'uninterpretedOption = y__}))
@@ -3046,119 +2912,109 @@ data MethodDescriptorProto = MethodDescriptorProto{_MethodDescriptorProto'name
                                                    !(Prelude.Maybe Prelude.Bool)}
                            deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "name" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f MethodDescriptorProto x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f MethodDescriptorProto MethodDescriptorProto x
+         a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "name" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'name
                  (\ x__ y__ -> x__{_MethodDescriptorProto'name = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'name" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "maybe'name" (Prelude.Maybe Data.Text.Text)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'name
                  (\ x__ y__ -> x__{_MethodDescriptorProto'name = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "inputType" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "inputType" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'inputType
                  (\ x__ y__ -> x__{_MethodDescriptorProto'inputType = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'inputType" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "maybe'inputType"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'inputType
                  (\ x__ y__ -> x__{_MethodDescriptorProto'inputType = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "outputType" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "outputType" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'outputType
                  (\ x__ y__ -> x__{_MethodDescriptorProto'outputType = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'outputType" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "maybe'outputType"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'outputType
                  (\ x__ y__ -> x__{_MethodDescriptorProto'outputType = y__}))
               Prelude.id
 
-instance (a ~ MethodOptions, b ~ MethodOptions,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "options" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "options" (MethodOptions) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'options
                  (\ x__ y__ -> x__{_MethodDescriptorProto'options = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
-instance (a ~ Prelude.Maybe MethodOptions,
-          b ~ Prelude.Maybe MethodOptions, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'options" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "maybe'options" (Prelude.Maybe MethodOptions)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'options
                  (\ x__ y__ -> x__{_MethodDescriptorProto'options = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "clientStreaming" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "clientStreaming" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'clientStreaming
                  (\ x__ y__ -> x__{_MethodDescriptorProto'clientStreaming = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'clientStreaming" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "maybe'clientStreaming"
+         (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'clientStreaming
                  (\ x__ y__ -> x__{_MethodDescriptorProto'clientStreaming = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "serverStreaming" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "serverStreaming" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'serverStreaming
                  (\ x__ y__ -> x__{_MethodDescriptorProto'serverStreaming = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'serverStreaming" f MethodDescriptorProto
-         MethodDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         MethodDescriptorProto "maybe'serverStreaming"
+         (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodDescriptorProto'serverStreaming
                  (\ x__ y__ -> x__{_MethodDescriptorProto'serverStreaming = y__}))
@@ -3249,30 +3105,29 @@ data MethodOptions = MethodOptions{_MethodOptions'deprecated ::
                                    _MethodOptions'uninterpretedOption :: ![UninterpretedOption]}
                    deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "deprecated" f MethodOptions MethodOptions a b
-         where
-        lensOf _
+instance (Lens.Labels.HasLens' f MethodOptions x a, a ~ b) =>
+         Lens.Labels.HasLens f MethodOptions MethodOptions x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f MethodOptions
+         "deprecated" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodOptions'deprecated
                  (\ x__ y__ -> x__{_MethodOptions'deprecated = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'deprecated" f MethodOptions
-         MethodOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f MethodOptions
+         "maybe'deprecated" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodOptions'deprecated
                  (\ x__ y__ -> x__{_MethodOptions'deprecated = y__}))
               Prelude.id
 
-instance (a ~ [UninterpretedOption], b ~ [UninterpretedOption],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "uninterpretedOption" f MethodOptions
-         MethodOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f MethodOptions
+         "uninterpretedOption" ([UninterpretedOption]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _MethodOptions'uninterpretedOption
                  (\ x__ y__ -> x__{_MethodOptions'uninterpretedOption = y__}))
@@ -3316,21 +3171,24 @@ data OneofDescriptorProto = OneofDescriptorProto{_OneofDescriptorProto'name
                                                  :: !(Prelude.Maybe Data.Text.Text)}
                           deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "name" f OneofDescriptorProto
-         OneofDescriptorProto a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f OneofDescriptorProto x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f OneofDescriptorProto OneofDescriptorProto x a
+         b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         OneofDescriptorProto "name" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _OneofDescriptorProto'name
                  (\ x__ y__ -> x__{_OneofDescriptorProto'name = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'name" f OneofDescriptorProto
-         OneofDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         OneofDescriptorProto "maybe'name" (Prelude.Maybe Data.Text.Text)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _OneofDescriptorProto'name
                  (\ x__ y__ -> x__{_OneofDescriptorProto'name = y__}))
@@ -3366,51 +3224,49 @@ data ServiceDescriptorProto = ServiceDescriptorProto{_ServiceDescriptorProto'nam
                                                      !(Prelude.Maybe ServiceOptions)}
                             deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "name" f ServiceDescriptorProto
-         ServiceDescriptorProto a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f ServiceDescriptorProto x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f ServiceDescriptorProto ServiceDescriptorProto
+         x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         ServiceDescriptorProto "name" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'name
                  (\ x__ y__ -> x__{_ServiceDescriptorProto'name = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'name" f ServiceDescriptorProto
-         ServiceDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         ServiceDescriptorProto "maybe'name" (Prelude.Maybe Data.Text.Text)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'name
                  (\ x__ y__ -> x__{_ServiceDescriptorProto'name = y__}))
               Prelude.id
 
-instance (a ~ [MethodDescriptorProto], b ~ [MethodDescriptorProto],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "method" f ServiceDescriptorProto
-         ServiceDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         ServiceDescriptorProto "method" ([MethodDescriptorProto]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'method
                  (\ x__ y__ -> x__{_ServiceDescriptorProto'method = y__}))
               Prelude.id
 
-instance (a ~ ServiceOptions, b ~ ServiceOptions,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "options" f ServiceDescriptorProto
-         ServiceDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         ServiceDescriptorProto "options" (ServiceOptions) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'options
                  (\ x__ y__ -> x__{_ServiceDescriptorProto'options = y__}))
               (Data.ProtoLens.maybeLens Data.Default.Class.def)
 
-instance (a ~ Prelude.Maybe ServiceOptions,
-          b ~ Prelude.Maybe ServiceOptions, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'options" f ServiceDescriptorProto
-         ServiceDescriptorProto a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         ServiceDescriptorProto "maybe'options"
+         (Prelude.Maybe ServiceOptions) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'options
                  (\ x__ y__ -> x__{_ServiceDescriptorProto'options = y__}))
@@ -3466,30 +3322,29 @@ data ServiceOptions = ServiceOptions{_ServiceOptions'deprecated ::
                                      _ServiceOptions'uninterpretedOption :: ![UninterpretedOption]}
                     deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "deprecated" f ServiceOptions ServiceOptions a
-         b where
-        lensOf _
+instance (Lens.Labels.HasLens' f ServiceOptions x a, a ~ b) =>
+         Lens.Labels.HasLens f ServiceOptions ServiceOptions x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f ServiceOptions
+         "deprecated" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _ServiceOptions'deprecated
                  (\ x__ y__ -> x__{_ServiceOptions'deprecated = y__}))
               (Data.ProtoLens.maybeLens Prelude.False)
 
-instance (a ~ Prelude.Maybe Prelude.Bool,
-          b ~ Prelude.Maybe Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'deprecated" f ServiceOptions
-         ServiceOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f ServiceOptions
+         "maybe'deprecated" (Prelude.Maybe Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _ServiceOptions'deprecated
                  (\ x__ y__ -> x__{_ServiceOptions'deprecated = y__}))
               Prelude.id
 
-instance (a ~ [UninterpretedOption], b ~ [UninterpretedOption],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "uninterpretedOption" f ServiceOptions
-         ServiceOptions a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f ServiceOptions
+         "uninterpretedOption" ([UninterpretedOption]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _ServiceOptions'uninterpretedOption
                  (\ x__ y__ -> x__{_ServiceOptions'uninterpretedOption = y__}))
@@ -3533,11 +3388,13 @@ data SourceCodeInfo = SourceCodeInfo{_SourceCodeInfo'location ::
                                      ![SourceCodeInfo'Location]}
                     deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ [SourceCodeInfo'Location],
-          b ~ [SourceCodeInfo'Location], Prelude.Functor f) =>
-         Lens.Labels.HasLens "location" f SourceCodeInfo SourceCodeInfo a b
-         where
-        lensOf _
+instance (Lens.Labels.HasLens' f SourceCodeInfo x a, a ~ b) =>
+         Lens.Labels.HasLens f SourceCodeInfo SourceCodeInfo x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f SourceCodeInfo
+         "location" ([SourceCodeInfo'Location]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _SourceCodeInfo'location
                  (\ x__ y__ -> x__{_SourceCodeInfo'location = y__}))
@@ -3575,53 +3432,50 @@ data SourceCodeInfo'Location = SourceCodeInfo'Location{_SourceCodeInfo'Location'
                                                        :: ![Data.Text.Text]}
                              deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ [Data.Int.Int32], b ~ [Data.Int.Int32],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "path" f SourceCodeInfo'Location
-         SourceCodeInfo'Location a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f SourceCodeInfo'Location x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f SourceCodeInfo'Location
+         SourceCodeInfo'Location x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         SourceCodeInfo'Location "path" ([Data.Int.Int32]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'path
                  (\ x__ y__ -> x__{_SourceCodeInfo'Location'path = y__}))
               Prelude.id
 
-instance (a ~ [Data.Int.Int32], b ~ [Data.Int.Int32],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "span" f SourceCodeInfo'Location
-         SourceCodeInfo'Location a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         SourceCodeInfo'Location "span" ([Data.Int.Int32]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'span
                  (\ x__ y__ -> x__{_SourceCodeInfo'Location'span = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "leadingComments" f SourceCodeInfo'Location
-         SourceCodeInfo'Location a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         SourceCodeInfo'Location "leadingComments" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens
                  _SourceCodeInfo'Location'leadingComments
                  (\ x__ y__ -> x__{_SourceCodeInfo'Location'leadingComments = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'leadingComments" f
-         SourceCodeInfo'Location SourceCodeInfo'Location a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         SourceCodeInfo'Location "maybe'leadingComments"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens
                  _SourceCodeInfo'Location'leadingComments
                  (\ x__ y__ -> x__{_SourceCodeInfo'Location'leadingComments = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "trailingComments" f SourceCodeInfo'Location
-         SourceCodeInfo'Location a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         SourceCodeInfo'Location "trailingComments" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens
                  _SourceCodeInfo'Location'trailingComments
@@ -3629,11 +3483,10 @@ instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
                     x__{_SourceCodeInfo'Location'trailingComments = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'trailingComments" f
-         SourceCodeInfo'Location SourceCodeInfo'Location a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         SourceCodeInfo'Location "maybe'trailingComments"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens
                  _SourceCodeInfo'Location'trailingComments
@@ -3641,11 +3494,10 @@ instance (a ~ Prelude.Maybe Data.Text.Text,
                     x__{_SourceCodeInfo'Location'trailingComments = y__}))
               Prelude.id
 
-instance (a ~ [Data.Text.Text], b ~ [Data.Text.Text],
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "leadingDetachedComments" f
-         SourceCodeInfo'Location SourceCodeInfo'Location a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         SourceCodeInfo'Location "leadingDetachedComments"
+         ([Data.Text.Text]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens
                  _SourceCodeInfo'Location'leadingDetachedComments
@@ -3739,131 +3591,117 @@ data UninterpretedOption = UninterpretedOption{_UninterpretedOption'name
                                                !(Prelude.Maybe Data.Text.Text)}
                          deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ [UninterpretedOption'NamePart],
-          b ~ [UninterpretedOption'NamePart], Prelude.Functor f) =>
-         Lens.Labels.HasLens "name" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f UninterpretedOption x a, a ~ b) =>
+         Lens.Labels.HasLens f UninterpretedOption UninterpretedOption x a b
+         where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "name" ([UninterpretedOption'NamePart]) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'name
                  (\ x__ y__ -> x__{_UninterpretedOption'name = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "identifierValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "identifierValue" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'identifierValue
                  (\ x__ y__ -> x__{_UninterpretedOption'identifierValue = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'identifierValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "maybe'identifierValue"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'identifierValue
                  (\ x__ y__ -> x__{_UninterpretedOption'identifierValue = y__}))
               Prelude.id
 
-instance (a ~ Data.Word.Word64, b ~ Data.Word.Word64,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "positiveIntValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "positiveIntValue" (Data.Word.Word64) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'positiveIntValue
                  (\ x__ y__ -> x__{_UninterpretedOption'positiveIntValue = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Word.Word64,
-          b ~ Prelude.Maybe Data.Word.Word64, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'positiveIntValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "maybe'positiveIntValue"
+         (Prelude.Maybe Data.Word.Word64) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'positiveIntValue
                  (\ x__ y__ -> x__{_UninterpretedOption'positiveIntValue = y__}))
               Prelude.id
 
-instance (a ~ Data.Int.Int64, b ~ Data.Int.Int64,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "negativeIntValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "negativeIntValue" (Data.Int.Int64) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'negativeIntValue
                  (\ x__ y__ -> x__{_UninterpretedOption'negativeIntValue = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Int.Int64,
-          b ~ Prelude.Maybe Data.Int.Int64, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'negativeIntValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "maybe'negativeIntValue"
+         (Prelude.Maybe Data.Int.Int64) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'negativeIntValue
                  (\ x__ y__ -> x__{_UninterpretedOption'negativeIntValue = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Double, b ~ Prelude.Double,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "doubleValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "doubleValue" (Prelude.Double) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'doubleValue
                  (\ x__ y__ -> x__{_UninterpretedOption'doubleValue = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Prelude.Double,
-          b ~ Prelude.Maybe Prelude.Double, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'doubleValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "maybe'doubleValue"
+         (Prelude.Maybe Prelude.Double) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'doubleValue
                  (\ x__ y__ -> x__{_UninterpretedOption'doubleValue = y__}))
               Prelude.id
 
-instance (a ~ Data.ByteString.ByteString,
-          b ~ Data.ByteString.ByteString, Prelude.Functor f) =>
-         Lens.Labels.HasLens "stringValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "stringValue" (Data.ByteString.ByteString)
+         where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'stringValue
                  (\ x__ y__ -> x__{_UninterpretedOption'stringValue = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.ByteString.ByteString,
-          b ~ Prelude.Maybe Data.ByteString.ByteString, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'stringValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "maybe'stringValue"
+         (Prelude.Maybe Data.ByteString.ByteString) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'stringValue
                  (\ x__ y__ -> x__{_UninterpretedOption'stringValue = y__}))
               Prelude.id
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "aggregateValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "aggregateValue" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'aggregateValue
                  (\ x__ y__ -> x__{_UninterpretedOption'aggregateValue = y__}))
               (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
 
-instance (a ~ Prelude.Maybe Data.Text.Text,
-          b ~ Prelude.Maybe Data.Text.Text, Prelude.Functor f) =>
-         Lens.Labels.HasLens "maybe'aggregateValue" f UninterpretedOption
-         UninterpretedOption a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption "maybe'aggregateValue"
+         (Prelude.Maybe Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'aggregateValue
                  (\ x__ y__ -> x__{_UninterpretedOption'aggregateValue = y__}))
@@ -3969,20 +3807,23 @@ data UninterpretedOption'NamePart = UninterpretedOption'NamePart{_UninterpretedO
                                                                  :: !Prelude.Bool}
                                   deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
 
-instance (a ~ Data.Text.Text, b ~ Data.Text.Text,
-          Prelude.Functor f) =>
-         Lens.Labels.HasLens "namePart" f UninterpretedOption'NamePart
-         UninterpretedOption'NamePart a b where
-        lensOf _
+instance (Lens.Labels.HasLens' f UninterpretedOption'NamePart x a,
+          a ~ b) =>
+         Lens.Labels.HasLens f UninterpretedOption'NamePart
+         UninterpretedOption'NamePart x a b where
+        lensOf = Lens.Labels.lensOf'
+
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption'NamePart "namePart" (Data.Text.Text) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens _UninterpretedOption'NamePart'namePart
                  (\ x__ y__ -> x__{_UninterpretedOption'NamePart'namePart = y__}))
               Prelude.id
 
-instance (a ~ Prelude.Bool, b ~ Prelude.Bool, Prelude.Functor f) =>
-         Lens.Labels.HasLens "isExtension" f UninterpretedOption'NamePart
-         UninterpretedOption'NamePart a b where
-        lensOf _
+instance Prelude.Functor f => Lens.Labels.HasLens' f
+         UninterpretedOption'NamePart "isExtension" (Prelude.Bool) where
+        lensOf' _
           = (Prelude..)
               (Lens.Family2.Unchecked.lens
                  _UninterpretedOption'NamePart'isExtension

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
@@ -150,6 +150,8 @@ type InstHead = Syntax.InstHead ()
 ihApp :: InstHead -> [Type] -> InstHead
 ihApp = foldl (Syntax.IHApp ())
 
+tyParen :: Type -> Type
+tyParen = Syntax.TyParen ()
 
 type Match = Syntax.Match ()
 

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -181,16 +181,24 @@ generateMessageDecls syntaxType env protoName info =
       ["Prelude.Show", "Prelude.Eq", "Prelude.Ord"]
     | oneofInfo <- messageOneofFields info
     ] ++
-
-    -- type instance (Functor f, a ~ Baz, b ~ Baz)
-    --     => HasLens "foo" f Bar Bar a b where
+    -- instance (HasLens' f Foo x a, HasLens' f Foo x b, a ~ b)
+    --    => HasLens f Foo Foo x a b
+    [ instDecl [classA "Lens.Labels.HasLens'" ["f", dataType, "x", "a"],
+                equalP "a" "b"]
+          ("Lens.Labels.HasLens" `ihApp`
+              ["f", dataType, dataType, "x", "a", "b"])
+          [[match "lensOf" [] "Lens.Labels.lensOf'"]]
+    ]
+    ++
+    -- instance Functor f
+    --     => HasLens' f Foo "foo" Bar
     --   lensOf _ = ...
     -- Note: for optional fields, this generates an instance both for "foo" and
-    -- for "maybe'foo" (see lensInfo below).
-    [ instDecl [equalP "a" t, equalP "b" t, classA "Prelude.Functor" ["f"]]
-        ("Lens.Labels.HasLens" `ihApp`
-            [sym, "f", dataType, dataType, "a", "b"])
-            [[match "lensOf" [pWildCard] $
+    -- for "maybe'foo" (see plainRecordField below).
+    [ instDecl [classA "Prelude.Functor" ["f"]]
+        ("Lens.Labels.HasLens'" `ihApp`
+            ["f", dataType, sym, tyParen t])
+            [[match "lensOf'" [pWildCard] $
                 "Prelude.."
                     @@ rawFieldAccessor (unQual $ recordFieldName li)
                     @@ lensExp i]]
@@ -368,12 +376,12 @@ generateEnumDecls info =
 generateFieldDecls :: Symbol -> [Decl]
 generateFieldDecls xStr =
     -- foo :: forall x f s t a b
-    --        . HasLens x f s t a b => LensLike f s t a b
+    --        . HasLens f s t x a b => LensLike f s t a b
     -- -- Note: `Lens.Family2.LensLike f` implies Functor f.
     -- foo = lensOf (Proxy# :: Proxy# x)
     [ typeSig [x]
           $ tyForAll ["f", "s", "t", "a", "b"]
-                  [classA "Lens.Labels.HasLens" [xSym, "f", "s", "t", "a", "b"]]
+                  [classA "Lens.Labels.HasLens" ["f", "s", "t", xSym, "a", "b"]]
                     $ "Lens.Family2.LensLike" @@ "f" @@ "s" @@ "t" @@ "a" @@ "b"
     , funBind [match x [] $ lensOfExp xStr]
     ]


### PR DESCRIPTION
- Swaps the order of type arguments to `HasLens` in order
  to make the instances more readable in Haddock and error
  messages.
- Adds a new class `HasLens'` which is effectively the
  "monomorphic" version of `HasLens`; that is, for lenses of
  monomorphic types (which includes all proto messages).

For example:

    instance (HasLens' f Foo x a, a ~ b) => HasLens f Foo Foo x a b where
        where lensOf = lensOf'
    instance Functor f => HasLens' f Foo "a" Int where ...
    instance Functor f => HasLens' f Foo "b" Double where ...
    instance Functor f => HasLens' f Foo "c" [Float]  where ...
    ...

And for a polymorphic type:

    instance Functor f => HasLens f (a,b) (a,c) "snd" b c where
        lensOf _ = lens snd (\(x,_) y -> (x,y))