### PR TITLE
Refactor `FieldTypeDescriptor`.

### DIFF
--- a/proto-lens-arbitrary/Changelog.md
+++ b/proto-lens-arbitrary/Changelog.md
@@ -3,8 +3,7 @@
 ## v0.1.1.2
 - Remove support for `ghc-7.10`. (#136)
 - Use a `.cabal` file that's auto-generated from `hpack`. (#138)
-- Track `proto-lens` change: split the `Message` class into
-  separate methods. (#139)
+- Track `proto-lens` changes to the `Message` class. (#139, #147)
 
 
 ## v0.1.1.1

--- a/proto-lens-arbitrary/src/Data/ProtoLens/Arbitrary.hs
+++ b/proto-lens-arbitrary/src/Data/ProtoLens/Arbitrary.hs
@@ -6,6 +6,7 @@
 
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 -- | An Arbitrary instance for protocol buffer Messages to use with QuickCheck.
 module Data.ProtoLens.Arbitrary
@@ -64,9 +65,12 @@ arbitraryField (FieldDescriptor _ ftd fa) = case fa of
     fieldGen = arbitraryFieldValue ftd
 
 arbitraryFieldValue :: FieldTypeDescriptor value -> Gen value
-arbitraryFieldValue ftd = case ftd of
-    MessageField -> arbitraryMessage
-    GroupField -> arbitraryMessage
+arbitraryFieldValue = \case
+    MessageField _ -> arbitraryMessage
+    ScalarField f -> arbitraryScalarValue f
+
+arbitraryScalarValue :: ScalarField value -> Gen value
+arbitraryScalarValue = \case
     -- For enum fields, all we know is that the value is an instance of
     -- MessageEnum, meaning we can only use fromEnum, toEnum, or maybeToEnum. So
     -- we must rely on the instance of Arbitrary for Int and filter out only the
@@ -115,9 +119,12 @@ shrinkField (FieldDescriptor _ ftd fa) = case fa of
     fieldShrinker = shrinkFieldValue ftd
 
 shrinkFieldValue :: FieldTypeDescriptor value -> value -> [value]
-shrinkFieldValue ftd = case ftd of
-    MessageField -> shrinkMessage
-    GroupField -> map unArbitraryMessage . shrink . ArbitraryMessage
+shrinkFieldValue = \case
+    MessageField _ -> shrinkMessage
+    ScalarField f -> shrinkScalarValue f
+
+shrinkScalarValue :: ScalarField value -> value -> [value]
+shrinkScalarValue = \case
     -- Shrink to the 0-equivalent Enum value if it's both a valid Enum value
     -- and the value isn't already 0.
     EnumField -> case maybeToEnum 0 of

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -10,6 +10,7 @@
 - Bundle enum pattern synonyms exports with their type. (#136)
 - Implement proto3-style "open" enums. (#137)
 - Split the `Message` class into separate methods. (#139)
+- Refactor the `FieldDescriptorType. (#147)
 
 ## v0.2.2.3
 - Don't camel-case message names.  This reverts behavior which was added

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -6,6 +6,7 @@
 
 -- | This module builds the actual, generated Haskell file
 -- for a given input .proto file.
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Data.ProtoLens.Compiler.Generate(
     generateModule,
@@ -894,23 +895,25 @@ isPackedField s f = case f ^. options . maybe'packed of
                       ]
 
 fieldTypeDescriptorExpr :: FieldDescriptorProto'Type -> Exp
-fieldTypeDescriptorExpr =
-    (\n -> fromString $ "Data.ProtoLens." ++ n ++ "Field") . \t -> case t of
-    FieldDescriptorProto'TYPE_DOUBLE -> "Double"
-    FieldDescriptorProto'TYPE_FLOAT -> "Float"
-    FieldDescriptorProto'TYPE_INT64 -> "Int64"
-    FieldDescriptorProto'TYPE_UINT64 -> "UInt64"
-    FieldDescriptorProto'TYPE_INT32 -> "Int32"
-    FieldDescriptorProto'TYPE_FIXED64 -> "Fixed64"
-    FieldDescriptorProto'TYPE_FIXED32 -> "Fixed32"
-    FieldDescriptorProto'TYPE_BOOL -> "Bool"
-    FieldDescriptorProto'TYPE_STRING -> "String"
-    FieldDescriptorProto'TYPE_GROUP -> "Group"
-    FieldDescriptorProto'TYPE_MESSAGE -> "Message"
-    FieldDescriptorProto'TYPE_BYTES -> "Bytes"
-    FieldDescriptorProto'TYPE_UINT32 -> "UInt32"
-    FieldDescriptorProto'TYPE_ENUM -> "Enum"
-    FieldDescriptorProto'TYPE_SFIXED32 -> "SFixed32"
-    FieldDescriptorProto'TYPE_SFIXED64 -> "SFixed64"
-    FieldDescriptorProto'TYPE_SINT32 -> "SInt32"
-    FieldDescriptorProto'TYPE_SINT64 -> "SInt64"
+fieldTypeDescriptorExpr = \case
+    FieldDescriptorProto'TYPE_DOUBLE -> mk "ScalarField" "DoubleField"
+    FieldDescriptorProto'TYPE_FLOAT -> mk "ScalarField" "FloatField"
+    FieldDescriptorProto'TYPE_INT64 -> mk "ScalarField" "Int64Field"
+    FieldDescriptorProto'TYPE_UINT64 -> mk "ScalarField" "UInt64Field"
+    FieldDescriptorProto'TYPE_INT32 -> mk "ScalarField" "Int32Field"
+    FieldDescriptorProto'TYPE_FIXED64 -> mk "ScalarField" "Fixed64Field"
+    FieldDescriptorProto'TYPE_FIXED32 -> mk "ScalarField" "Fixed32Field"
+    FieldDescriptorProto'TYPE_BOOL -> mk "ScalarField" "BoolField"
+    FieldDescriptorProto'TYPE_STRING -> mk "ScalarField" "StringField"
+    FieldDescriptorProto'TYPE_GROUP -> mk "MessageField" "GroupType"
+    FieldDescriptorProto'TYPE_MESSAGE -> mk "MessageField" "MessageType"
+    FieldDescriptorProto'TYPE_BYTES -> mk "ScalarField" "BytesField"
+    FieldDescriptorProto'TYPE_UINT32 -> mk "ScalarField" "UInt32Field"
+    FieldDescriptorProto'TYPE_ENUM -> mk "ScalarField" "EnumField"
+    FieldDescriptorProto'TYPE_SFIXED32 -> mk "ScalarField" "SFixed32Field"
+    FieldDescriptorProto'TYPE_SFIXED64 -> mk "ScalarField" "SFixed64Field"
+    FieldDescriptorProto'TYPE_SINT32 -> mk "ScalarField" "SInt32Field"
+    FieldDescriptorProto'TYPE_SINT64 -> mk "ScalarField" "SInt64Field"
+  where
+    mk x y = fromString ("Data.ProtoLens." ++ x)
+              @@ fromString ("Data.ProtoLens." ++ y)

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -12,6 +12,7 @@
 - Implement proto3-style "open" enums. (#137)
 - Consolidate `proto-lens-descriptors` into `proto-lens`. (#140)
 - Split the `Message` class into separate methods. (#139)
+- Refactor the `FieldDescriptorType. (#147)
 
 ## v0.2.2.0
 - Bump the dependency on `base` to support `ghc-8.2.1`.

--- a/proto-lens/src/Data/ProtoLens/TextFormat.hs
+++ b/proto-lens/src/Data/ProtoLens/TextFormat.hs
@@ -24,6 +24,7 @@ module Data.ProtoLens.TextFormat(
 
 import Lens.Family2 ((&),(^.),(.~), set, over, view)
 import Control.Arrow (left)
+import Data.Bifunctor (first)
 import qualified Data.ByteString
 import Data.Char (isPrint, isAscii, chr)
 import Data.Foldable (foldlM, foldl')
@@ -103,7 +104,7 @@ pprintField reg msg (FieldDescriptor name typeDescr accessor)
                                       & v .~ y
 
 pprintFieldValue :: Registry -> String -> FieldTypeDescriptor value -> value -> Doc
-pprintFieldValue reg name field@MessageField m
+pprintFieldValue reg name field@(MessageField MessageType) m
   | Just AnyMessageDescriptor { anyTypeUrlLens, anyValueLens } <- matchAnyMessage field,
     typeUri <- view anyTypeUrlLens m,
     fieldData <- view anyValueLens m,
@@ -116,24 +117,31 @@ pprintFieldValue reg name field@MessageField m
             , rbrace ]
   | otherwise =
       pprintSubmessage name (pprintMessageWithRegistry reg m)
-pprintFieldValue _ name EnumField x = text name <> colon <+> text (showEnum x)
-pprintFieldValue _ name Int32Field x = primField name x
-pprintFieldValue _ name Int64Field x = primField name x
-pprintFieldValue _ name UInt32Field x = primField name x
-pprintFieldValue _ name UInt64Field x = primField name x
-pprintFieldValue _ name SInt32Field x = primField name x
-pprintFieldValue _ name SInt64Field x = primField name x
-pprintFieldValue _ name Fixed32Field x = primField name x
-pprintFieldValue _ name Fixed64Field x = primField name x
-pprintFieldValue _ name SFixed32Field x = primField name x
-pprintFieldValue _ name SFixed64Field x = primField name x
-pprintFieldValue _ name FloatField x = primField name x
-pprintFieldValue _ name DoubleField x = primField name x
-pprintFieldValue _ name BoolField x = text name <> colon <+> boolValue x
-pprintFieldValue _ name StringField x = pprintByteString name (Text.encodeUtf8 x)
-pprintFieldValue _ name BytesField x = pprintByteString name x
-pprintFieldValue reg name GroupField m
+pprintFieldValue reg name (MessageField GroupType) m
     = pprintSubmessage name (pprintMessageWithRegistry reg m)
+pprintFieldValue _ name (ScalarField f) x = named name $ pprintScalarValue f x
+
+named :: String -> Doc -> Doc
+named n x = text n <> colon <+> x
+
+
+pprintScalarValue :: ScalarField value -> value -> Doc
+pprintScalarValue EnumField x = text (showEnum x)
+pprintScalarValue Int32Field x = primField x
+pprintScalarValue Int64Field x = primField x
+pprintScalarValue UInt32Field x = primField x
+pprintScalarValue UInt64Field x = primField x
+pprintScalarValue SInt32Field x = primField x
+pprintScalarValue SInt64Field x = primField x
+pprintScalarValue Fixed32Field x = primField x
+pprintScalarValue Fixed64Field x = primField x
+pprintScalarValue SFixed32Field x = primField x
+pprintScalarValue SFixed64Field x = primField x
+pprintScalarValue FloatField x = primField x
+pprintScalarValue DoubleField x = primField x
+pprintScalarValue BoolField x = boolValue x
+pprintScalarValue StringField x = pprintByteString (Text.encodeUtf8 x)
+pprintScalarValue BytesField x = pprintByteString x
 
 pprintSubmessage :: String -> Doc -> Doc
 pprintSubmessage name contents =
@@ -148,8 +156,8 @@ pprintSubmessage name contents =
 -- and \\ only.  Note that Haskell string-literal syntax calls for "\011" to be
 -- interpreted as decimal 11, rather than the decimal 9 it actually represent,
 -- so you can't use Prelude.read to parse the strings created here.
-pprintByteString :: String -> Data.ByteString.ByteString -> Doc
-pprintByteString name x = text name <> colon <+> char '\"'
+pprintByteString :: Data.ByteString.ByteString -> Doc
+pprintByteString x = char '\"'
     <> text (concatMap escape $ Data.ByteString.unpack x) <> char '\"'
   where escape w8 | ch == '\n'               = "\\n"
                   | ch == '\r'               = "\\r"
@@ -163,8 +171,8 @@ pprintByteString name x = text name <> colon <+> char '\"'
             ch = chr $ fromIntegral w8
             pad str = replicate (3 - length str) '0' ++ str
 
-primField :: Show value => String -> value -> Doc
-primField name x = text name <> colon <+> text (show x)
+primField :: Show value => value -> Doc
+primField x = text (show x)
 
 boolValue :: Bool -> Doc
 boolValue True = text "true"
@@ -172,16 +180,16 @@ boolValue False = text "false"
 
 pprintTaggedValue :: TaggedValue -> Doc
 pprintTaggedValue (TaggedValue t (WireValue v x)) = case v of
-    VarInt -> primField name x
-    Fixed64 -> primField name x
-    Fixed32 -> primField name x
+    VarInt -> named name $ primField x
+    Fixed64 -> named name $ primField x
+    Fixed32 -> named name $ primField x
     Lengthy -> case decodeFieldSet x of
-                  Left _ -> pprintByteString name x
+                  Left _ -> named name $ pprintByteString x
                   Right ts -> pprintSubmessage name
                                 $ sep $ map pprintTaggedValue ts
     -- TODO: implement better printing for unknown groups
-    StartGroup -> text name <> colon <+> text "start_group"
-    EndGroup -> text name <> colon <+> text "end_group"
+    StartGroup -> named name $ text "start_group"
+    EndGroup -> named name $ text "end_group"
   where
     name = show (unTag t)
 
@@ -253,39 +261,8 @@ modifyField (MapField key value f) mapElem
     = over f (Map.insert (mapElem ^. key) (mapElem ^. value))
 
 makeValue :: forall value. Registry -> FieldTypeDescriptor value -> Parser.Value -> Either String value
-makeValue _ Int32Field (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ Int64Field (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ UInt32Field (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ UInt64Field (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ SInt32Field (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ SInt64Field (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ Fixed32Field (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ Fixed64Field (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ SFixed32Field (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ SFixed64Field (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ FloatField (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ DoubleField (Parser.IntValue x) = Right (fromInteger x)
-makeValue _ BoolField (Parser.IntValue x)
-    | x == 0 = Right False
-    | x == 1 = Right True
-    | otherwise = Left $ "Unrecognized bool value " ++ show x
-makeValue _ DoubleField (Parser.DoubleValue x) = Right x
-makeValue _ FloatField (Parser.DoubleValue x) = Right (realToFrac x)
-makeValue _ BoolField (Parser.EnumValue x)
-    | x == "true" = Right True
-    | x == "false" = Right False
-    | otherwise = Left $ "Unrecognized bool value " ++ show x
-makeValue _ StringField (Parser.ByteStringValue x) = Right (Text.decodeUtf8 x)
-makeValue _ BytesField (Parser.ByteStringValue x) = Right x
-makeValue _ EnumField (Parser.IntValue x) =
-    maybe (Left $ "Unrecognized enum value " ++ show x) Right
-        (maybeToEnum $ fromInteger x)
-makeValue _ EnumField (Parser.EnumValue x) =
-    maybe (Left $ "Unrecognized enum value " ++ show x) Right
-        (readEnum x)
-makeValue reg MessageField (Parser.MessageValue Nothing x) =
-  buildMessage reg x
-makeValue reg field@MessageField (Parser.MessageValue (Just typeUri) x)
+makeValue _ (ScalarField f) v = makeScalarValue f v
+makeValue reg field@(MessageField MessageType) (Parser.MessageValue (Just typeUri) x)
     | Just AnyMessageDescriptor { anyTypeUrlLens, anyValueLens } <- matchAnyMessage field =
         case lookupRegistered typeUri reg of
           Nothing -> Left $ "Could not decode google.protobuf.Any: "
@@ -299,5 +276,37 @@ makeValue reg field@MessageField (Parser.MessageValue (Just typeUri) x)
     | otherwise = Left ("Type mismatch parsing explicitly typed message. Expected " ++
                         show (messageName (Proxy @value))  ++
                         ", got " ++ show typeUri)
-makeValue reg GroupField (Parser.MessageValue _ x) = buildMessage reg x
-makeValue _ f val = Left $ "Type mismatch parsing text format: " ++ show (f, val)
+makeValue reg (MessageField _) (Parser.MessageValue _ x) = buildMessage reg x
+
+makeScalarValue :: ScalarField value -> Parser.Value -> Either String value
+makeScalarValue Int32Field (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue Int64Field (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue UInt32Field (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue UInt64Field (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue SInt32Field (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue SInt64Field (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue Fixed32Field (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue Fixed64Field (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue SFixed32Field (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue SFixed64Field (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue FloatField (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue DoubleField (Parser.IntValue x) = Right (fromInteger x)
+makeScalarValue BoolField (Parser.IntValue x)
+    | x == 0 = Right False
+    | x == 1 = Right True
+    | otherwise = Left $ "Unrecognized bool value " ++ show x
+makeScalarValue DoubleField (Parser.DoubleValue x) = Right x
+makeScalarValue FloatField (Parser.DoubleValue x) = Right (realToFrac x)
+makeScalarValue BoolField (Parser.EnumValue x)
+    | x == "true" = Right True
+    | x == "false" = Right False
+    | otherwise = Left $ "Unrecognized bool value " ++ show x
+makeScalarValue StringField (Parser.ByteStringValue x) = Right (Text.decodeUtf8 x)
+makeScalarValue BytesField (Parser.ByteStringValue x) = Right x
+makeScalarValue EnumField (Parser.IntValue x) =
+    maybe (Left $ "Unrecognized enum value " ++ show x) Right
+        (maybeToEnum $ fromInteger x)
+makeScalarValue EnumField (Parser.EnumValue x) =
+    maybe (Left $ "Unrecognized enum value " ++ show x) Right
+        (readEnum x)
+makeScalarValue f val = Left $ "Type mismatch: " ++ show (f, val)

--- a/proto-lens/src/Data/ProtoLens/TextFormat.hs
+++ b/proto-lens/src/Data/ProtoLens/TextFormat.hs
@@ -24,7 +24,6 @@ module Data.ProtoLens.TextFormat(
 
 import Lens.Family2 ((&),(^.),(.~), set, over, view)
 import Control.Arrow (left)
-import Data.Bifunctor (first)
 import qualified Data.ByteString
 import Data.Char (isPrint, isAscii, chr)
 import Data.Foldable (foldlM, foldl')
@@ -277,6 +276,7 @@ makeValue reg field@(MessageField MessageType) (Parser.MessageValue (Just typeUr
                         show (messageName (Proxy @value))  ++
                         ", got " ++ show typeUri)
 makeValue reg (MessageField _) (Parser.MessageValue _ x) = buildMessage reg x
+makeValue _ (MessageField _) val = Left $ "Type mismatch: expected message, found " ++ show val
 
 makeScalarValue :: ScalarField value -> Parser.Value -> Either String value
 makeScalarValue Int32Field (Parser.IntValue x) = Right (fromInteger x)

--- a/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -86,7 +86,7 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
         fieldsByTag
           = let fileToGenerate__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "file_to_generate"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -94,7 +94,7 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                       :: Data.ProtoLens.FieldDescriptor CodeGeneratorRequest
                 parameter__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "parameter"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -102,7 +102,7 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                       :: Data.ProtoLens.FieldDescriptor CodeGeneratorRequest
                 protoFile__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "proto_file"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor
                            Proto.Google.Protobuf.Descriptor.FileDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
@@ -170,7 +170,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
         fieldsByTag
           = let error__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "error"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -178,7 +178,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
                       :: Data.ProtoLens.FieldDescriptor CodeGeneratorResponse
                 file__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "file"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor CodeGeneratorResponse'File)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -279,7 +279,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
         fieldsByTag
           = let name__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -287,7 +287,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
                       :: Data.ProtoLens.FieldDescriptor CodeGeneratorResponse'File
                 insertionPoint__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "insertion_point"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -296,7 +296,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
                       :: Data.ProtoLens.FieldDescriptor CodeGeneratorResponse'File
                 content__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "content"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf

--- a/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
@@ -172,7 +172,7 @@ instance Data.ProtoLens.Message DescriptorProto where
         fieldsByTag
           = let name__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -180,7 +180,7 @@ instance Data.ProtoLens.Message DescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto
                 field__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "field"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor FieldDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -188,7 +188,7 @@ instance Data.ProtoLens.Message DescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto
                 extension__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "extension"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor FieldDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -196,7 +196,7 @@ instance Data.ProtoLens.Message DescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto
                 nestedType__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "nested_type"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor DescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -204,7 +204,7 @@ instance Data.ProtoLens.Message DescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto
                 enumType__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "enum_type"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor EnumDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -212,7 +212,7 @@ instance Data.ProtoLens.Message DescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto
                 extensionRange__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "extension_range"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor DescriptorProto'ExtensionRange)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -220,7 +220,7 @@ instance Data.ProtoLens.Message DescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto
                 oneofDecl__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "oneof_decl"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor OneofDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -228,7 +228,7 @@ instance Data.ProtoLens.Message DescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto
                 options__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "options"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor MessageOptions)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -236,7 +236,7 @@ instance Data.ProtoLens.Message DescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto
                 reservedRange__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "reserved_range"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor DescriptorProto'ReservedRange)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -244,7 +244,7 @@ instance Data.ProtoLens.Message DescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto
                 reservedName__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "reserved_name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -334,7 +334,7 @@ instance Data.ProtoLens.Message DescriptorProto'ExtensionRange
         fieldsByTag
           = let start__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "start"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -342,7 +342,7 @@ instance Data.ProtoLens.Message DescriptorProto'ExtensionRange
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto'ExtensionRange
                 end__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "end"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -422,7 +422,7 @@ instance Data.ProtoLens.Message DescriptorProto'ReservedRange where
         fieldsByTag
           = let start__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "start"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -430,7 +430,7 @@ instance Data.ProtoLens.Message DescriptorProto'ReservedRange where
                       :: Data.ProtoLens.FieldDescriptor DescriptorProto'ReservedRange
                 end__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "end"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -516,7 +516,7 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
         fieldsByTag
           = let name__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -524,7 +524,7 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor EnumDescriptorProto
                 value__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "value"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor EnumValueDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -532,7 +532,7 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor EnumDescriptorProto
                 options__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "options"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor EnumOptions)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -610,7 +610,7 @@ instance Data.ProtoLens.Message EnumOptions where
         fieldsByTag
           = let allowAlias__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "allow_alias"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -618,7 +618,7 @@ instance Data.ProtoLens.Message EnumOptions where
                       :: Data.ProtoLens.FieldDescriptor EnumOptions
                 deprecated__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "deprecated"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -626,7 +626,7 @@ instance Data.ProtoLens.Message EnumOptions where
                       :: Data.ProtoLens.FieldDescriptor EnumOptions
                 uninterpretedOption__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "uninterpreted_option"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor UninterpretedOption)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -723,7 +723,7 @@ instance Data.ProtoLens.Message EnumValueDescriptorProto where
         fieldsByTag
           = let name__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -731,7 +731,7 @@ instance Data.ProtoLens.Message EnumValueDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor EnumValueDescriptorProto
                 number__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "number"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -739,7 +739,7 @@ instance Data.ProtoLens.Message EnumValueDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor EnumValueDescriptorProto
                 options__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "options"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor EnumValueOptions)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -804,7 +804,7 @@ instance Data.ProtoLens.Message EnumValueOptions where
         fieldsByTag
           = let deprecated__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "deprecated"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -812,7 +812,7 @@ instance Data.ProtoLens.Message EnumValueOptions where
                       :: Data.ProtoLens.FieldDescriptor EnumValueOptions
                 uninterpretedOption__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "uninterpreted_option"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor UninterpretedOption)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -1048,7 +1048,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
         fieldsByTag
           = let name__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1056,7 +1056,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FieldDescriptorProto
                 number__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "number"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1064,7 +1064,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FieldDescriptorProto
                 label__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "label"
-                      (Data.ProtoLens.EnumField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.EnumField ::
                          Data.ProtoLens.FieldTypeDescriptor FieldDescriptorProto'Label)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1072,7 +1072,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FieldDescriptorProto
                 type'__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "type"
-                      (Data.ProtoLens.EnumField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.EnumField ::
                          Data.ProtoLens.FieldTypeDescriptor FieldDescriptorProto'Type)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1080,7 +1080,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FieldDescriptorProto
                 typeName__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "type_name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1088,7 +1088,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FieldDescriptorProto
                 extendee__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "extendee"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1096,7 +1096,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FieldDescriptorProto
                 defaultValue__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "default_value"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1105,7 +1105,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FieldDescriptorProto
                 oneofIndex__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "oneof_index"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1113,7 +1113,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FieldDescriptorProto
                 jsonName__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "json_name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1121,7 +1121,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FieldDescriptorProto
                 options__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "options"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor FieldOptions)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1552,7 +1552,7 @@ instance Data.ProtoLens.Message FieldOptions where
         fieldsByTag
           = let ctype__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "ctype"
-                      (Data.ProtoLens.EnumField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.EnumField ::
                          Data.ProtoLens.FieldTypeDescriptor FieldOptions'CType)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1560,7 +1560,7 @@ instance Data.ProtoLens.Message FieldOptions where
                       :: Data.ProtoLens.FieldDescriptor FieldOptions
                 packed__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "packed"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1568,7 +1568,7 @@ instance Data.ProtoLens.Message FieldOptions where
                       :: Data.ProtoLens.FieldDescriptor FieldOptions
                 jstype__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "jstype"
-                      (Data.ProtoLens.EnumField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.EnumField ::
                          Data.ProtoLens.FieldTypeDescriptor FieldOptions'JSType)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1576,7 +1576,7 @@ instance Data.ProtoLens.Message FieldOptions where
                       :: Data.ProtoLens.FieldDescriptor FieldOptions
                 lazy__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "lazy"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1584,7 +1584,7 @@ instance Data.ProtoLens.Message FieldOptions where
                       :: Data.ProtoLens.FieldDescriptor FieldOptions
                 deprecated__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "deprecated"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1592,7 +1592,7 @@ instance Data.ProtoLens.Message FieldOptions where
                       :: Data.ProtoLens.FieldDescriptor FieldOptions
                 weak__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "weak"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1600,7 +1600,7 @@ instance Data.ProtoLens.Message FieldOptions where
                       :: Data.ProtoLens.FieldDescriptor FieldOptions
                 uninterpretedOption__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "uninterpreted_option"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor UninterpretedOption)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -1923,7 +1923,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
         fieldsByTag
           = let name__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1931,7 +1931,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
                 package__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "package"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -1939,7 +1939,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
                 dependency__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "dependency"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -1947,7 +1947,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
                 publicDependency__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "public_dependency"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -1955,7 +1955,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
                 weakDependency__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "weak_dependency"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -1963,7 +1963,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
                 messageType__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "message_type"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor DescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -1971,7 +1971,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
                 enumType__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "enum_type"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor EnumDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -1979,7 +1979,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
                 service__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "service"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor ServiceDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -1987,7 +1987,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
                 extension__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "extension"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor FieldDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -1995,7 +1995,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
                 options__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "options"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor FileOptions)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2003,7 +2003,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
                 sourceCodeInfo__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "source_code_info"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor SourceCodeInfo)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2012,7 +2012,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor FileDescriptorProto
                 syntax__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "syntax"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2065,7 +2065,7 @@ instance Data.ProtoLens.Message FileDescriptorSet where
         fieldsByTag
           = let file__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "file"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor FileDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -2359,7 +2359,7 @@ instance Data.ProtoLens.Message FileOptions where
         fieldsByTag
           = let javaPackage__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "java_package"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2368,7 +2368,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 javaOuterClassname__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "java_outer_classname"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2377,7 +2377,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 javaMultipleFiles__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "java_multiple_files"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2386,7 +2386,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 javaGenerateEqualsAndHash__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "java_generate_equals_and_hash"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2395,7 +2395,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 javaStringCheckUtf8__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "java_string_check_utf8"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2404,7 +2404,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 optimizeFor__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "optimize_for"
-                      (Data.ProtoLens.EnumField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.EnumField ::
                          Data.ProtoLens.FieldTypeDescriptor FileOptions'OptimizeMode)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2413,7 +2413,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 goPackage__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "go_package"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2421,7 +2421,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 ccGenericServices__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "cc_generic_services"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2430,7 +2430,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 javaGenericServices__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "java_generic_services"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2439,7 +2439,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 pyGenericServices__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "py_generic_services"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2448,7 +2448,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 deprecated__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "deprecated"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2456,7 +2456,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 ccEnableArenas__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "cc_enable_arenas"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2465,7 +2465,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 objcClassPrefix__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "objc_class_prefix"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2474,7 +2474,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 csharpNamespace__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "csharp_namespace"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2483,7 +2483,7 @@ instance Data.ProtoLens.Message FileOptions where
                       :: Data.ProtoLens.FieldDescriptor FileOptions
                 uninterpretedOption__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "uninterpreted_option"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor UninterpretedOption)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -2596,7 +2596,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo where
         fieldsByTag
           = let annotation__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "annotation"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor GeneratedCodeInfo'Annotation)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -2704,7 +2704,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
         fieldsByTag
           = let path__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "path"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Packed
                          (Lens.Labels.lensOf
@@ -2712,7 +2712,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                       :: Data.ProtoLens.FieldDescriptor GeneratedCodeInfo'Annotation
                 sourceFile__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "source_file"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2720,7 +2720,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                       :: Data.ProtoLens.FieldDescriptor GeneratedCodeInfo'Annotation
                 begin__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "begin"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2728,7 +2728,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                       :: Data.ProtoLens.FieldDescriptor GeneratedCodeInfo'Annotation
                 end__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "end"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2852,7 +2852,7 @@ instance Data.ProtoLens.Message MessageOptions where
         fieldsByTag
           = let messageSetWireFormat__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "message_set_wire_format"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2861,7 +2861,7 @@ instance Data.ProtoLens.Message MessageOptions where
                       :: Data.ProtoLens.FieldDescriptor MessageOptions
                 noStandardDescriptorAccessor__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "no_standard_descriptor_accessor"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2870,7 +2870,7 @@ instance Data.ProtoLens.Message MessageOptions where
                       :: Data.ProtoLens.FieldDescriptor MessageOptions
                 deprecated__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "deprecated"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2878,7 +2878,7 @@ instance Data.ProtoLens.Message MessageOptions where
                       :: Data.ProtoLens.FieldDescriptor MessageOptions
                 mapEntry__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "map_entry"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -2886,7 +2886,7 @@ instance Data.ProtoLens.Message MessageOptions where
                       :: Data.ProtoLens.FieldDescriptor MessageOptions
                 uninterpretedOption__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "uninterpreted_option"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor UninterpretedOption)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -3046,7 +3046,7 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
         fieldsByTag
           = let name__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3054,7 +3054,7 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor MethodDescriptorProto
                 inputType__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "input_type"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3062,7 +3062,7 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor MethodDescriptorProto
                 outputType__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "output_type"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3070,7 +3070,7 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor MethodDescriptorProto
                 options__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "options"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor MethodOptions)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3078,7 +3078,7 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor MethodDescriptorProto
                 clientStreaming__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "client_streaming"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3087,7 +3087,7 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor MethodDescriptorProto
                 serverStreaming__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "server_streaming"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3151,7 +3151,7 @@ instance Data.ProtoLens.Message MethodOptions where
         fieldsByTag
           = let deprecated__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "deprecated"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3159,7 +3159,7 @@ instance Data.ProtoLens.Message MethodOptions where
                       :: Data.ProtoLens.FieldDescriptor MethodOptions
                 uninterpretedOption__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "uninterpreted_option"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor UninterpretedOption)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -3215,7 +3215,7 @@ instance Data.ProtoLens.Message OneofDescriptorProto where
         fieldsByTag
           = let name__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3299,7 +3299,7 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
         fieldsByTag
           = let name__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "name"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3307,7 +3307,7 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor ServiceDescriptorProto
                 method__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "method"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor MethodDescriptorProto)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -3315,7 +3315,7 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
                       :: Data.ProtoLens.FieldDescriptor ServiceDescriptorProto
                 options__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "options"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor ServiceOptions)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3376,7 +3376,7 @@ instance Data.ProtoLens.Message ServiceOptions where
         fieldsByTag
           = let deprecated__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "deprecated"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3384,7 +3384,7 @@ instance Data.ProtoLens.Message ServiceOptions where
                       :: Data.ProtoLens.FieldDescriptor ServiceOptions
                 uninterpretedOption__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "uninterpreted_option"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor UninterpretedOption)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -3426,7 +3426,7 @@ instance Data.ProtoLens.Message SourceCodeInfo where
         fieldsByTag
           = let location__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "location"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor SourceCodeInfo'Location)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -3541,7 +3541,7 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
         fieldsByTag
           = let path__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "path"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Packed
                          (Lens.Labels.lensOf
@@ -3549,7 +3549,7 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                       :: Data.ProtoLens.FieldDescriptor SourceCodeInfo'Location
                 span__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "span"
-                      (Data.ProtoLens.Int32Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int32Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int32)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Packed
                          (Lens.Labels.lensOf
@@ -3557,7 +3557,7 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                       :: Data.ProtoLens.FieldDescriptor SourceCodeInfo'Location
                 leadingComments__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "leading_comments"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3566,7 +3566,7 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                       :: Data.ProtoLens.FieldDescriptor SourceCodeInfo'Location
                 trailingComments__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "trailing_comments"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3575,7 +3575,7 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                       :: Data.ProtoLens.FieldDescriptor SourceCodeInfo'Location
                 leadingDetachedComments__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "leading_detached_comments"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -3745,7 +3745,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
         fieldsByTag
           = let name__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "name"
-                      (Data.ProtoLens.MessageField ::
+                      (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
                          Data.ProtoLens.FieldTypeDescriptor UninterpretedOption'NamePart)
                       (Data.ProtoLens.RepeatedField Data.ProtoLens.Unpacked
                          (Lens.Labels.lensOf
@@ -3753,7 +3753,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                       :: Data.ProtoLens.FieldDescriptor UninterpretedOption
                 identifierValue__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "identifier_value"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3762,7 +3762,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                       :: Data.ProtoLens.FieldDescriptor UninterpretedOption
                 positiveIntValue__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "positive_int_value"
-                      (Data.ProtoLens.UInt64Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.UInt64Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Word.Word64)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3771,7 +3771,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                       :: Data.ProtoLens.FieldDescriptor UninterpretedOption
                 negativeIntValue__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "negative_int_value"
-                      (Data.ProtoLens.Int64Field ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.Int64Field ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Int.Int64)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3780,7 +3780,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                       :: Data.ProtoLens.FieldDescriptor UninterpretedOption
                 doubleValue__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "double_value"
-                      (Data.ProtoLens.DoubleField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.DoubleField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Double)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3789,7 +3789,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                       :: Data.ProtoLens.FieldDescriptor UninterpretedOption
                 stringValue__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "string_value"
-                      (Data.ProtoLens.BytesField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BytesField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.ByteString.ByteString)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3798,7 +3798,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                       :: Data.ProtoLens.FieldDescriptor UninterpretedOption
                 aggregateValue__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "aggregate_value"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.OptionalField
                          (Lens.Labels.lensOf
@@ -3865,7 +3865,7 @@ instance Data.ProtoLens.Message UninterpretedOption'NamePart where
         fieldsByTag
           = let namePart__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "name_part"
-                      (Data.ProtoLens.StringField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.StringField ::
                          Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Required
                          (Lens.Labels.lensOf
@@ -3873,7 +3873,7 @@ instance Data.ProtoLens.Message UninterpretedOption'NamePart where
                       :: Data.ProtoLens.FieldDescriptor UninterpretedOption'NamePart
                 isExtension__field_descriptor
                   = Data.ProtoLens.FieldDescriptor "is_extension"
-                      (Data.ProtoLens.BoolField ::
+                      (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
                          Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
                       (Data.ProtoLens.PlainField Data.ProtoLens.Required
                          (Lens.Labels.lensOf


### PR DESCRIPTION
Distinguish the recursive sub-message case from the other
scalar field types.

Motivated by the changes in #134.

Small behaivor change: this prevents any message type from being
packed, not just groups.  (But that's closer to the standard anyway.)