### PR TITLE
Get proto-lens building with ghc-8.4.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
     addons: {apt: {packages: [libgmp-dev]}}
   - env: BUILD=stack STACK=stack # Use the resolver in stack.yaml
     addons: {apt: {packages: [libgmp-dev]}}
+  - env: BUILD=stack STACK='stack --resolver=nightly-2018-05-04'
+    addons: {apt: {packages: [libgmp-dev]}}
 
 before_install:
   - mkdir -p $HOME/.local/bin

--- a/lens-labels/Changelog.md
+++ b/lens-labels/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `lens-labels`
 
+## v0.2.0.1
+- Bump the dependency on `base` to support `ghc-8.4.2`.
+
 ## v0.2.0.0
 - Improve readability of `HasLens` instances. (#118)
 - Remove support for `ghc-7.10`. (#136)

--- a/lens-labels/package.yaml
+++ b/lens-labels/package.yaml
@@ -1,5 +1,5 @@
 name: lens-labels
-version: "0.2.0.0"
+version: "0.2.0.1"
 synopsis: Integration of lenses with OverloadedLabels.
 description: >
   Provides a framework to integrate lenses with GHC's OverloadedLabels
@@ -20,7 +20,7 @@ library:
     - Lens.Labels.Unwrapped
     - Lens.Labels.Prism
   dependencies:
-    - base >= 4.8 && < 4.11
+    - base >= 4.8 && < 4.12
     - ghc-prim >= 0.4 && < 0.6
     - profunctors >= 5.2
     - tagged >= 0.8

--- a/proto-lens-arbitrary/Changelog.md
+++ b/proto-lens-arbitrary/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog for `proto-lens-arbitrary`
 
+## v0.1.2.1
+- Bump the dependency on `base` for `ghc-8.4.2`.
+- Bump the dependency for `QuickCheck-2.11`.
+
 ## v0.1.2.0
 - Remove support for `ghc-7.10`. (#136)
 - Use a `.cabal` file that's auto-generated from `hpack`. (#138)

--- a/proto-lens-arbitrary/package.yaml
+++ b/proto-lens-arbitrary/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-arbitrary
-version: "0.1.2.0"
+version: "0.1.2.1"
 synopsis: Arbitrary instances for proto-lens.
 description: >
   The proto-lens-arbitrary allows generating arbitrary messages for
@@ -15,12 +15,12 @@ extra-source-files:
 
 dependencies:
   - proto-lens == 0.3.*
-  - base >= 4.8 && < 4.11
+  - base >= 4.8 && < 4.12
   - bytestring == 0.10.*
   - containers == 0.5.*
   - text == 1.2.*
   - lens-family == 1.2.*
-  - QuickCheck >= 2.8 && < 2.11
+  - QuickCheck >= 2.8 && < 2.12
 
 library:
   source-dirs: src

--- a/proto-lens-benchmarks/package.yaml
+++ b/proto-lens-benchmarks/package.yaml
@@ -12,18 +12,18 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.8 && < 4.11
+    - base
     - Cabal
-    - proto-lens-protoc == 0.3.*
+    - proto-lens-protoc
 
 dependencies:
-  - base >= 4.8 && < 4.11
-  - criterion >= 1.1 && < 1.3
+  - base
+  - criterion
   - deepseq
   - lens-family
   - lens-family-core
-  - proto-lens == 0.3.*
-  - proto-lens-protoc == 0.3.*
+  - proto-lens
+  - proto-lens-protoc
   - text
 
 ghc-options:
@@ -35,9 +35,9 @@ library:
   exposed-modules:
     - Data.ProtoLens.BenchmarkUtil
   dependencies:
-    - bytestring == 0.10.*
-    - deepseq == 1.4.*
-    - optparse-applicative >= 0.12 && < 0.15
+    - bytestring
+    - deepseq
+    - optparse-applicative
 
 benchmarks:
   nested:

--- a/proto-lens-combinators/Changelog.md
+++ b/proto-lens-combinators/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-combinators`
 
+## v0.1.0.10
+- Bump the dependency on `base` for `ghc-8.4.2`.
+
 ## v0.1.0.9
 - Track proto-lens change: separate types into their own module. (#100)
 - Remove support for `ghc-7.10`. (#136)

--- a/proto-lens-combinators/package.yaml
+++ b/proto-lens-combinators/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-combinators
-version: '0.1.0.9'
+version: '0.1.0.10'
 synopsis: Utilities functions to proto-lens.
 description: Useful things for working with protos.
 category: Data
@@ -14,12 +14,12 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.8 && < 4.11
+    - base >= 4.8 && < 4.12
     - Cabal
     - proto-lens-protoc == 0.3.*
 
 dependencies:
-  - base >= 4.8 && < 4.11
+  - base >= 4.8 && < 4.12
   - proto-lens-protoc == 0.3.*
   - lens-family == 1.2.*
 

--- a/proto-lens-optparse/Changelog.md
+++ b/proto-lens-optparse/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-optparse`
 
+## v0.1.1.1
+- Bump the dependency on `base` for `ghc-8.4.2`.
+
 ## v0.1.1.0
 - Add MessageEnum ReadM and option builders (#181).
 

--- a/proto-lens-optparse/package.yaml
+++ b/proto-lens-optparse/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-optparse
-version: '0.1.1.0'
+version: '0.1.1.1'
 synopsis: Adapting proto-lens to optparse-applicative ReadMs.
 description: >
   A package adapting proto-lens to optparse-applicative ReadMs.
@@ -16,7 +16,7 @@ extra-source-files:
 
 dependencies:
   - proto-lens >= 0.1 && < 0.4
-  - base >= 4.8 && < 4.11
+  - base >= 4.8 && < 4.12
   - optparse-applicative >= 0.12 && < 0.15
   - text == 1.2.*
 

--- a/proto-lens-protobuf-types/Changelog.md
+++ b/proto-lens-protobuf-types/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-protobuf-types`
 
+## v0.3.0.1
+- Bump the dependency on `base` for `ghc-8.4.2`.
+
 ## v0.3.0.0
 - Remove support for `ghc-7.10`. (#136)
 - Use a `.cabal` file that's auto-generated from `hpack`. (#138)

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-protobuf-types
-version: '0.3.0.0'
+version: '0.3.0.1'
 synopsis: Basic protocol buffer message types.
 description: >
   This package provides bindings standard protocol message types,
@@ -19,12 +19,12 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.8 && < 4.11
+    - base >= 4.8 && < 4.12
     - Cabal
     - proto-lens-protoc == 0.3.*
 
 dependencies:
-  - base >= 4.8 && < 4.11
+  - base >= 4.8 && < 4.12
   - lens-family
   - proto-lens == 0.3.*
   - proto-lens-protoc == 0.3.*

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog for `proto-lens-protoc`
 
+## v0.3.1.0
+- Bump the dependency on `base` for `ghc-8.4.2`.
+- Bump the dependency to `Cabal-2.2.*`.
+- Make `Symbol` an instance of Semigroup.
+
 ## v0.3.0.0
 - Remove support for `ghc-7.10`. (#136)
 - Use a `.cabal` file that's auto-generated from `hpack`. (#138)

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-protoc
-version: '0.3.0.0'
+version: '0.3.1.0'
 synopsis: Protocol buffer compiler for the proto-lens library.
 description: >
   Turn protocol buffer files (.proto) into Haskell files (.hs) which
@@ -17,7 +17,7 @@ extra-source-files:
   - Changelog.md
 
 dependencies:
-  - base >= 4.8 && < 4.11
+  - base >= 4.8 && < 4.12
   - bytestring == 0.10.*
   - containers == 0.5.*
   - data-default-class >= 0.0 && < 0.2
@@ -32,7 +32,7 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
-    - Cabal >= 1.22 && < 2.1
+    - Cabal >= 1.22 && < 2.3
     - directory >= 1.2 && < 1.4
     - lens-labels == 0.2.*
     - pretty == 1.1.*

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -40,6 +40,7 @@ import Data.List (mapAccumL)
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
 import Data.Monoid
+import qualified Data.Semigroup as Semigroup
 import qualified Data.Set as Set
 import Data.String (IsString(..))
 import Data.Text (Text, cons, splitOn, toLower, uncons, unpack)
@@ -174,7 +175,7 @@ data FieldName = FieldName
 -- a 'Symbol' is used to construct both the type-level argument to
 -- @HasLens@ and the name of the function @foo@.
 newtype Symbol = Symbol String
-    deriving (Eq, Ord, IsString, Monoid)
+    deriving (Eq, Ord, IsString, Semigroup.Semigroup, Monoid)
 
 nameFromSymbol :: Symbol -> Name
 nameFromSymbol (Symbol s) = fromString s

--- a/proto-lens-tests-dep/package.yaml
+++ b/proto-lens-tests-dep/package.yaml
@@ -20,9 +20,9 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.8 && < 4.11
+    - base
     - Cabal
-    - proto-lens-protoc == 0.3.*
+    - proto-lens-protoc
 
 dependencies:
   - proto-lens-protoc

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -12,26 +12,26 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.8 && < 4.11
+    - base
     - Cabal
-    - proto-lens-protoc == 0.3.*
+    - proto-lens-protoc
 
 # Dependencies shared by the library and/or several of the tests:
 dependencies:
-    - HUnit >= 1.3 && < 1.7
+    - HUnit
     - QuickCheck
-    - base >= 4.8 && < 4.11
-    - bytestring == 0.10.*
+    - base
+    - bytestring
     - data-default-class
     - lens-family
-    - pretty == 1.1.*
-    - proto-lens == 0.3.*
-    - proto-lens-arbitrary == 0.1.*
-    - proto-lens-protoc == 0.3.*
-    - test-framework == 0.8.*
-    - test-framework-hunit == 0.3.*
-    - test-framework-quickcheck2 == 0.3.*
-    - text == 1.2.*
+    - pretty
+    - proto-lens
+    - proto-lens-arbitrary
+    - proto-lens-protoc
+    - test-framework
+    - test-framework-hunit
+    - test-framework-quickcheck2
+    - text
 
 
 library:

--- a/proto-lens-tutorial/stack.yaml
+++ b/proto-lens-tutorial/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.14
+resolver: lts-11.7
 packages:
 - person
 - coffee-order

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -1,7 +1,9 @@
 # Changelog for `proto-lens`
 
-## Latest
+## v0.3.1.0
 - Improve references to types/fields in decoding error messages (#187).
+- Bump the dependency on `base` for `ghc-8.4.2`.
+- Make `Registry` an instance of `Semigroup`.
 
 ## v0.3.0.0
 - Remove support for `ghc-7.10`. (#136)

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens
-version: "0.3.0.0"
+version: "0.3.1.0"
 synopsis: A lens-based implementation of protocol buffers in Haskell.
 description: >
   The proto-lens library provides to protocol buffers using modern
@@ -46,7 +46,7 @@ library:
     - Data.ProtoLens.TextFormat.Parser
   dependencies:
     - attoparsec == 0.13.*
-    - base >= 4.8 && < 4.11
+    - base >= 4.8 && < 4.12
     - bytestring == 0.10.*
     - containers == 0.5.*
     - deepseq == 1.4.*

--- a/proto-lens/src/Data/ProtoLens/Message.hs
+++ b/proto-lens/src/Data/ProtoLens/Message.hs
@@ -61,6 +61,7 @@ import qualified Data.Text as T
 import Data.Word
 import Lens.Family2 (Lens', over, set)
 import Lens.Family2.Unchecked (lens)
+import qualified Data.Semigroup as Semigroup
 
 import Data.ProtoLens.Encoding.Wire
     ( Tag(..)
@@ -285,7 +286,7 @@ reverseRepeatedFields fields x0
 --
 -- See the @withRegistry@ functions in 'Data.ProtoLens.TextFormat'
 newtype Registry = Registry (Map.Map T.Text SomeMessageType)
-    deriving Monoid
+    deriving (Semigroup.Semigroup, Monoid)
 
 -- | Build a 'Registry' containing a single proto type.
 --

--- a/proto-lens/src/Data/ProtoLens/TextFormat.hs
+++ b/proto-lens/src/Data/ProtoLens/TextFormat.hs
@@ -5,6 +5,7 @@
 -- https://developers.google.com/open-source/licenses/bsd
 
 -- | Functions for converting protocol buffers to a human-readable text format.
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE PatternGuards #-}
@@ -39,6 +40,10 @@ import qualified Data.Text as Text (unpack)
 import Numeric (showOct)
 import Text.Parsec (parse)
 import Text.PrettyPrint
+
+#if MIN_VERSION_base(4,11,0)
+import Prelude hiding ((<>))
+#endif
 
 import Data.ProtoLens.Encoding.Wire
 import Data.ProtoLens.Message

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.3
+resolver: lts-11.7
 packages:
 - lens-labels
 - proto-lens


### PR DESCRIPTION
- Bump resolver to lts-11.6 (ghc-8.2.2)
- Add a CI build against nightly stackage
- Bump package versions and update changelogs

The only nontrivial bit was that `Data.Semigroup` is now included
in `base`, and a superclass of `Data.Monoid`.

I also removed all the version bounds from
`proto-lens-{benchmarks,tests,tests-dep}`.  They're mainly noise since we
don't release those packages on Hackage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/191)
<!-- Reviewable:end -->
