### PR TITLE
Expose shrinkMessage

### DIFF
--- a/proto-lens-arbitrary/src/Data/ProtoLens/Arbitrary.hs
+++ b/proto-lens-arbitrary/src/Data/ProtoLens/Arbitrary.hs
@@ -12,6 +12,7 @@
 module Data.ProtoLens.Arbitrary
     ( ArbitraryMessage(..)
     , arbitraryMessage
+    , shrinkMessage
     ) where
 
 import Data.ProtoLens.Message


### PR DESCRIPTION
This makes it easier to call `forAllShrink`, which is what you're stuck with if you forego QuickCheck's TH property discovery. Currently this is only accessible via the `ArbitraryMessage` newtype.

Before:

```haskell
forAllShrink arbitraryMessage (fmap unArbitraryMessage . shrink . ArbitraryMessage)
```

After:

```haskell
forAllShrink arbitraryMessage shrinkMessage
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/159)
<!-- Reviewable:end -->
