### PR TITLE
Add an explicit test for `imports.proto`.

### DIFF
--- a/lens-labels/src/Lens/Labels.hs
+++ b/lens-labels/src/Lens/Labels.hs
@@ -33,6 +33,7 @@ module Lens.Labels (
     (&),
     (Category..),
     Lens,
+    Lens',
     -- * HasLens
     HasLens(..),
     Proxy#,
@@ -69,6 +70,7 @@ newtype LensFn a b = LensFn {runLens :: a -> b}
 type LensLike f s t a b = LensFn (a -> f b) (s -> f t)
 type LensLike' f s a = LensLike f s s a a
 type Lens s t a b = forall f . Functor f => LensLike f s t a b
+type Lens' s a = Lens s s a a
 
 -- | A type class for lens fields.
 class HasLens f s t (x :: Symbol) a b
@@ -117,8 +119,10 @@ infixr 4 %~
 
 type Getting r s t a b = LensLike (Const r) s t a b
 
-(^.), view :: s -> Getting a s t a b -> a
+(^.) :: s -> Getting a s t a b -> a
 s ^. f = getConst $ runLens f Const s
-view = (^.)
+
+view :: Getting a s t a b -> s -> a
+view = flip (^.)
 
 infixl 8 ^.

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -213,3 +213,17 @@ tests:
     other-modules:
       - Proto.UnknownFields
       - Proto.UnknownFields'Fields
+
+  imports_test:
+    main: imports_test.hs
+    source-dirs: tests
+    dependencies:
+      - lens-labels
+      - proto-lens-tests
+    other-modules:
+      - Proto.Enum
+      - Proto.Imports
+      - Proto.ImportsDep
+      - Proto.ImportsTransitive
+      - Proto.ImportsTransitive2
+      - Proto.Nested

--- a/proto-lens-tests/tests/imports.proto
+++ b/proto-lens-tests/tests/imports.proto
@@ -6,8 +6,8 @@ import "enum.proto";
 import "imports_dep.proto";
 import "nested.proto";
 
-// Test that we can import from proto-lens-descriptors, which is special
-// due to bootstrapping:
+// Test that we can import descriptor-related modules, which are special due
+// to bootstrapping:
 import "google/protobuf/descriptor.proto";
 import "google/protobuf/compiler/plugin.proto";
 

--- a/proto-lens-tests/tests/imports_test.hs
+++ b/proto-lens-tests/tests/imports_test.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Main where
+
+import Data.Default.Class (Default(def))
+import Lens.Labels (Lens', view, set)
+import Test.Framework.Providers.HUnit (testCase)
+import Test.HUnit ((@=?))
+
+import Data.ProtoLens.TestUtil (Test, testMain)
+import qualified Proto.Enum as Enum
+import qualified Proto.Imports as Imports
+import qualified Proto.ImportsDep as ImportsDep
+import qualified Proto.Nested as Nested
+import qualified Proto.ImportsTransitive as ImportsTransitive
+import qualified Proto.ImportsTransitive2 as ImportsTransitive2
+import qualified Proto.Google.Protobuf.Compiler.Plugin as Plugin
+import qualified Proto.Google.Protobuf.Descriptor as Descriptor
+
+main :: IO ()
+main = testMain
+    [ testFoo
+    , testUseDep
+    , testUseBootstrapped
+    ]
+
+-- A simple check that a type is a sub-field of another type.
+-- (In this test, we're checking that the sub-field type got imported
+-- correctly from another file.)
+testField
+    :: forall a b . (Default a, Default b, Eq b, Show b)
+    => Lens' a b -> IO ()
+testField f = def @=? view f (set f def def)
+
+testFoo :: Test
+testFoo = testCase "testFoo" $ do
+    testField @Imports.Foo @Nested.A #a
+    testField @Imports.Foo @Nested.A'B #b
+    -- Check that it uses the (proto2 non-zero) default values which were
+    -- part of a different module:
+    Enum.BAR5 @=? view #bar (def :: Imports.Foo)
+    Enum.Foo'BAZ4 @=? view #baz (def :: Imports.Foo)
+
+testUseDep :: Test
+testUseDep = testCase "testUseDep" $ do
+    testField @Imports.UseDep @ImportsDep.DepPkg #foo
+    testField @Imports.UseDep @ImportsTransitive.TransitiveDep #bar
+    testField @Imports.UseDep @ImportsTransitive2.TransitiveDep2 #baz
+
+testUseBootstrapped :: Test
+testUseBootstrapped = testCase "testUseBootstrapped" $ do
+    testField @Imports.UseBootstrapped @Descriptor.DescriptorProto #descriptor
+    testField @Imports.UseBootstrapped @Plugin.CodeGeneratorRequest #request


### PR DESCRIPTION
Also, minor changes to `lens-labels`:
- Export a `Lens'` type synonym
- Swap the order of `view` to match other packages.

Originally, `imports.proto` and its dependencies were compiled automatically
along with everything in the `tests` folder.  However, we changed the behavior
in #126 to ignore proto files that aren't actually being used in some Cabal
component.

Fixed by adding an explicit test for that file.