### PR TITLE
Add protobuf timestamp support

### DIFF
--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -15,6 +15,7 @@ extra-source-files:
   - proto-src/google/protobuf/any.proto
   - proto-src/google/protobuf/duration.proto
   - proto-src/google/protobuf/wrappers.proto
+  - proto-src/google/protobuf/timestamp.proto
 
 custom-setup:
   dependencies:
@@ -39,3 +40,5 @@ library:
     - Proto.Google.Protobuf.Duration'Fields
     - Proto.Google.Protobuf.Wrappers
     - Proto.Google.Protobuf.Wrappers'Fields
+    - Proto.Google.Protobuf.Timestamp
+    - Proto.Google.Protobuf.Timestamp'Fields


### PR DESCRIPTION
Fix #165. I also have functions for Timestamp <-> UTCTime conversion lying around but was unsure whether they should be in this repo and under which package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/166)
<!-- Reviewable:end -->
