### PR TITLE
Hide the constructors and raw record fields of message types.

### DIFF
--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -9,12 +9,14 @@
 - Don't generate Haskell modules if they won't be used. (#126)
 - Bundle enum pattern synonyms exports with their type. (#136)
 - Split the `Message` class into separate methods. (#139)
-- Refactor the `FieldDescriptorType. (#147)
+- Refactor the `FieldDescriptorType`. (#147)
 - Add a case to proto3 enums for unknown values. (#137)
 - Track consolidation of `proto-lens-descriptors` into `proto-lens`. (#140)
 - Generate service definitions using promoted datatypes. (#154)
 - Generate prisms for `oneof` message fields. (#160)
 - Build with `haskell-src-exts-1.20.*`.
+- Hide the constructors and record fields of message types, and make `Show`
+  instances call `showMessageShort`.
 
 ## v0.2.2.3
 - Don't camel-case message names.  This reverts behavior which was added

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
@@ -157,6 +157,9 @@ alt p e = Syntax.Alt () p (Syntax.UnGuardedRhs () e) Nothing
 stringExp :: String -> Exp
 stringExp = Syntax.Lit () . string
 
+charExp :: Char -> Exp
+charExp = Syntax.Lit () . char
+
 tuple :: [Exp] -> Exp
 tuple = Syntax.Tuple () Syntax.Boxed
 
@@ -406,6 +409,9 @@ pLitInt n = Syntax.PLit () sign $ Syntax.Int () n' (show n')
 
 string :: String -> Syntax.Literal ()
 string s = Syntax.String () s (show s)
+
+char :: Char -> Syntax.Literal ()
+char c = Syntax.Char () c [c]
 
 modifyModuleName :: (String -> String) -> ModuleName -> ModuleName
 modifyModuleName f (Syntax.ModuleName _ unpacked) =

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -181,8 +181,10 @@ messageComment fieldModName n fields = unlines
 
 generateMessageExports :: MessageInfo Name -> [ExportSpec]
 generateMessageExports m =
-    map (exportAll . unQual)
-        $ messageName m : map oneofTypeName (messageOneofFields m)
+    -- Hide the message contructor, but expose "oneof" case constructors.
+    exportWith (unQual $ messageName m) []
+        : map (exportAll . unQual . oneofTypeName)
+                (messageOneofFields m)
 
 generateServiceDecls :: Env QName -> ServiceInfo -> [Decl]
 generateServiceDecls env si =
@@ -253,9 +255,16 @@ generateMessageDecls fieldModName syntaxType env protoName info =
                       ]
                       ++ [(messageUnknownFields info, "Data.ProtoLens.FieldSet")]
             ]
-            $ deriving' ["Prelude.Show", "Prelude.Eq", "Prelude.Ord"]
+            $ deriving' ["Prelude.Eq", "Prelude.Ord"]
+    -- instance Show Bar where
+    --   showsPrec __x __s = showChar '{' (showString (showMessageShort __x) (showChar '}' s))
+    , uncommented $
+        instDecl [] ("Prelude.Show" `ihApp` [dataType])
+            [[match "showsPrec" ["_", "__x", "__s"]
+                $ "Prelude.showChar" @@ charExp '{'
+                    @@ ("Prelude.showString" @@ ("Data.ProtoLens.showMessageShort" @@ "__x")
+                        @@ ("Prelude.showChar" @@ charExp '}' @@ "__s"))]]
     ] ++
-
     -- oneof field data type declarations
     -- proto: message Foo {
     --          oneof bar {

--- a/proto-lens-tests/tests/oneof_test.hs
+++ b/proto-lens-tests/tests/oneof_test.hs
@@ -75,13 +75,10 @@ main = testMain
         -- A oneof type and constructor that overlap with an enum
         trivial (Disambiguated'EnumCon' 42 :: Disambiguated'EnumType')
 
-        -- And we don't change the message or enum types and constructors.
-        trivial (Disambiguated'MessageTypeA
-                    {_Disambiguated'MessageTypeA'_unknownFields = []}
-                    :: Disambiguated'MessageTypeA)
-        trivial (Disambiguated'MessageTypeB
-                    {_Disambiguated'MessageTypeB'_unknownFields = []}
-                    :: Disambiguated'MessageTypeB)
+        -- And we don't change the types of messages, nor the types or
+        -- constructors of enums.
+        trivial (def :: Disambiguated'MessageTypeA)
+        trivial (def :: Disambiguated'MessageTypeB)
         trivial (Disambiguated'EnumCon :: Disambiguated'EnumType)
 
     , testCase "not disambiguated names" $ do

--- a/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -6,8 +6,8 @@
 {-# OPTIONS_GHC -fno-warn-unused-imports#-}
 {-# OPTIONS_GHC -fno-warn-duplicate-exports#-}
 module Proto.Google.Protobuf.Compiler.Plugin
-       (CodeGeneratorRequest(..), CodeGeneratorResponse(..),
-        CodeGeneratorResponse'File(..))
+       (CodeGeneratorRequest(), CodeGeneratorResponse(),
+        CodeGeneratorResponse'File())
        where
 import qualified Lens.Labels.Prism
 import qualified Prelude
@@ -43,7 +43,12 @@ data CodeGeneratorRequest = CodeGeneratorRequest{_CodeGeneratorRequest'fileToGen
                                                  ![Proto.Google.Protobuf.Descriptor.FileDescriptorProto],
                                                  _CodeGeneratorRequest'_unknownFields ::
                                                  !Data.ProtoLens.FieldSet}
-                          deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                          deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show CodeGeneratorRequest where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f CodeGeneratorRequest x a,
           a ~ b) =>
          Lens.Labels.HasLens f CodeGeneratorRequest CodeGeneratorRequest x a
@@ -141,7 +146,12 @@ data CodeGeneratorResponse = CodeGeneratorResponse{_CodeGeneratorResponse'error
                                                    ![CodeGeneratorResponse'File],
                                                    _CodeGeneratorResponse'_unknownFields ::
                                                    !Data.ProtoLens.FieldSet}
-                           deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                           deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show CodeGeneratorResponse where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f CodeGeneratorResponse x a,
           a ~ b) =>
          Lens.Labels.HasLens f CodeGeneratorResponse CodeGeneratorResponse x
@@ -226,7 +236,12 @@ data CodeGeneratorResponse'File = CodeGeneratorResponse'File{_CodeGeneratorRespo
                                                              !(Prelude.Maybe Data.Text.Text),
                                                              _CodeGeneratorResponse'File'_unknownFields
                                                              :: !Data.ProtoLens.FieldSet}
-                                deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                                deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show CodeGeneratorResponse'File where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f CodeGeneratorResponse'File x a,
           a ~ b) =>
          Lens.Labels.HasLens f CodeGeneratorResponse'File

--- a/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
@@ -6,22 +6,21 @@
 {-# OPTIONS_GHC -fno-warn-unused-imports#-}
 {-# OPTIONS_GHC -fno-warn-duplicate-exports#-}
 module Proto.Google.Protobuf.Descriptor
-       (DescriptorProto(..), DescriptorProto'ExtensionRange(..),
-        DescriptorProto'ReservedRange(..), EnumDescriptorProto(..),
-        EnumOptions(..), EnumValueDescriptorProto(..),
-        EnumValueOptions(..), FieldDescriptorProto(..),
-        FieldDescriptorProto'Label(..), FieldDescriptorProto'Label(),
-        FieldDescriptorProto'Type(..), FieldDescriptorProto'Type(),
-        FieldOptions(..), FieldOptions'CType(..), FieldOptions'CType(),
+       (DescriptorProto(), DescriptorProto'ExtensionRange(),
+        DescriptorProto'ReservedRange(), EnumDescriptorProto(),
+        EnumOptions(), EnumValueDescriptorProto(), EnumValueOptions(),
+        FieldDescriptorProto(), FieldDescriptorProto'Label(..),
+        FieldDescriptorProto'Label(), FieldDescriptorProto'Type(..),
+        FieldDescriptorProto'Type(), FieldOptions(),
+        FieldOptions'CType(..), FieldOptions'CType(),
         FieldOptions'JSType(..), FieldOptions'JSType(),
-        FileDescriptorProto(..), FileDescriptorSet(..), FileOptions(..),
+        FileDescriptorProto(), FileDescriptorSet(), FileOptions(),
         FileOptions'OptimizeMode(..), FileOptions'OptimizeMode(),
-        GeneratedCodeInfo(..), GeneratedCodeInfo'Annotation(..),
-        MessageOptions(..), MethodDescriptorProto(..), MethodOptions(..),
-        OneofDescriptorProto(..), ServiceDescriptorProto(..),
-        ServiceOptions(..), SourceCodeInfo(..),
-        SourceCodeInfo'Location(..), UninterpretedOption(..),
-        UninterpretedOption'NamePart(..))
+        GeneratedCodeInfo(), GeneratedCodeInfo'Annotation(),
+        MessageOptions(), MethodDescriptorProto(), MethodOptions(),
+        OneofDescriptorProto(), ServiceDescriptorProto(), ServiceOptions(),
+        SourceCodeInfo(), SourceCodeInfo'Location(), UninterpretedOption(),
+        UninterpretedOption'NamePart())
        where
 import qualified Lens.Labels.Prism
 import qualified Prelude
@@ -69,7 +68,12 @@ data DescriptorProto = DescriptorProto{_DescriptorProto'name ::
                                        ![DescriptorProto'ReservedRange],
                                        _DescriptorProto'reservedName :: ![Data.Text.Text],
                                        _DescriptorProto'_unknownFields :: !Data.ProtoLens.FieldSet}
-                     deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                     deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show DescriptorProto where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f DescriptorProto x a, a ~ b) =>
          Lens.Labels.HasLens f DescriptorProto DescriptorProto x a b
          where
@@ -306,7 +310,12 @@ data DescriptorProto'ExtensionRange = DescriptorProto'ExtensionRange{_Descriptor
                                                                          Data.Int.Int32),
                                                                      _DescriptorProto'ExtensionRange'_unknownFields
                                                                      :: !Data.ProtoLens.FieldSet}
-                                    deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                                    deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show DescriptorProto'ExtensionRange where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f DescriptorProto'ExtensionRange x
             a,
           a ~ b) =>
@@ -405,7 +414,12 @@ data DescriptorProto'ReservedRange = DescriptorProto'ReservedRange{_DescriptorPr
                                                                    !(Prelude.Maybe Data.Int.Int32),
                                                                    _DescriptorProto'ReservedRange'_unknownFields
                                                                    :: !Data.ProtoLens.FieldSet}
-                                   deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                                   deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show DescriptorProto'ReservedRange where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f DescriptorProto'ReservedRange x a,
           a ~ b) =>
          Lens.Labels.HasLens f DescriptorProto'ReservedRange
@@ -503,7 +517,12 @@ data EnumDescriptorProto = EnumDescriptorProto{_EnumDescriptorProto'name
                                                !(Prelude.Maybe EnumOptions),
                                                _EnumDescriptorProto'_unknownFields ::
                                                !Data.ProtoLens.FieldSet}
-                         deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                         deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show EnumDescriptorProto where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f EnumDescriptorProto x a, a ~ b) =>
          Lens.Labels.HasLens f EnumDescriptorProto EnumDescriptorProto x a b
          where
@@ -606,7 +625,12 @@ data EnumOptions = EnumOptions{_EnumOptions'allowAlias ::
                                _EnumOptions'deprecated :: !(Prelude.Maybe Prelude.Bool),
                                _EnumOptions'uninterpretedOption :: ![UninterpretedOption],
                                _EnumOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
-                 deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                 deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show EnumOptions where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f EnumOptions x a, a ~ b) =>
          Lens.Labels.HasLens f EnumOptions EnumOptions x a b
          where
@@ -713,7 +737,12 @@ data EnumValueDescriptorProto = EnumValueDescriptorProto{_EnumValueDescriptorPro
                                                          !(Prelude.Maybe EnumValueOptions),
                                                          _EnumValueDescriptorProto'_unknownFields ::
                                                          !Data.ProtoLens.FieldSet}
-                              deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                              deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show EnumValueDescriptorProto where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f EnumValueDescriptorProto x a,
           a ~ b) =>
          Lens.Labels.HasLens f EnumValueDescriptorProto
@@ -833,7 +862,12 @@ data EnumValueOptions = EnumValueOptions{_EnumValueOptions'deprecated
                                          ![UninterpretedOption],
                                          _EnumValueOptions'_unknownFields ::
                                          !Data.ProtoLens.FieldSet}
-                      deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                      deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show EnumValueOptions where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f EnumValueOptions x a, a ~ b) =>
          Lens.Labels.HasLens f EnumValueOptions EnumValueOptions x a b
          where
@@ -943,7 +977,12 @@ data FieldDescriptorProto = FieldDescriptorProto{_FieldDescriptorProto'name
                                                  !(Prelude.Maybe FieldOptions),
                                                  _FieldDescriptorProto'_unknownFields ::
                                                  !Data.ProtoLens.FieldSet}
-                          deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                          deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show FieldDescriptorProto where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f FieldDescriptorProto x a,
           a ~ b) =>
          Lens.Labels.HasLens f FieldDescriptorProto FieldDescriptorProto x a
@@ -1530,7 +1569,12 @@ data FieldOptions = FieldOptions{_FieldOptions'ctype ::
                                  _FieldOptions'weak :: !(Prelude.Maybe Prelude.Bool),
                                  _FieldOptions'uninterpretedOption :: ![UninterpretedOption],
                                  _FieldOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
-                  deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                  deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show FieldOptions where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f FieldOptions x a, a ~ b) =>
          Lens.Labels.HasLens f FieldOptions FieldOptions x a b
          where
@@ -1869,7 +1913,12 @@ data FileDescriptorProto = FileDescriptorProto{_FileDescriptorProto'name
                                                !(Prelude.Maybe Data.Text.Text),
                                                _FileDescriptorProto'_unknownFields ::
                                                !Data.ProtoLens.FieldSet}
-                         deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                         deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show FileDescriptorProto where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f FileDescriptorProto x a, a ~ b) =>
          Lens.Labels.HasLens f FileDescriptorProto FileDescriptorProto x a b
          where
@@ -2166,7 +2215,12 @@ data FileDescriptorSet = FileDescriptorSet{_FileDescriptorSet'file
                                            :: ![FileDescriptorProto],
                                            _FileDescriptorSet'_unknownFields ::
                                            !Data.ProtoLens.FieldSet}
-                       deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                       deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show FileDescriptorSet where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f FileDescriptorSet x a, a ~ b) =>
          Lens.Labels.HasLens f FileDescriptorSet FileDescriptorSet x a b
          where
@@ -2251,7 +2305,12 @@ data FileOptions = FileOptions{_FileOptions'javaPackage ::
                                _FileOptions'csharpNamespace :: !(Prelude.Maybe Data.Text.Text),
                                _FileOptions'uninterpretedOption :: ![UninterpretedOption],
                                _FileOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
-                 deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                 deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show FileOptions where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f FileOptions x a, a ~ b) =>
          Lens.Labels.HasLens f FileOptions FileOptions x a b
          where
@@ -2745,7 +2804,12 @@ data GeneratedCodeInfo = GeneratedCodeInfo{_GeneratedCodeInfo'annotation
                                            :: ![GeneratedCodeInfo'Annotation],
                                            _GeneratedCodeInfo'_unknownFields ::
                                            !Data.ProtoLens.FieldSet}
-                       deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                       deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show GeneratedCodeInfo where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f GeneratedCodeInfo x a, a ~ b) =>
          Lens.Labels.HasLens f GeneratedCodeInfo GeneratedCodeInfo x a b
          where
@@ -2800,7 +2864,12 @@ data GeneratedCodeInfo'Annotation = GeneratedCodeInfo'Annotation{_GeneratedCodeI
                                                                  :: !(Prelude.Maybe Data.Int.Int32),
                                                                  _GeneratedCodeInfo'Annotation'_unknownFields
                                                                  :: !Data.ProtoLens.FieldSet}
-                                  deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                                  deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show GeneratedCodeInfo'Annotation where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f GeneratedCodeInfo'Annotation x a,
           a ~ b) =>
          Lens.Labels.HasLens f GeneratedCodeInfo'Annotation
@@ -2952,7 +3021,12 @@ data MessageOptions = MessageOptions{_MessageOptions'messageSetWireFormat
                                      _MessageOptions'mapEntry :: !(Prelude.Maybe Prelude.Bool),
                                      _MessageOptions'uninterpretedOption :: ![UninterpretedOption],
                                      _MessageOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
-                    deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                    deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show MessageOptions where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f MessageOptions x a, a ~ b) =>
          Lens.Labels.HasLens f MessageOptions MessageOptions x a b
          where
@@ -3137,7 +3211,12 @@ data MethodDescriptorProto = MethodDescriptorProto{_MethodDescriptorProto'name
                                                    !(Prelude.Maybe Prelude.Bool),
                                                    _MethodDescriptorProto'_unknownFields ::
                                                    !Data.ProtoLens.FieldSet}
-                           deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                           deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show MethodDescriptorProto where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f MethodDescriptorProto x a,
           a ~ b) =>
          Lens.Labels.HasLens f MethodDescriptorProto MethodDescriptorProto x
@@ -3340,7 +3419,12 @@ data MethodOptions = MethodOptions{_MethodOptions'deprecated ::
                                    !(Prelude.Maybe Prelude.Bool),
                                    _MethodOptions'uninterpretedOption :: ![UninterpretedOption],
                                    _MethodOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
-                   deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                   deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show MethodOptions where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f MethodOptions x a, a ~ b) =>
          Lens.Labels.HasLens f MethodOptions MethodOptions x a b
          where
@@ -3412,7 +3496,12 @@ data OneofDescriptorProto = OneofDescriptorProto{_OneofDescriptorProto'name
                                                  :: !(Prelude.Maybe Data.Text.Text),
                                                  _OneofDescriptorProto'_unknownFields ::
                                                  !Data.ProtoLens.FieldSet}
-                          deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                          deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show OneofDescriptorProto where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f OneofDescriptorProto x a,
           a ~ b) =>
          Lens.Labels.HasLens f OneofDescriptorProto OneofDescriptorProto x a
@@ -3474,7 +3563,12 @@ data ServiceDescriptorProto = ServiceDescriptorProto{_ServiceDescriptorProto'nam
                                                      !(Prelude.Maybe ServiceOptions),
                                                      _ServiceDescriptorProto'_unknownFields ::
                                                      !Data.ProtoLens.FieldSet}
-                            deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                            deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ServiceDescriptorProto where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f ServiceDescriptorProto x a,
           a ~ b) =>
          Lens.Labels.HasLens f ServiceDescriptorProto ServiceDescriptorProto
@@ -3582,7 +3676,12 @@ data ServiceOptions = ServiceOptions{_ServiceOptions'deprecated ::
                                      !(Prelude.Maybe Prelude.Bool),
                                      _ServiceOptions'uninterpretedOption :: ![UninterpretedOption],
                                      _ServiceOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
-                    deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                    deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show ServiceOptions where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f ServiceOptions x a, a ~ b) =>
          Lens.Labels.HasLens f ServiceOptions ServiceOptions x a b
          where
@@ -3652,7 +3751,12 @@ instance Data.ProtoLens.Message ServiceOptions where
 data SourceCodeInfo = SourceCodeInfo{_SourceCodeInfo'location ::
                                      ![SourceCodeInfo'Location],
                                      _SourceCodeInfo'_unknownFields :: !Data.ProtoLens.FieldSet}
-                    deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                    deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show SourceCodeInfo where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f SourceCodeInfo x a, a ~ b) =>
          Lens.Labels.HasLens f SourceCodeInfo SourceCodeInfo x a b
          where
@@ -3709,7 +3813,12 @@ data SourceCodeInfo'Location = SourceCodeInfo'Location{_SourceCodeInfo'Location'
                                                        :: ![Data.Text.Text],
                                                        _SourceCodeInfo'Location'_unknownFields ::
                                                        !Data.ProtoLens.FieldSet}
-                             deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                             deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show SourceCodeInfo'Location where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f SourceCodeInfo'Location x a,
           a ~ b) =>
          Lens.Labels.HasLens f SourceCodeInfo'Location
@@ -3892,7 +4001,12 @@ data UninterpretedOption = UninterpretedOption{_UninterpretedOption'name
                                                !(Prelude.Maybe Data.Text.Text),
                                                _UninterpretedOption'_unknownFields ::
                                                !Data.ProtoLens.FieldSet}
-                         deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                         deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show UninterpretedOption where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f UninterpretedOption x a, a ~ b) =>
          Lens.Labels.HasLens f UninterpretedOption UninterpretedOption x a b
          where
@@ -4113,7 +4227,12 @@ data UninterpretedOption'NamePart = UninterpretedOption'NamePart{_UninterpretedO
                                                                  :: !Prelude.Bool,
                                                                  _UninterpretedOption'NamePart'_unknownFields
                                                                  :: !Data.ProtoLens.FieldSet}
-                                  deriving (Prelude.Show, Prelude.Eq, Prelude.Ord)
+                                  deriving (Prelude.Eq, Prelude.Ord)
+instance Prelude.Show UninterpretedOption'NamePart where
+        showsPrec _ __x __s
+          = Prelude.showChar '{'
+              (Prelude.showString (Data.ProtoLens.showMessageShort __x)
+                 (Prelude.showChar '}' __s))
 instance (Lens.Labels.HasLens' f UninterpretedOption'NamePart x a,
           a ~ b) =>
          Lens.Labels.HasLens f UninterpretedOption'NamePart

--- a/stack-bootstrap.yaml
+++ b/stack-bootstrap.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.21
+resolver: lts-10.3
 packages:
 - proto-lens-protoc
 # Build the current HEAD proto-lens-protoc against older revisions of proto-lens


### PR DESCRIPTION
They're not that useful for constructing values (especially after adding the
"unknown fields" case) and were previously mostly used for documentation.  Now
that #172 has landed, we have a better source of documentation that doesn't
expose internal details.

Also change the `Show` instance for messages to be a wrapper around
`showMessageShort`.  This both hides the now-inaccessible record fields and
shortens the output in most cases.  For example:

```
> print (def :: DescriptorProto)
{}
> print (def & #name .~ "hello" & #field .~ [def, def & #name .~ "bye"]:: DescriptorProto)
{name: "hello" field { } field { name: "bye" }}
```

Also bump the resolver for bootstrapping to match the regular build.

Hide message constructors.

showsPrec, and bootstrap