### PR TITLE
Allow other packages to import protos from proto-lens-descriptors.

### DIFF
--- a/proto-lens-descriptors/data/proto-lens-imports/google
+++ b/proto-lens-descriptors/data/proto-lens-imports/google
@@ -1,0 +1,1 @@
+../../../google/protobuf/src/google/

--- a/proto-lens-descriptors/proto-lens-descriptors.cabal
+++ b/proto-lens-descriptors/proto-lens-descriptors.cabal
@@ -14,6 +14,14 @@ build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:  Changelog.md
 
+-- Make the corresponding .proto files available for other packages to import.
+-- Usually this happens automatically as part of Data.ProtoLens.Setup,
+-- but because of bootstrapping we don't use that module here.
+data-dir: data
+data-files:
+    proto-lens-imports/google/protobuf/descriptor.proto
+    proto-lens-imports/google/protobuf/compiler/plugin.proto
+
 library
   hs-source-dirs:      src
   exposed-modules:

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -32,6 +32,8 @@ library
                -- compile tests/package-deps.proto (since it's listed in
                -- extra-source-files regardless).
                , proto-lens-tests-dep
+               -- For tests/imports.proto:
+               , proto-lens-descriptors
                , base >= 4.8 && < 4.11
                , bytestring == 0.10.*
                , text == 1.2.*

--- a/proto-lens-tests/tests/imports.proto
+++ b/proto-lens-tests/tests/imports.proto
@@ -6,6 +6,11 @@ import "enum.proto";
 import "imports_dep.proto";
 import "nested.proto";
 
+// Test that we can import from proto-lens-descriptors, which is special
+// due to bootstrapping:
+import "google/protobuf/descriptor.proto";
+import "google/protobuf/compiler/plugin.proto";
+
 // Note that this clashes with the name "Foo" from enums; however, since they're
 // in different modules/packages, it should still compile.
 message Foo {
@@ -20,4 +25,9 @@ message UseDep {
   optional dep.pkg.DepPkg foo = 1;
   optional transitive.TransitiveDep bar = 2;
   optional transitive.TransitiveDep2 baz = 3;
+}
+
+message UseBootstrapped {
+  optional google.protobuf.DescriptorProto descriptor = 1;
+  optional google.protobuf.compiler.CodeGeneratorRequest request = 2;
 }


### PR DESCRIPTION
Packages that use Data.ProtoLens.Setup (e.g. proto-lens-protobuf-types) pass
`.proto` file to each other by copying them into
`$datadir/proto-lens-imports/**/*.proto`.  We need to fake this behavior for
`proto-lens-descriptors` since it uses bootstrapping.  So instead
we symlink the `.proto` files manually into the right location.