### PR TITLE
Update changelogs with some missing entries.

### DIFF
--- a/lens-labels/Changelog.md
+++ b/lens-labels/Changelog.md
@@ -4,8 +4,11 @@
 - Improve readability of `HasLens` instances. (#118)
 - Remove support for `ghc-7.10`. (#136)
 - Use a `.cabal` file that's auto-generated from `hpack`. (#138)
+- Export a `Lens'` type synonym. (#141)
+- Swap the order of parameters for `view` to match other packages. (#141)
 - Add `Lens.Labels.Unwrapped`, allowing easier interoperation with
   other lens libraries. (#157)
+- Add `Lens.Labels.Prism`. (#160)
 
 ## v0.1.0.2
 - Bump the dependency on `base` to support `ghc-8.2.1`.

--- a/proto-lens-arbitrary/Changelog.md
+++ b/proto-lens-arbitrary/Changelog.md
@@ -1,9 +1,11 @@
 # Changelog for `proto-lens-arbitrary`
 
-## v0.1.1.2
+## v0.1.2.0
 - Remove support for `ghc-7.10`. (#136)
 - Use a `.cabal` file that's auto-generated from `hpack`. (#138)
 - Track `proto-lens` changes to the `Message` class. (#139, #147)
+- Expose `shrinkMessage` (#159)
+- Improve the `Arbitrary` generator for nested structures (#163)
 
 
 ## v0.1.1.1

--- a/proto-lens-arbitrary/package.yaml
+++ b/proto-lens-arbitrary/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-arbitrary
-version: "0.1.1.2"
+version: "0.1.2.0"
 synopsis: Arbitrary instances for proto-lens.
 description: >
   The proto-lens-arbitrary allows generating arbitrary messages for

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -8,9 +8,12 @@
 - Add support for tracking unknown fields. (#129)
 - Don't generate Haskell modules if they won't be used. (#126)
 - Bundle enum pattern synonyms exports with their type. (#136)
-- Implement proto3-style "open" enums. (#137)
 - Split the `Message` class into separate methods. (#139)
 - Refactor the `FieldDescriptorType. (#147)
+- Add a case to proto3 enums for unknown values. (#137)
+- Track consolidation of `proto-lens-descriptors` into `proto-lens`. (#140)
+- Generate service definitions using promoted datatypes. (#154)
+- Generate prisms for `oneof` message fields. (#160)
 
 ## v0.2.2.3
 - Don't camel-case message names.  This reverts behavior which was added

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -24,9 +24,7 @@ dependencies:
   - filepath >= 1.4 && < 1.6
   - haskell-src-exts >= 1.17 && < 1.20
   - lens-family == 1.2.*
-  # Specify a more precise version of `proto-lens`, since it depends on the
-  # exact definition of the Message class.
-  - proto-lens == 0.3.0.*
+  - proto-lens == 0.3.*
   - text == 1.2.*
 
 

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -12,7 +12,10 @@
 - Implement proto3-style "open" enums. (#137)
 - Consolidate `proto-lens-descriptors` into `proto-lens`. (#140)
 - Split the `Message` class into separate methods. (#139)
+- Improve an error message when decoding Anys. (#146)
 - Refactor the `FieldDescriptorType. (#147)
+- Improve text format error messages. (#148)
+- Add module `Data.ProtoLens.Service.Types`. (#154)
 
 ## v0.2.2.0
 - Bump the dependency on `base` to support `ghc-8.2.1`.


### PR DESCRIPTION
Also:
- Loosen the bound for `proto-lens-protoc`'s dependency on `proto-lens`.
  Previously it was overly tight to let the `Message` evolve,
  but we can be more lenient now that the class is more stable.
- Give `proto-lens-arbitrary` a minor bump to `0.1.2.0` since it added
a function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/168)
<!-- Reviewable:end -->
