### PR TITLE
Update changelogs.

### DIFF
--- a/lens-labels/Changelog.md
+++ b/lens-labels/Changelog.md
@@ -1,6 +1,9 @@
 # Changelog for `lens-labels`
 
 ## Unreleased changes
+- Improve readability of `HasLens` instances. (#118)
+- Remove support for `ghc-7.10`. (#136)
+- Use a `.cabal` file that's auto-generated from `hpack`. (#138)
 
 ## v0.1.0.2
 - Bump the dependency on `base` to support `ghc-8.2.1`.

--- a/proto-lens-arbitrary/Changelog.md
+++ b/proto-lens-arbitrary/Changelog.md
@@ -1,6 +1,11 @@
 # Changelog for `proto-lens-arbitrary`
 
 ## Unreleased changes
+- Remove support for `ghc-7.10`. (#136)
+- Use a `.cabal` file that's auto-generated from `hpack`. (#138)
+- Track `proto-lens` change: split the `Message` class into
+  separate methods. (#139)
+
 
 ## v0.1.1.1
 - Bump the dependency on `base` to support `ghc-8.2.1`.

--- a/proto-lens-combinators/Changelog.md
+++ b/proto-lens-combinators/Changelog.md
@@ -1,6 +1,9 @@
 # Changelog for `proto-lens-combinators`
 
 ## Unreleased changes
+- Track proto-lens change: separate types into their own module. (#100)
+- Remove support for `ghc-7.10`. (#136)
+- Use a `.cabal` file that's auto-generated from `hpack`. (#138)
 
 ## 0.1.0.8
 - Bump the dependency on `base` to support `ghc-8.2.1`.

--- a/proto-lens-optparse/Changelog.md
+++ b/proto-lens-optparse/Changelog.md
@@ -1,6 +1,8 @@
 # Changelog for `proto-lens-optparse`
 
 ## Unreleased changes
+- Remove support for `ghc-7.10`. (#136)
+- Use a `.cabal` file that's auto-generated from `hpack`. (#138)
 
 ## v0.1.0.4
 - Bump the dependency on `base` to support `ghc-8.2.1`.

--- a/proto-lens-protobuf-types/Changelog.md
+++ b/proto-lens-protobuf-types/Changelog.md
@@ -1,6 +1,12 @@
 # Changelog for `proto-lens-protobuf-types`
 
 ## Unreleased changes
+- Remove support for `ghc-7.10`. (#136)
+- Use a `.cabal` file that's auto-generated from `hpack`. (#138)
+- Separate types into their own module, apart from field lenses. (#100)
+- Track `proto-lens` change: split the `Message` class into
+  separate methods. (#139)
+
 
 ## v0.2.2.0
 - Add the `Data.ProtoLens.Any` module for storing arbitrary Messages (#88).

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -1,6 +1,15 @@
 # Changelog for `proto-lens-protoc`
 
 ## Unreleased changes
+- Remove support for `ghc-7.10`. (#136)
+- Use a `.cabal` file that's auto-generated from `hpack`. (#138)
+- Separate types into their own module, apart from field lenses.
+- Improve readability of `HasLens` instances. (#118)
+- Add support for tracking unknown fields. (#129)
+- Don't generate Haskell modules if they won't be used. (#126)
+- Bundle enum pattern synonyms exports with their type. (#136)
+- Implement proto3-style "open" enums. (#137)
+- Split the `Message` class into separate methods.
 
 ## v0.2.2.3
 - Don't camel-case message names.  This reverts behavior which was added

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -1,6 +1,16 @@
 # Changelog for `proto-lens`
 
 ## Unreleased changes
+- Remove support for `ghc-7.10`. (#136)
+- Use a `.cabal` file that's auto-generated from `hpack`. (#138)
+- Add buildMessageDelimited: size-delimited streams of Messages (#102)
+- Add support for parsing `Any` messages in google protobuf text format (#124)
+- Use the Tag newtype consistently. (#127)
+- Add support for tracking unknown fields. (#129)
+- Improve an error message. (#132)
+- Bundle enum pattern synonyms with their type. (#136)
+- Implement proto3-style "open" enums. (#137)
+- Consolidate `proto-lens-descriptors` into `proto-lens`.
 
 ## v0.2.2.0
 - Bump the dependency on `base` to support `ghc-8.2.1`.


### PR DESCRIPTION
In the future we ought to do this "in place" whenever we submit a PR.
It wasn't too bad this time though, since we have proper tags for
the previous releases.