### PR TITLE
Expose bindings for empty.proto.

### DIFF
--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -14,6 +14,7 @@ extra-source-files:
   - Changelog.md
   - proto-src/google/protobuf/any.proto
   - proto-src/google/protobuf/duration.proto
+  - proto-src/google/protobuf/empty.proto
   - proto-src/google/protobuf/wrappers.proto
   - proto-src/google/protobuf/timestamp.proto
 
@@ -38,6 +39,8 @@ library:
     - Proto.Google.Protobuf.Any_Fields
     - Proto.Google.Protobuf.Duration
     - Proto.Google.Protobuf.Duration_Fields
+    - Proto.Google.Protobuf.Empty
+    - Proto.Google.Protobuf.Empty_Fields
     - Proto.Google.Protobuf.Wrappers
     - Proto.Google.Protobuf.Wrappers_Fields
     - Proto.Google.Protobuf.Timestamp

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -54,6 +54,8 @@ library:
         Proto.Google.Protobuf.Any_Fields
         Proto.Google.Protobuf.Duration
         Proto.Google.Protobuf.Duration_Fields
+        Proto.Google.Protobuf.Empty
+        Proto.Google.Protobuf.Empty_Fields
         Proto.Google.Protobuf.Wrappers
         Proto.Google.Protobuf.Wrappers_Fields
         Proto.Google.Protobuf.Timestamp


### PR DESCRIPTION
We've found it useful to use that generic type, for example in RPCs that don't
return a value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/206)
<!-- Reviewable:end -->
