### PR TITLE
Simplify an API slightly.

### DIFF
--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -87,12 +87,11 @@ generateFiles modifyImports header files toGenerate = let
              (definitions f)
              (collectEnvFromDeps deps filesByName)
              (services f)
-  in [ ( outputFilePath $ prettyPrint modName
+  in [ ( outputFilePath $ prettyPrint $ getModuleName modul
        , header (descriptor f) <> pack (prettyPrintModule modul)
        )
      | fileName <- toGenerate
      , let f = filesByName ! fileName
      , modul <- modulesToBuild f
-     , let Just modName =  getModuleName modul
      ]
 

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
@@ -233,8 +233,8 @@ prettyPrintModule (Module modName exports pragmas imports decls) =
 
 type ExportSpec = Syntax.ExportSpec ()
 
-getModuleName :: Module -> Maybe ModuleName
-getModuleName (Module name _ _ _ _) = Just name
+getModuleName :: Module -> ModuleName
+getModuleName (Module name _ _ _ _) = name
 
 type ModuleName = Syntax.ModuleName ()
 type ModulePragma = Syntax.ModulePragma ()


### PR DESCRIPTION
Now that we define our own `Module` type (#172), we don't need `getModuleName`
to return a `Maybe`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/173)
<!-- Reviewable:end -->
