### PR TITLE
Expose `parseMessage`

### DIFF
--- a/proto-lens/src/Data/ProtoLens/Encoding.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding.hs
@@ -20,6 +20,7 @@ module Data.ProtoLens.Encoding(
     buildMessageDelimited,
     decodeMessage,
     decodeMessageOrDie,
+    parseMessage
     ) where
 
 import Data.ProtoLens.Message


### PR DESCRIPTION
Let's not hide useful functions