### PR TITLE
Bump lower-bounds to `base-4.9`.

### DIFF
--- a/discrimination-ieee754/package.yaml
+++ b/discrimination-ieee754/package.yaml
@@ -12,7 +12,7 @@ license: BSD3
 github: google/proto-lens/discrimination-ieee754
 
 dependencies:
-  - base >= 4.8 && < 4.12
+  - base >= 4.9 && < 4.12
   - data-binary-ieee754 >= 0.4 && < 0.5
   - contravariant >= 1.3 && < 1.5
   - discrimination >= 0.3 && < 0.4

--- a/lens-labels/Changelog.md
+++ b/lens-labels/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `lens-labels`
 
+## v0.2.0.2
+- Bump the lower bound on `base` to indicate we require `ghc>=8.0`.
+
 ## v0.2.0.1
 - Bump the dependency on `base` to support `ghc-8.4.2`.
 

--- a/lens-labels/package.yaml
+++ b/lens-labels/package.yaml
@@ -1,5 +1,5 @@
 name: lens-labels
-version: "0.2.0.1"
+version: "0.2.0.2"
 synopsis: Integration of lenses with OverloadedLabels.
 description: >
   Provides a framework to integrate lenses with GHC's OverloadedLabels
@@ -20,7 +20,7 @@ library:
     - Lens.Labels.Unwrapped
     - Lens.Labels.Prism
   dependencies:
-    - base >= 4.8 && < 4.12
+    - base >= 4.9 && < 4.12
     - ghc-prim >= 0.4 && < 0.6
     - profunctors >= 5.2
     - tagged >= 0.8

--- a/proto-lens-arbitrary/Changelog.md
+++ b/proto-lens-arbitrary/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-arbitrary`
 
+## v0.1.2.2
+- Bump the lower bound on `base` to indicate we require `ghc>=8.0`.
+
 ## v0.1.2.1
 - Bump the dependency on `base` for `ghc-8.4.2`.
 - Bump the dependency for `QuickCheck-2.11`.

--- a/proto-lens-arbitrary/package.yaml
+++ b/proto-lens-arbitrary/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-arbitrary
-version: "0.1.2.1"
+version: "0.1.2.2"
 synopsis: Arbitrary instances for proto-lens.
 description: >
   The proto-lens-arbitrary allows generating arbitrary messages for
@@ -15,7 +15,7 @@ extra-source-files:
 
 dependencies:
   - proto-lens == 0.3.*
-  - base >= 4.8 && < 4.12
+  - base >= 4.9 && < 4.12
   - bytestring == 0.10.*
   - containers == 0.5.*
   - text == 1.2.*

--- a/proto-lens-combinators/Changelog.md
+++ b/proto-lens-combinators/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-combinators`
 
+## v0.1.0.11
+- Bump the lower bound on `base` to indicate we require `ghc>=8.0`.
+
 ## v0.1.0.10
 - Bump the dependency on `base` for `ghc-8.4.2`.
 

--- a/proto-lens-combinators/package.yaml
+++ b/proto-lens-combinators/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-combinators
-version: '0.1.0.10'
+version: '0.1.0.11'
 synopsis: Utilities functions to proto-lens.
 description: Useful things for working with protos.
 category: Data
@@ -14,12 +14,12 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.8 && < 4.12
+    - base >= 4.9 && < 4.12
     - Cabal
     - proto-lens-protoc == 0.3.*
 
 dependencies:
-  - base >= 4.8 && < 4.12
+  - base >= 4.9 && < 4.12
   - proto-lens-protoc == 0.3.*
   - lens-family == 1.2.*
 

--- a/proto-lens-discrimination/package.yaml
+++ b/proto-lens-discrimination/package.yaml
@@ -15,12 +15,12 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.8 && < 4.12
+    - base >= 4.9 && < 4.12
     - Cabal
     - proto-lens-protoc == 0.3.*
 
 dependencies:
-  - base >= 4.8 && < 4.12
+  - base >= 4.9 && < 4.12
   - data-default >= 0.5 && < 0.8
   - bytestring == 0.10.*
   - contravariant >= 1.3 && < 1.5

--- a/proto-lens-optparse/Changelog.md
+++ b/proto-lens-optparse/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-optparse`
 
+## v0.1.1.2
+- Bump the lower bound on `base` to indicate we require `ghc>=8.0`.
+
 ## v0.1.1.1
 - Bump the dependency on `base` for `ghc-8.4.2`.
 

--- a/proto-lens-optparse/package.yaml
+++ b/proto-lens-optparse/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-optparse
-version: '0.1.1.1'
+version: '0.1.1.2'
 synopsis: Adapting proto-lens to optparse-applicative ReadMs.
 description: >
   A package adapting proto-lens to optparse-applicative ReadMs.
@@ -16,7 +16,7 @@ extra-source-files:
 
 dependencies:
   - proto-lens >= 0.1 && < 0.4
-  - base >= 4.8 && < 4.12
+  - base >= 4.9 && < 4.12
   - optparse-applicative >= 0.12 && < 0.15
   - text == 1.2.*
 

--- a/proto-lens-protobuf-types/Changelog.md
+++ b/proto-lens-protobuf-types/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-protobuf-types`
 
+## v0.3.0.2
+- Bump the lower bound on `base` to indicate we require `ghc>=8.0`.
+
 ## v0.3.0.1
 - Bump the dependency on `base` for `ghc-8.4.2`.
 

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-protobuf-types
-version: '0.3.0.1'
+version: '0.3.0.2'
 synopsis: Basic protocol buffer message types.
 description: >
   This package provides bindings standard protocol message types,
@@ -19,12 +19,12 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.8 && < 4.12
+    - base >= 4.9 && < 4.12
     - Cabal
     - proto-lens-protoc == 0.3.*
 
 dependencies:
-  - base >= 4.8 && < 4.12
+  - base >= 4.9 && < 4.12
   - lens-family
   - proto-lens == 0.3.*
   - proto-lens-protoc == 0.3.*

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -2,6 +2,7 @@
 
 ## v0.3.1.1
 - Fix management of generated files between Cabal components (#171).
+- Bump the lower bound on `base` to indicate we require `ghc>=8.0`.
 
 ## v0.3.1.0
 - Bump the dependency on `base` for `ghc-8.4.2`.

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -17,7 +17,7 @@ extra-source-files:
   - Changelog.md
 
 dependencies:
-  - base >= 4.8 && < 4.12
+  - base >= 4.9 && < 4.12
   - bytestring == 0.10.*
   - containers == 0.5.*
   - data-default-class >= 0.0 && < 0.2

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens`
 
+## v0.3.1.1
+- Bump the lower bound on `base` to indicate we require `ghc>=8.0`.
+
 ## v0.3.1.0
 - Improve references to types/fields in decoding error messages (#187).
 - Bump the dependency on `base` for `ghc-8.4.2`.

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens
-version: "0.3.1.0"
+version: "0.3.1.1"
 synopsis: A lens-based implementation of protocol buffers in Haskell.
 description: >
   The proto-lens library provides to protocol buffers using modern
@@ -46,7 +46,7 @@ library:
     - Data.ProtoLens.TextFormat.Parser
   dependencies:
     - attoparsec == 0.13.*
-    - base >= 4.8 && < 4.12
+    - base >= 4.9 && < 4.12
     - bytestring == 0.10.*
     - containers == 0.5.*
     - deepseq == 1.4.*


### PR DESCRIPTION
The bump was actually supposed to be done by #136.  Unfortunately,
I accidentally reverted it during the switch to `hpack` (#138).

Also bump package versions and update changelogs accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/197)
<!-- Reviewable:end -->
