### PR TITLE
Separate compiler and run-time for sake of cross.

### DIFF
--- a/proto-lens-combinators/package.yaml
+++ b/proto-lens-combinators/package.yaml
@@ -20,7 +20,7 @@ custom-setup:
 
 dependencies:
   - base >= 4.9 && < 4.12
-  - proto-lens-protoc == 0.3.*
+  - proto-lens-protoc-rt == 0.3.*
   - lens-family == 1.2.*
 
 library:
@@ -42,7 +42,7 @@ tests:
       - lens-family-core
       - proto-lens
       - proto-lens-combinators
-      - proto-lens-protoc
+      - proto-lens-protoc-rt
       - test-framework
       - test-framework-hunit
     other-modules:

--- a/proto-lens-discrimination/package.yaml
+++ b/proto-lens-discrimination/package.yaml
@@ -29,7 +29,7 @@ dependencies:
   - discrimination-ieee754 == 0.1.*
   - lens-family == 1.2.*
   - proto-lens >= 0.3 && < 0.4
-  - proto-lens-protoc >= 0.3 && < 0.4
+  - proto-lens-protoc-rt >= 0.3 && < 0.4
   - text == 1.2.*
 
 library:

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -27,7 +27,7 @@ dependencies:
   - base >= 4.9 && < 4.12
   - lens-labels == 0.2.*
   - proto-lens == 0.3.*
-  - proto-lens-protoc == 0.3.*
+  - proto-lens-protoc-rt == 0.3.*
   - text == 1.2.*
 
 library:

--- a/proto-lens-protoc-rt/Changelog.md
+++ b/proto-lens-protoc-rt/Changelog.md
@@ -1,0 +1,7 @@
+# Changelog for `proto-lens-protoc-rt`
+
+## v0.3.2.1
+- Pull out of `proto-lens-protoc`.
+
+## v0.3.1.0 and older
+See `Changelog.md` for `proto-lens-protoc`.

--- a/proto-lens-protoc-rt/LICENSE
+++ b/proto-lens-protoc-rt/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2016, Google Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Google Inc. nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/proto-lens-protoc-rt/Setup.hs
+++ b/proto-lens-protoc-rt/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/proto-lens-protoc-rt/package.yaml
+++ b/proto-lens-protoc-rt/package.yaml
@@ -1,0 +1,53 @@
+name: proto-lens-protoc-rt
+version: '0.3.1.1'
+synopsis: Protocol buffer compiler for the proto-lens library.
+description: >
+  Modules that are needed by the generated Haskell files.
+  For forwards compatibility, reexport them as new module names so that
+  other packages don't accidentally write non-generated code that
+  relies on these modules being reexported by proto-lens-protoc.
+
+  This was pulled out of the compiler for sake for cross compilation. In that
+  case, the compiler and run time are built for different platforms, so they
+  need to be separate packages (until Cabal is improved).
+
+  Nothing here is guaranteed to have a stable API. Use a compiler and runtime
+  from the same source revision.
+category: Data
+author: Judah Jacobson
+maintainer: proto-lens@googlegroups.com
+github: google/proto-lens/proto-lens-protoc
+copyright: Google Inc.
+license: BSD3
+extra-source-files:
+  - Changelog.md
+
+library:
+  dependencies:
+    - base >= 4.9 && < 4.12
+    - bytestring == 0.10.*
+    - containers == 0.5.*
+    - data-default-class >= 0.0 && < 0.2
+    - deepseq == 1.4.*
+    - lens-family == 1.2.*
+    - lens-labels == 0.2.*
+    - pretty == 1.1.*
+    - proto-lens == 0.3.*
+    - text == 1.2.*
+  reexported-modules:
+    - Prelude as Data.ProtoLens.Reexport.Prelude,
+    - Data.Int as Data.ProtoLens.Reexport.Data.Int,
+    - Data.Word as Data.ProtoLens.Reexport.Data.Word,
+    - Data.ByteString as Data.ProtoLens.Reexport.Data.ByteString,
+    - Data.ByteString.Char8 as Data.ProtoLens.Reexport.Data.ByteString.Char8,
+    - Data.Default.Class as Data.ProtoLens.Reexport.Data.Default.Class,
+    - Data.Map as Data.ProtoLens.Reexport.Data.Map,
+    - Data.ProtoLens as Data.ProtoLens.Reexport.Data.ProtoLens,
+    - Data.ProtoLens.Service.Types as Data.ProtoLens.Reexport.Data.ProtoLens.Service.Types,
+    - Data.ProtoLens.Message.Enum as Data.ProtoLens.Reexport.Data.ProtoLens.Message.Enum,
+    - Data.Text as Data.ProtoLens.Reexport.Data.Text,
+    - Lens.Family2 as Data.ProtoLens.Reexport.Lens.Family2,
+    - Lens.Family2.Unchecked as Data.ProtoLens.Reexport.Lens.Family2.Unchecked,
+    - Lens.Labels as Data.ProtoLens.Reexport.Lens.Labels,
+    - Lens.Labels.Prism as Data.ProtoLens.Reexport.Lens.Labels.Prism,
+    - Text.Read as Data.ProtoLens.Reexport.Text.Read

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -44,27 +44,6 @@ library:
     - Data.ProtoLens.Compiler.Generate
     - Data.ProtoLens.Compiler.Plugin
     - Data.ProtoLens.Setup
-  reexported-modules:
-    # Modules that are needed by the generated Haskell files.
-    # For forwards compatibility, reexport them as new module names so that
-    # other packages don't accidentally write non-generated code that
-    # relies on these modules being reexported by proto-lens-protoc.
-    - Prelude as Data.ProtoLens.Reexport.Prelude,
-    - Data.Int as Data.ProtoLens.Reexport.Data.Int,
-    - Data.Word as Data.ProtoLens.Reexport.Data.Word,
-    - Data.ByteString as Data.ProtoLens.Reexport.Data.ByteString,
-    - Data.ByteString.Char8 as Data.ProtoLens.Reexport.Data.ByteString.Char8,
-    - Data.Default.Class as Data.ProtoLens.Reexport.Data.Default.Class,
-    - Data.Map as Data.ProtoLens.Reexport.Data.Map,
-    - Data.ProtoLens as Data.ProtoLens.Reexport.Data.ProtoLens,
-    - Data.ProtoLens.Service.Types as Data.ProtoLens.Reexport.Data.ProtoLens.Service.Types,
-    - Data.ProtoLens.Message.Enum as Data.ProtoLens.Reexport.Data.ProtoLens.Message.Enum,
-    - Data.Text as Data.ProtoLens.Reexport.Data.Text,
-    - Lens.Family2 as Data.ProtoLens.Reexport.Lens.Family2,
-    - Lens.Family2.Unchecked as Data.ProtoLens.Reexport.Lens.Family2.Unchecked,
-    - Lens.Labels as Data.ProtoLens.Reexport.Lens.Labels,
-    - Lens.Labels.Prism as Data.ProtoLens.Reexport.Lens.Labels.Prism,
-    - Text.Read as Data.ProtoLens.Reexport.Text.Read
 
 executables:
   proto-lens-protoc:

--- a/proto-lens-tests-dep/package.yaml
+++ b/proto-lens-tests-dep/package.yaml
@@ -25,7 +25,7 @@ custom-setup:
     - proto-lens-protoc
 
 dependencies:
-  - proto-lens-protoc
+  - proto-lens-protoc-rt
   - base
 
 library:

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -27,7 +27,7 @@ dependencies:
     - pretty
     - proto-lens
     - proto-lens-arbitrary
-    - proto-lens-protoc
+    - proto-lens-protoc-rt
     - test-framework
     - test-framework-hunit
     - test-framework-quickcheck2

--- a/proto-lens-tutorial/coffee-order/package.yaml
+++ b/proto-lens-tutorial/coffee-order/package.yaml
@@ -21,14 +21,14 @@ dependencies:
   - data-default
   - microlens
   - proto-lens
-  - proto-lens-protoc
+  - proto-lens-protoc-rt
   - lens-labels
   - text
 
 executables:
   gimme-coffee:
     dependencies:
-      - proto-lens-protoc
+      - proto-lens-protoc-rt
     other-modules:
       - Proto.Coffee.Order
       - Proto.Coffee.Order_Fields

--- a/proto-lens-tutorial/person/package.yaml
+++ b/proto-lens-tutorial/person/package.yaml
@@ -11,7 +11,7 @@ extra-source-files: proto/**/*.proto
 library:
   dependencies:
     - base
-    - proto-lens-protoc
+    - proto-lens-protoc-rt
 
   exposed-modules:
     - Proto.Person
@@ -27,6 +27,3 @@ executables:
       - person
       - microlens
       - proto-lens
-      # The following dependency works around a bug with Cabal-1.*.  It is not
-      # needed with Cabal-2.0 or later (stack lts-10.0 or later).
-      - proto-lens-protoc

--- a/proto-lens-tutorial/stack.yaml
+++ b/proto-lens-tutorial/stack.yaml
@@ -9,4 +9,5 @@ packages:
   subdirs:
     - proto-lens
     - proto-lens-protoc
+    - proto-lens-protoc-rt
     - lens-labels

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,7 @@ packages:
 - lens-labels
 - proto-lens
 - proto-lens-protoc
+- proto-lens-protoc-rt
 - proto-lens-protobuf-types
 - proto-lens-arbitrary
 - proto-lens-combinators

--- a/travis-cabal.sh
+++ b/travis-cabal.sh
@@ -21,6 +21,7 @@ PACKAGES_TO_INSTALL="
     lens-labels
     proto-lens
     proto-lens-protoc
+    proto-lens-protoc-rt
     proto-lens-protobuf-types
     proto-lens-arbitrary
     proto-lens-combinators


### PR DESCRIPTION
The run-time was pulled out of the compiler for sake for cross compilation. In that case, the compiler and run time are built for different platforms, so they need to be separate packages (until Cabal is improved).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/202)
<!-- Reviewable:end -->
