### PR TITLE
Improve text format error messages.

### DIFF
--- a/proto-lens/src/Data/ProtoLens/TextFormat/Parser.hs
+++ b/proto-lens/src/Data/ProtoLens/TextFormat/Parser.hs
@@ -75,7 +75,8 @@ data Value = IntValue Integer  -- ^ An integer
 
 instance Show Key
   where
-    show (Key name) = name
+    show (Key name) = show name  -- Quoting field names (i.e., `"field"` vs `field`
+                                 -- leads to nicer error messages.
     show (UnknownKey k) = show k
     show (ExtensionKey name) = "[" ++ intercalate "." name ++ "]"
     show (UnknownExtensionKey k) = "[" ++ show k ++ "]"


### PR DESCRIPTION
- Include field names in type mismatch errors
- Quote field names in error messages

Example new output:
```
*** Exception: readMessageOrDie: Error parsing field "value": Type
mismatch: (BytesField,IntValue 3)
```
Compare to old output:
```
*** Exception: readMessageOrDie: Type mismatch: (BytesField,IntValue 3)
```