### PR TITLE
Use OverloadedLabels inside Data.ProtoLens.Any.

### DIFF
--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -25,7 +25,7 @@ custom-setup:
 
 dependencies:
   - base >= 4.8 && < 4.12
-  - lens-family
+  - lens-labels == 0.2.*
   - proto-lens == 0.3.*
   - proto-lens-protoc == 0.3.*
   - text == 1.2.*

--- a/proto-lens-protobuf-types/src/Data/ProtoLens/Any.hs
+++ b/proto-lens-protobuf-types/src/Data/ProtoLens/Any.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -21,9 +22,8 @@ import Data.ProtoLens
     , Message(..)
     )
 import Data.Proxy (Proxy(..))
-import Lens.Family2 ((&), (.~), (^.))
+import Lens.Labels ((&), (.~), (^.))
 import Proto.Google.Protobuf.Any
-import Proto.Google.Protobuf.Any_Fields
 
 -- | Packs the given message into an 'Any' using the default type URL prefix
 -- "type.googleapis.com".
@@ -36,8 +36,8 @@ googleApisPrefix = "type.googleapis.com"
 -- | Packs the given message into an 'Any' using the given type URL prefix.
 packWithPrefix :: forall a . Message a => Text -> a -> Any
 packWithPrefix prefix x =
-    def & typeUrl .~ (prefix <> "/" <> name)
-        & value .~ encodeMessage x
+    def & #typeUrl .~ (prefix <> "/" <> name)
+        & #value .~ encodeMessage x
   where
     name = messageName (Proxy @a)
 
@@ -59,12 +59,12 @@ instance Exception UnpackError
 -- Ignores the type URL prefix.
 unpack :: forall a . Message a => Any -> Either UnpackError a
 unpack a
-    | expectedName /= snd (Text.breakOnEnd "/" $ a ^. typeUrl)
+    | expectedName /= snd (Text.breakOnEnd "/" $ a ^. #typeUrl)
         = Left DifferentType
               { expectedMessageType = expectedName
-              , actualUrl = a ^. typeUrl
+              , actualUrl = a ^. #typeUrl
               }
-    | otherwise = case decodeMessage (a ^. value) of
+    | otherwise = case decodeMessage (a ^. #value) of
         Left e -> Left $ DecodingError $ Text.pack e
         Right x -> Right x
   where


### PR DESCRIPTION
It's not necessary for the internal code to use the `_Fields` modules,
since proto-lens already requires `ghc>=8.0`.

Additionally, this makes it easier to build `proto-lens-proto-types`
with `rules_haskell`, which doesn't currently generate the `_Fields`
modules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/198)
<!-- Reviewable:end -->
