### PR TITLE
Improve references to types/fields in error messages.

### DIFF
--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens`
 
+## Latest
+- Improve references to types/fields in decoding error messages (#187).
+
 ## v0.3.0.0
 - Remove support for `ghc-7.10`. (#136)
 - Use a `.cabal` file that's auto-generated from `hpack`. (#138)

--- a/proto-lens/src/Data/ProtoLens/Encoding.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding.hs
@@ -14,6 +14,7 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 module Data.ProtoLens.Encoding(
     encodeMessage,
     buildMessage,
@@ -31,8 +32,10 @@ import Control.Monad (guard)
 import Data.Attoparsec.ByteString as Parse
 import Data.Bool (bool)
 import Data.Monoid ((<>))
+import Data.Proxy (Proxy(Proxy))
 import Data.Text.Encoding (encodeUtf8, decodeUtf8')
 import Data.Text.Encoding.Error (UnicodeException(..))
+import qualified Data.Text as T
 import qualified Data.ByteString as B
 import qualified Data.Map.Strict as Map
 import Data.ByteString.Lazy.Builder as Builder
@@ -51,7 +54,7 @@ decodeMessage input = parseOnly (parseMessage endOfInput) input
 -- | Parse a message with the given ending delimiter (which will be EndGroup in
 -- the case of a group, and end-of-input otherwise).
 parseMessage :: forall msg . Message msg => Parser () -> Parser msg
-parseMessage end = do
+parseMessage end = (Parse.<?> T.unpack (messageName (Proxy @msg))) $ do
     (msg, unsetFields) <- loop def requiredFields
     if Map.null unsetFields
         then return $ over unknownFields reverse
@@ -73,6 +76,7 @@ parseMessage end = do
                         Nothing -> (loop $! addUnknown tv msg) unsetFields
                         Just field -> do
                             !msg' <- parseAndAddField msg field tv
+                                      <?> fieldDescriptorName field
                             loop msg' $! Map.delete tag unsetFields
 
 -- | Decode a message from its wire format.  Throws an error if the decoding
@@ -95,21 +99,21 @@ parseAndAddField
     (TaggedValue tag (WireValue wt val)) = let
           getSimpleVal = case typeDescriptor of
                             MessageField GroupType -> do
-                                Equal <- equalWireTypes name StartGroup wt
-                                parseMessage (endOfGroup name tag)
+                                Equal <- equalWireTypes StartGroup wt
+                                parseMessage (endOfGroup tag)
                             MessageField MessageType -> do
-                                Equal <- equalWireTypes name Lengthy wt
+                                Equal <- equalWireTypes Lengthy wt
                                 runEither $ decodeMessage val
                             ScalarField f -> case fieldWireType f of
                                 FieldWireType fieldWt _ get -> do
-                                    Equal <- equalWireTypes name fieldWt wt
+                                    Equal <- equalWireTypes fieldWt wt
                                     runEither $ get val
           -- Get a block of packed values, reversed.
           getPackedVals = case typeDescriptor of
             MessageField _ -> fail "Messages can't be packed"
             ScalarField f -> case fieldWireType f of
               FieldWireType fieldWt _ get -> do
-                Equal <- equalWireTypes name Lengthy wt
+                Equal <- equalWireTypes Lengthy wt
                 let getElt = do
                           wv <- getWireValue fieldWt
                           x <- runEither $ get wv
@@ -133,8 +137,7 @@ parseAndAddField
                 <|> (do
                         xs <- getPackedVals
                         return $! over' f (xs ++) msg)
-                <|> fail ("Field " ++ name
-                            ++ " expects a repeated field wire type but found "
+                <|> fail ("Expected a repeated field wire type but found "
                             ++ show wt)
               MapField keyLens valueLens f -> do
                   entry <- getSimpleVal
@@ -259,10 +262,10 @@ fieldWireType StringField = FieldWireType Lengthy encodeUtf8
                                     (stringizeError . decodeUtf8')
 fieldWireType BytesField = identityFieldWireType Lengthy
 
-endOfGroup :: String -> Tag -> Parser ()
-endOfGroup name tag = do
+endOfGroup :: Tag -> Parser ()
+endOfGroup tag = do
     TaggedValue tag' (WireValue wt _) <- getTaggedValue
-    Equal <- equalWireTypes name EndGroup wt
+    Equal <- equalWireTypes EndGroup wt
     guard (tag == tag')
 
 -- | Helper function to define a field type whose decoding operation can't fail.

--- a/proto-lens/src/Data/ProtoLens/Encoding.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding.hs
@@ -95,7 +95,7 @@ parseAndAddField :: msg
                  -> Parser msg
 parseAndAddField
     !msg
-    (FieldDescriptor name typeDescriptor accessor)
+    (FieldDescriptor _ typeDescriptor accessor)
     (TaggedValue tag (WireValue wt val)) = let
           getSimpleVal = case typeDescriptor of
                             MessageField GroupType -> do

--- a/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
@@ -87,27 +87,27 @@ data Equal a b where
 -- Assert that two wire types are the same, or fail with a message about this
 -- field.
 {-# INLINE equalWireTypes #-}
-equalWireTypes :: Monad m => String -> WireType a -> WireType b
+equalWireTypes :: Monad m => WireType a -> WireType b
                -> m (Equal a b)
-equalWireTypes _ VarInt VarInt = return Equal
-equalWireTypes _ Fixed64 Fixed64 = return Equal
-equalWireTypes _ Fixed32 Fixed32 = return Equal
-equalWireTypes _ Lengthy Lengthy = return Equal
-equalWireTypes _ StartGroup StartGroup = return Equal
-equalWireTypes _ EndGroup EndGroup = return Equal
-equalWireTypes name expected actual
-    = fail $ "Field " ++ name ++ " expects wire type " ++ show expected
+equalWireTypes VarInt VarInt = return Equal
+equalWireTypes Fixed64 Fixed64 = return Equal
+equalWireTypes Fixed32 Fixed32 = return Equal
+equalWireTypes Lengthy Lengthy = return Equal
+equalWireTypes StartGroup StartGroup = return Equal
+equalWireTypes EndGroup EndGroup = return Equal
+equalWireTypes expected actual
+    = fail $ "Expected wire type " ++ show expected
         ++ " but found " ++ show actual
 
 instance Eq WireValue where
     WireValue t v == WireValue t' v'
-        | Just Equal <- equalWireTypes "" t t'
+        | Just Equal <- equalWireTypes t t'
             = v == v'
         | otherwise = False
 
 instance Ord WireValue where
     WireValue t v `compare` WireValue t' v'
-        | Just Equal <- equalWireTypes "" t t'
+        | Just Equal <- equalWireTypes t t'
             = v `compare` v'
         | otherwise = wireTypeToInt t `compare` wireTypeToInt t'
 


### PR DESCRIPTION
Previously, when decoding failed we didn't print the message type, and often
didn't print the field name either.

(Running the benchmarks indicated that this change doesn't noticeably affect
performance; all differences were within noise levels.)

Example of new error message:
```
Left "canonical.Test3 > c: Failed reading: canonical.Test1 > a: Failed
reading: Expected wire type 0 but found 2"
```
where a `Test5` is incorrectly decoded as a `Test3`:

```
message Test1 {
    required int32 a = 1;
}

message Test3 {
    required Test1 c = 1;
}

message Test2 {
    required string b = 1;
}
message Test4 {
    required Test2 c = 1;
}
```
I haven't been able to figure out a way to remove the nested "Failed reading"
messages that are added automatically by `attoparsec` without significantly
refactoring the decoding code.  But I think this is still a net improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/187)
<!-- Reviewable:end -->
