### PR TITLE
Generate explicit instances of NFData.

### DIFF
--- a/proto-lens-benchmarks/benchmarks/IntPacking.hs
+++ b/proto-lens-benchmarks/benchmarks/IntPacking.hs
@@ -3,33 +3,18 @@
 -- Use of this source code is governed by a BSD-style
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | A benchmark to measure the performance difference between packed and
 -- unpacked integer data.
 module Main (main) where
 
 import Data.ProtoLens.BenchmarkUtil (protoBenchmark, benchmarkMain)
-import GHC.Generics (Generic)
-import Control.DeepSeq (NFData)
 import Criterion.Main (Benchmark)
 import Lens.Family ((&), (.~))
 import Data.Int (Int32)
 import Data.ProtoLens (def)
 import Proto.IntPacking
 import Proto.IntPacking_Fields
-
--- These instances are required by Criterion to benchmark proto decoding.
-deriving instance Generic FooUnpacked
-
-deriving instance Generic FooPacked
-
-deriving instance NFData FooUnpacked
-
-deriving instance NFData FooPacked
 
 defaultNumInt32s :: Int
 defaultNumInt32s = 10000

--- a/proto-lens-benchmarks/benchmarks/Nested.hs
+++ b/proto-lens-benchmarks/benchmarks/Nested.hs
@@ -3,11 +3,7 @@
 -- Use of this source code is governed by a BSD-style
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | A benchmark to measure the difference between nesting fields in a repeated
 -- submessage vs. putting repeated fields directly in the top-level message.
@@ -15,27 +11,12 @@ module Main (main) where
 
 import Data.Int (Int32)
 import Data.ProtoLens.BenchmarkUtil (protoBenchmark, benchmarkMain)
-import GHC.Generics (Generic)
-import Control.DeepSeq (NFData)
 import Criterion.Main (Benchmark)
 import Data.Text (Text)
 import Lens.Family ((&), (.~))
 import Data.ProtoLens.Message (def)
 import Proto.Nested
 import Proto.Nested_Fields
-
--- These instances are required by Criterion to benchmark proto decoding.
-deriving instance Generic FooFlat
-
-deriving instance Generic FooNested
-
-deriving instance Generic FooNested'Sub
-
-deriving instance NFData FooFlat
-
-deriving instance NFData FooNested
-
-deriving instance NFData FooNested'Sub
 
 defaultNumValues :: Int
 defaultNumValues = 10000

--- a/proto-lens-benchmarks/benchmarks/UnusedFields.hs
+++ b/proto-lens-benchmarks/benchmarks/UnusedFields.hs
@@ -3,10 +3,6 @@
 -- Use of this source code is governed by a BSD-style
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 -- | A benchmark to measure the overhead of including a lot of unused fields
 -- in a proto message. Because protos are modeled as Haskell records, decoding
@@ -16,23 +12,12 @@
 module Main where
 
 import Data.ProtoLens.BenchmarkUtil (protoBenchmark, benchmarkMain)
-import GHC.Generics (Generic)
-import Control.DeepSeq (NFData)
 import Criterion.Main (Benchmark)
 import Lens.Family2 ((&), (.~))
 import Data.Int (Int32)
 import Data.ProtoLens.Message (def)
 import Proto.UnusedFields
 import Proto.UnusedFields_Fields
-
--- These instances are required by Criterion to benchmark proto decoding.
-deriving instance Generic Foo
-
-deriving instance Generic FooWithUnusedFields
-
-deriving instance NFData Foo
-
-deriving instance NFData FooWithUnusedFields
 
 defaultNumInt32s :: Int
 defaultNumInt32s = 10000

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -3,6 +3,7 @@
 ## v0.4
 - Split out `proto-lens-setup` and `proto-lens-runtime` into separate
   packages.
+- Generate explicit `NFData` instances for each type.
 
 ## v0.3.1.1
 - Fix management of generated files between Cabal components (#171).

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -84,7 +84,7 @@ generateModule modName imports syntaxType modifyImport definitions importedEnv s
     = [ Module modName
                 (Just $ (serviceExports ++) $ concatMap generateExports $ Map.elems definitions)
                 pragmas
-                (prismImport:sharedImports)
+                (mainImports ++ sharedImports)
           $ (concatMap generateDecls $ Map.toList definitions)
          ++ map uncommented (concatMap (generateServiceDecls env) services)
       , Module fieldModName
@@ -110,7 +110,8 @@ generateModule modName imports syntaxType modifyImport definitions importedEnv s
           -- in a single entry, so we use two: `Foo(..)` and `Foo(A, B)`.
           , optionsGhcPragma "-fno-warn-duplicate-exports"
           ]
-    prismImport = modifyImport $ importSimple "Lens.Labels.Prism"
+    mainImports = map (modifyImport . importSimple)
+                    [ "Control.DeepSeq", "Lens.Labels.Prism" ]
     sharedImports = map (modifyImport . importSimple)
               [ "Prelude", "Data.Int", "Data.Word"
               , "Data.ProtoLens", "Data.ProtoLens.Message.Enum", "Data.ProtoLens.Service.Types"
@@ -323,6 +324,16 @@ generateMessageDecls fieldModName syntaxType env protoName info =
     -- instance Message.Message Bar where
     , uncommented $ instDecl [] ("Data.ProtoLens.Message" `ihApp` [dataType])
         $ messageInstance syntaxType env protoName info
+    -- instance NFData Bar where
+    , uncommented $ instDecl [] ("Control.DeepSeq.NFData" `ihApp` [dataType])
+        [[match "rnf" [] $ messageRnfExpr info]]
+    ] ++
+    -- instance NFData Foo'Bar where
+    [ uncommented $
+        instDecl [] ("Control.DeepSeq.NFData" `ihApp`
+                        [tyCon $ unQual $ oneofTypeName o])
+        [map oneofRnfMatch $ oneofCases o]
+    | o <- messageOneofFields info
     ]
   where
     dataType = tyCon $ unQual dataName
@@ -531,6 +542,11 @@ generateEnumDecls Proto3 info =
     --   fieldDefault = FirstEnumValue
     , instDecl [] ("Data.ProtoLens.FieldDefault" `ihApp` [dataType])
         [[match "fieldDefault" [] defaultCon]]
+    -- instance NFData Foo where
+    --   rnf x__ = seq x__ ()
+    -- (Trivial since enum types are already strict)
+    , instDecl [] ("Control.DeepSeq.NFData" `ihApp` [dataType])
+        [[ match "rnf" ["x__"] $ "Prelude.seq" @@ "x__" @@ "()" ]]
     ] ++
     -- pattern Enum2a :: FooEnum
     -- pattern Enum2a = Enum2
@@ -684,6 +700,11 @@ generateEnumDecls Proto2 info =
         [[ match "minBound" [] $ con $ unQual minBoundName
          , match "maxBound" [] $ con $ unQual maxBoundName
          ]]
+    -- instance NFData Foo where
+    --   rnf x__ = seq x__ ()
+    -- (Trivial since enum types are already strict)
+    , instDecl [] ("Control.DeepSeq.NFData" `ihApp` [dataType])
+        [[ match "rnf" ["x__"] $ "Prelude.seq" @@ "x__" @@ "()" ]]
     ]
     ++
     -- pattern FooAlias :: Foo
@@ -1181,3 +1202,25 @@ fieldTypeDescriptorExpr = \case
   where
     mk x y = fromString ("Data.ProtoLens." ++ x)
               @@ fromString ("Data.ProtoLens." ++ y)
+
+-- | Generate the implementation of NFData.rnf for the given message.
+--
+-- instance NFData Bar where
+--    rnf = \x -> deepseq (_Bar'foo x) (deepseq (_Bar'bar x) ())
+messageRnfExpr :: MessageInfo Name -> Exp
+messageRnfExpr msg = lambda ["x__"] $ foldr (@@) "()" (map seqField fieldNames)
+  where
+    fieldNames = messageUnknownFields msg
+                : map (haskellRecordFieldName . plainFieldName)
+                       (messageFields msg)
+                ++ map (haskellRecordFieldName . oneofFieldName)
+                       (messageOneofFields msg)
+    seqField :: Name -> Exp
+    seqField f = "Control.DeepSeq.deepseq" @@ (var (unQual f) @@ "x__")
+
+-- instance NFData Bar where
+--   rnf (Foo'a x__) = rnf x__
+--   rnf (Bar'b x__) = rnf x__
+oneofRnfMatch :: OneofCase -> Match
+oneofRnfMatch c = match "rnf" [unQual (caseConstructorName c) `pApp` ["x__"]]
+                    $ "Control.DeepSeq.rnf" @@ "x__"

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -20,6 +20,7 @@ library:
     - bytestring == 0.10.*
     - containers == 0.5.*
     - data-default-class >= 0.0 && < 0.2
+    - deepseq == 1.4.*
     - filepath >= 1.4 && < 1.6
     - lens-family == 1.2.*
     - lens-labels == 0.2.*
@@ -29,6 +30,7 @@ library:
 
   reexported-modules:
     - Prelude as Data.ProtoLens.Runtime.Prelude,
+    - Control.DeepSeq as Data.ProtoLens.Runtime.Control.DeepSeq,
     - Data.Int as Data.ProtoLens.Runtime.Data.Int,
     - Data.Word as Data.ProtoLens.Runtime.Data.Word,
     - Data.ByteString as Data.ProtoLens.Runtime.Data.ByteString,

--- a/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -9,6 +9,7 @@ module Proto.Google.Protobuf.Compiler.Plugin
        (CodeGeneratorRequest(..), CodeGeneratorResponse(..),
         CodeGeneratorResponse'File(..))
        where
+import qualified Control.DeepSeq
 import qualified Lens.Labels.Prism
 import qualified Prelude
 import qualified Data.Int
@@ -129,6 +130,14 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
         unknownFields
           = Lens.Family2.Unchecked.lens _CodeGeneratorRequest'_unknownFields
               (\ x__ y__ -> x__{_CodeGeneratorRequest'_unknownFields = y__})
+instance Control.DeepSeq.NFData CodeGeneratorRequest where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_CodeGeneratorRequest'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_CodeGeneratorRequest'fileToGenerate x__)
+                   (Control.DeepSeq.deepseq (_CodeGeneratorRequest'parameter x__)
+                      (Control.DeepSeq.deepseq (_CodeGeneratorRequest'protoFile x__)
+                         (()))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.error' @:: Lens' CodeGeneratorResponse Data.Text.Text@
@@ -209,6 +218,12 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
         unknownFields
           = Lens.Family2.Unchecked.lens _CodeGeneratorResponse'_unknownFields
               (\ x__ y__ -> x__{_CodeGeneratorResponse'_unknownFields = y__})
+instance Control.DeepSeq.NFData CodeGeneratorResponse where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_CodeGeneratorResponse'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_CodeGeneratorResponse'error x__)
+                   (Control.DeepSeq.deepseq (_CodeGeneratorResponse'file x__) (())))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.name' @:: Lens' CodeGeneratorResponse'File Data.Text.Text@
@@ -343,3 +358,13 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
               _CodeGeneratorResponse'File'_unknownFields
               (\ x__ y__ ->
                  x__{_CodeGeneratorResponse'File'_unknownFields = y__})
+instance Control.DeepSeq.NFData CodeGeneratorResponse'File where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq
+                (_CodeGeneratorResponse'File'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_CodeGeneratorResponse'File'name x__)
+                   (Control.DeepSeq.deepseq
+                      (_CodeGeneratorResponse'File'insertionPoint x__)
+                      (Control.DeepSeq.deepseq (_CodeGeneratorResponse'File'content x__)
+                         (()))))

--- a/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
@@ -23,6 +23,7 @@ module Proto.Google.Protobuf.Descriptor
         SourceCodeInfo'Location(..), UninterpretedOption(..),
         UninterpretedOption'NamePart(..))
        where
+import qualified Control.DeepSeq
 import qualified Lens.Labels.Prism
 import qualified Prelude
 import qualified Data.Int
@@ -289,6 +290,23 @@ instance Data.ProtoLens.Message DescriptorProto where
         unknownFields
           = Lens.Family2.Unchecked.lens _DescriptorProto'_unknownFields
               (\ x__ y__ -> x__{_DescriptorProto'_unknownFields = y__})
+instance Control.DeepSeq.NFData DescriptorProto where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_DescriptorProto'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_DescriptorProto'name x__)
+                   (Control.DeepSeq.deepseq (_DescriptorProto'field x__)
+                      (Control.DeepSeq.deepseq (_DescriptorProto'extension x__)
+                         (Control.DeepSeq.deepseq (_DescriptorProto'nestedType x__)
+                            (Control.DeepSeq.deepseq (_DescriptorProto'enumType x__)
+                               (Control.DeepSeq.deepseq (_DescriptorProto'extensionRange x__)
+                                  (Control.DeepSeq.deepseq (_DescriptorProto'oneofDecl x__)
+                                     (Control.DeepSeq.deepseq (_DescriptorProto'options x__)
+                                        (Control.DeepSeq.deepseq
+                                           (_DescriptorProto'reservedRange x__)
+                                           (Control.DeepSeq.deepseq
+                                              (_DescriptorProto'reservedName x__)
+                                              (())))))))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.start' @:: Lens' DescriptorProto'ExtensionRange Data.Int.Int32@
@@ -390,6 +408,16 @@ instance Data.ProtoLens.Message DescriptorProto'ExtensionRange
               _DescriptorProto'ExtensionRange'_unknownFields
               (\ x__ y__ ->
                  x__{_DescriptorProto'ExtensionRange'_unknownFields = y__})
+instance Control.DeepSeq.NFData DescriptorProto'ExtensionRange
+         where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq
+                (_DescriptorProto'ExtensionRange'_unknownFields x__)
+                (Control.DeepSeq.deepseq
+                   (_DescriptorProto'ExtensionRange'start x__)
+                   (Control.DeepSeq.deepseq (_DescriptorProto'ExtensionRange'end x__)
+                      (())))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.start' @:: Lens' DescriptorProto'ReservedRange Data.Int.Int32@
@@ -487,6 +515,14 @@ instance Data.ProtoLens.Message DescriptorProto'ReservedRange where
               _DescriptorProto'ReservedRange'_unknownFields
               (\ x__ y__ ->
                  x__{_DescriptorProto'ReservedRange'_unknownFields = y__})
+instance Control.DeepSeq.NFData DescriptorProto'ReservedRange where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq
+                (_DescriptorProto'ReservedRange'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_DescriptorProto'ReservedRange'start x__)
+                   (Control.DeepSeq.deepseq (_DescriptorProto'ReservedRange'end x__)
+                      (())))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' EnumDescriptorProto Data.Text.Text@
@@ -593,6 +629,13 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
         unknownFields
           = Lens.Family2.Unchecked.lens _EnumDescriptorProto'_unknownFields
               (\ x__ y__ -> x__{_EnumDescriptorProto'_unknownFields = y__})
+instance Control.DeepSeq.NFData EnumDescriptorProto where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_EnumDescriptorProto'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_EnumDescriptorProto'name x__)
+                   (Control.DeepSeq.deepseq (_EnumDescriptorProto'value x__)
+                      (Control.DeepSeq.deepseq (_EnumDescriptorProto'options x__) (()))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.allowAlias' @:: Lens' EnumOptions Prelude.Bool@
@@ -696,6 +739,14 @@ instance Data.ProtoLens.Message EnumOptions where
         unknownFields
           = Lens.Family2.Unchecked.lens _EnumOptions'_unknownFields
               (\ x__ y__ -> x__{_EnumOptions'_unknownFields = y__})
+instance Control.DeepSeq.NFData EnumOptions where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_EnumOptions'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_EnumOptions'allowAlias x__)
+                   (Control.DeepSeq.deepseq (_EnumOptions'deprecated x__)
+                      (Control.DeepSeq.deepseq (_EnumOptions'uninterpretedOption x__)
+                         (()))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' EnumValueDescriptorProto Data.Text.Text@
@@ -821,6 +872,15 @@ instance Data.ProtoLens.Message EnumValueDescriptorProto where
           = Lens.Family2.Unchecked.lens
               _EnumValueDescriptorProto'_unknownFields
               (\ x__ y__ -> x__{_EnumValueDescriptorProto'_unknownFields = y__})
+instance Control.DeepSeq.NFData EnumValueDescriptorProto where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq
+                (_EnumValueDescriptorProto'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_EnumValueDescriptorProto'name x__)
+                   (Control.DeepSeq.deepseq (_EnumValueDescriptorProto'number x__)
+                      (Control.DeepSeq.deepseq (_EnumValueDescriptorProto'options x__)
+                         (()))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' EnumValueOptions Prelude.Bool@
@@ -896,6 +956,14 @@ instance Data.ProtoLens.Message EnumValueOptions where
         unknownFields
           = Lens.Family2.Unchecked.lens _EnumValueOptions'_unknownFields
               (\ x__ y__ -> x__{_EnumValueOptions'_unknownFields = y__})
+instance Control.DeepSeq.NFData EnumValueOptions where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_EnumValueOptions'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_EnumValueOptions'deprecated x__)
+                   (Control.DeepSeq.deepseq
+                      (_EnumValueOptions'uninterpretedOption x__)
+                      (())))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' FieldDescriptorProto Data.Text.Text@
@@ -1243,6 +1311,23 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
         unknownFields
           = Lens.Family2.Unchecked.lens _FieldDescriptorProto'_unknownFields
               (\ x__ y__ -> x__{_FieldDescriptorProto'_unknownFields = y__})
+instance Control.DeepSeq.NFData FieldDescriptorProto where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_FieldDescriptorProto'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_FieldDescriptorProto'name x__)
+                   (Control.DeepSeq.deepseq (_FieldDescriptorProto'number x__)
+                      (Control.DeepSeq.deepseq (_FieldDescriptorProto'label x__)
+                         (Control.DeepSeq.deepseq (_FieldDescriptorProto'type' x__)
+                            (Control.DeepSeq.deepseq (_FieldDescriptorProto'typeName x__)
+                               (Control.DeepSeq.deepseq (_FieldDescriptorProto'extendee x__)
+                                  (Control.DeepSeq.deepseq (_FieldDescriptorProto'defaultValue x__)
+                                     (Control.DeepSeq.deepseq (_FieldDescriptorProto'oneofIndex x__)
+                                        (Control.DeepSeq.deepseq
+                                           (_FieldDescriptorProto'jsonName x__)
+                                           (Control.DeepSeq.deepseq
+                                              (_FieldDescriptorProto'options x__)
+                                              (())))))))))))
 data FieldDescriptorProto'Label = FieldDescriptorProto'LABEL_OPTIONAL
                                 | FieldDescriptorProto'LABEL_REQUIRED
                                 | FieldDescriptorProto'LABEL_REPEATED
@@ -1301,6 +1386,8 @@ instance Prelude.Enum FieldDescriptorProto'Label where
 instance Prelude.Bounded FieldDescriptorProto'Label where
         minBound = FieldDescriptorProto'LABEL_OPTIONAL
         maxBound = FieldDescriptorProto'LABEL_REPEATED
+instance Control.DeepSeq.NFData FieldDescriptorProto'Label where
+        rnf x__ = Prelude.seq x__ (())
 data FieldDescriptorProto'Type = FieldDescriptorProto'TYPE_DOUBLE
                                | FieldDescriptorProto'TYPE_FLOAT
                                | FieldDescriptorProto'TYPE_INT64
@@ -1505,6 +1592,8 @@ instance Prelude.Enum FieldDescriptorProto'Type where
 instance Prelude.Bounded FieldDescriptorProto'Type where
         minBound = FieldDescriptorProto'TYPE_DOUBLE
         maxBound = FieldDescriptorProto'TYPE_SINT64
+instance Control.DeepSeq.NFData FieldDescriptorProto'Type where
+        rnf x__ = Prelude.seq x__ (())
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.ctype' @:: Lens' FieldOptions FieldOptions'CType@
@@ -1728,6 +1817,18 @@ instance Data.ProtoLens.Message FieldOptions where
         unknownFields
           = Lens.Family2.Unchecked.lens _FieldOptions'_unknownFields
               (\ x__ y__ -> x__{_FieldOptions'_unknownFields = y__})
+instance Control.DeepSeq.NFData FieldOptions where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_FieldOptions'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_FieldOptions'ctype x__)
+                   (Control.DeepSeq.deepseq (_FieldOptions'packed x__)
+                      (Control.DeepSeq.deepseq (_FieldOptions'jstype x__)
+                         (Control.DeepSeq.deepseq (_FieldOptions'lazy x__)
+                            (Control.DeepSeq.deepseq (_FieldOptions'deprecated x__)
+                               (Control.DeepSeq.deepseq (_FieldOptions'weak x__)
+                                  (Control.DeepSeq.deepseq (_FieldOptions'uninterpretedOption x__)
+                                     (()))))))))
 data FieldOptions'CType = FieldOptions'STRING
                         | FieldOptions'CORD
                         | FieldOptions'STRING_PIECE
@@ -1776,6 +1877,8 @@ instance Prelude.Enum FieldOptions'CType where
 instance Prelude.Bounded FieldOptions'CType where
         minBound = FieldOptions'STRING
         maxBound = FieldOptions'STRING_PIECE
+instance Control.DeepSeq.NFData FieldOptions'CType where
+        rnf x__ = Prelude.seq x__ (())
 data FieldOptions'JSType = FieldOptions'JS_NORMAL
                          | FieldOptions'JS_STRING
                          | FieldOptions'JS_NUMBER
@@ -1824,6 +1927,8 @@ instance Prelude.Enum FieldOptions'JSType where
 instance Prelude.Bounded FieldOptions'JSType where
         minBound = FieldOptions'JS_NORMAL
         maxBound = FieldOptions'JS_NUMBER
+instance Control.DeepSeq.NFData FieldOptions'JSType where
+        rnf x__ = Prelude.seq x__ (())
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' FileDescriptorProto Data.Text.Text@
@@ -2158,6 +2263,28 @@ instance Data.ProtoLens.Message FileDescriptorProto where
         unknownFields
           = Lens.Family2.Unchecked.lens _FileDescriptorProto'_unknownFields
               (\ x__ y__ -> x__{_FileDescriptorProto'_unknownFields = y__})
+instance Control.DeepSeq.NFData FileDescriptorProto where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_FileDescriptorProto'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_FileDescriptorProto'name x__)
+                   (Control.DeepSeq.deepseq (_FileDescriptorProto'package x__)
+                      (Control.DeepSeq.deepseq (_FileDescriptorProto'dependency x__)
+                         (Control.DeepSeq.deepseq
+                            (_FileDescriptorProto'publicDependency x__)
+                            (Control.DeepSeq.deepseq (_FileDescriptorProto'weakDependency x__)
+                               (Control.DeepSeq.deepseq (_FileDescriptorProto'messageType x__)
+                                  (Control.DeepSeq.deepseq (_FileDescriptorProto'enumType x__)
+                                     (Control.DeepSeq.deepseq (_FileDescriptorProto'service x__)
+                                        (Control.DeepSeq.deepseq
+                                           (_FileDescriptorProto'extension x__)
+                                           (Control.DeepSeq.deepseq
+                                              (_FileDescriptorProto'options x__)
+                                              (Control.DeepSeq.deepseq
+                                                 (_FileDescriptorProto'sourceCodeInfo x__)
+                                                 (Control.DeepSeq.deepseq
+                                                    (_FileDescriptorProto'syntax x__)
+                                                    (())))))))))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.file' @:: Lens' FileDescriptorSet [FileDescriptorProto]@
@@ -2200,6 +2327,11 @@ instance Data.ProtoLens.Message FileDescriptorSet where
         unknownFields
           = Lens.Family2.Unchecked.lens _FileDescriptorSet'_unknownFields
               (\ x__ y__ -> x__{_FileDescriptorSet'_unknownFields = y__})
+instance Control.DeepSeq.NFData FileDescriptorSet where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_FileDescriptorSet'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_FileDescriptorSet'file x__) (()))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.javaPackage' @:: Lens' FileOptions Data.Text.Text@
@@ -2689,6 +2821,33 @@ instance Data.ProtoLens.Message FileOptions where
         unknownFields
           = Lens.Family2.Unchecked.lens _FileOptions'_unknownFields
               (\ x__ y__ -> x__{_FileOptions'_unknownFields = y__})
+instance Control.DeepSeq.NFData FileOptions where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_FileOptions'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_FileOptions'javaPackage x__)
+                   (Control.DeepSeq.deepseq (_FileOptions'javaOuterClassname x__)
+                      (Control.DeepSeq.deepseq (_FileOptions'javaMultipleFiles x__)
+                         (Control.DeepSeq.deepseq
+                            (_FileOptions'javaGenerateEqualsAndHash x__)
+                            (Control.DeepSeq.deepseq (_FileOptions'javaStringCheckUtf8 x__)
+                               (Control.DeepSeq.deepseq (_FileOptions'optimizeFor x__)
+                                  (Control.DeepSeq.deepseq (_FileOptions'goPackage x__)
+                                     (Control.DeepSeq.deepseq (_FileOptions'ccGenericServices x__)
+                                        (Control.DeepSeq.deepseq
+                                           (_FileOptions'javaGenericServices x__)
+                                           (Control.DeepSeq.deepseq
+                                              (_FileOptions'pyGenericServices x__)
+                                              (Control.DeepSeq.deepseq (_FileOptions'deprecated x__)
+                                                 (Control.DeepSeq.deepseq
+                                                    (_FileOptions'ccEnableArenas x__)
+                                                    (Control.DeepSeq.deepseq
+                                                       (_FileOptions'objcClassPrefix x__)
+                                                       (Control.DeepSeq.deepseq
+                                                          (_FileOptions'csharpNamespace x__)
+                                                          (Control.DeepSeq.deepseq
+                                                             (_FileOptions'uninterpretedOption x__)
+                                                             (()))))))))))))))))
 data FileOptions'OptimizeMode = FileOptions'SPEED
                               | FileOptions'CODE_SIZE
                               | FileOptions'LITE_RUNTIME
@@ -2737,6 +2896,8 @@ instance Prelude.Enum FileOptions'OptimizeMode where
 instance Prelude.Bounded FileOptions'OptimizeMode where
         minBound = FileOptions'SPEED
         maxBound = FileOptions'LITE_RUNTIME
+instance Control.DeepSeq.NFData FileOptions'OptimizeMode where
+        rnf x__ = Prelude.seq x__ (())
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.annotation' @:: Lens' GeneratedCodeInfo [GeneratedCodeInfo'Annotation]@
@@ -2780,6 +2941,11 @@ instance Data.ProtoLens.Message GeneratedCodeInfo where
         unknownFields
           = Lens.Family2.Unchecked.lens _GeneratedCodeInfo'_unknownFields
               (\ x__ y__ -> x__{_GeneratedCodeInfo'_unknownFields = y__})
+instance Control.DeepSeq.NFData GeneratedCodeInfo where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_GeneratedCodeInfo'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_GeneratedCodeInfo'annotation x__) (()))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.path' @:: Lens' GeneratedCodeInfo'Annotation [Data.Int.Int32]@
@@ -2932,6 +3098,17 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
               _GeneratedCodeInfo'Annotation'_unknownFields
               (\ x__ y__ ->
                  x__{_GeneratedCodeInfo'Annotation'_unknownFields = y__})
+instance Control.DeepSeq.NFData GeneratedCodeInfo'Annotation where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq
+                (_GeneratedCodeInfo'Annotation'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_GeneratedCodeInfo'Annotation'path x__)
+                   (Control.DeepSeq.deepseq
+                      (_GeneratedCodeInfo'Annotation'sourceFile x__)
+                      (Control.DeepSeq.deepseq (_GeneratedCodeInfo'Annotation'begin x__)
+                         (Control.DeepSeq.deepseq (_GeneratedCodeInfo'Annotation'end x__)
+                            (())))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.messageSetWireFormat' @:: Lens' MessageOptions Prelude.Bool@
@@ -3108,6 +3285,17 @@ instance Data.ProtoLens.Message MessageOptions where
         unknownFields
           = Lens.Family2.Unchecked.lens _MessageOptions'_unknownFields
               (\ x__ y__ -> x__{_MessageOptions'_unknownFields = y__})
+instance Control.DeepSeq.NFData MessageOptions where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_MessageOptions'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_MessageOptions'messageSetWireFormat x__)
+                   (Control.DeepSeq.deepseq
+                      (_MessageOptions'noStandardDescriptorAccessor x__)
+                      (Control.DeepSeq.deepseq (_MessageOptions'deprecated x__)
+                         (Control.DeepSeq.deepseq (_MessageOptions'mapEntry x__)
+                            (Control.DeepSeq.deepseq (_MessageOptions'uninterpretedOption x__)
+                               (()))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' MethodDescriptorProto Data.Text.Text@
@@ -3330,6 +3518,19 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
         unknownFields
           = Lens.Family2.Unchecked.lens _MethodDescriptorProto'_unknownFields
               (\ x__ y__ -> x__{_MethodDescriptorProto'_unknownFields = y__})
+instance Control.DeepSeq.NFData MethodDescriptorProto where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_MethodDescriptorProto'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_MethodDescriptorProto'name x__)
+                   (Control.DeepSeq.deepseq (_MethodDescriptorProto'inputType x__)
+                      (Control.DeepSeq.deepseq (_MethodDescriptorProto'outputType x__)
+                         (Control.DeepSeq.deepseq (_MethodDescriptorProto'options x__)
+                            (Control.DeepSeq.deepseq
+                               (_MethodDescriptorProto'clientStreaming x__)
+                               (Control.DeepSeq.deepseq
+                                  (_MethodDescriptorProto'serverStreaming x__)
+                                  (())))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' MethodOptions Prelude.Bool@
@@ -3403,6 +3604,13 @@ instance Data.ProtoLens.Message MethodOptions where
         unknownFields
           = Lens.Family2.Unchecked.lens _MethodOptions'_unknownFields
               (\ x__ y__ -> x__{_MethodOptions'_unknownFields = y__})
+instance Control.DeepSeq.NFData MethodOptions where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_MethodOptions'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_MethodOptions'deprecated x__)
+                   (Control.DeepSeq.deepseq (_MethodOptions'uninterpretedOption x__)
+                      (())))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' OneofDescriptorProto Data.Text.Text@
@@ -3458,6 +3666,11 @@ instance Data.ProtoLens.Message OneofDescriptorProto where
         unknownFields
           = Lens.Family2.Unchecked.lens _OneofDescriptorProto'_unknownFields
               (\ x__ y__ -> x__{_OneofDescriptorProto'_unknownFields = y__})
+instance Control.DeepSeq.NFData OneofDescriptorProto where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_OneofDescriptorProto'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_OneofDescriptorProto'name x__) (()))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' ServiceDescriptorProto Data.Text.Text@
@@ -3572,6 +3785,15 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
           = Lens.Family2.Unchecked.lens
               _ServiceDescriptorProto'_unknownFields
               (\ x__ y__ -> x__{_ServiceDescriptorProto'_unknownFields = y__})
+instance Control.DeepSeq.NFData ServiceDescriptorProto where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq
+                (_ServiceDescriptorProto'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_ServiceDescriptorProto'name x__)
+                   (Control.DeepSeq.deepseq (_ServiceDescriptorProto'method x__)
+                      (Control.DeepSeq.deepseq (_ServiceDescriptorProto'options x__)
+                         (()))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' ServiceOptions Prelude.Bool@
@@ -3645,6 +3867,13 @@ instance Data.ProtoLens.Message ServiceOptions where
         unknownFields
           = Lens.Family2.Unchecked.lens _ServiceOptions'_unknownFields
               (\ x__ y__ -> x__{_ServiceOptions'_unknownFields = y__})
+instance Control.DeepSeq.NFData ServiceOptions where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_ServiceOptions'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_ServiceOptions'deprecated x__)
+                   (Control.DeepSeq.deepseq (_ServiceOptions'uninterpretedOption x__)
+                      (())))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.location' @:: Lens' SourceCodeInfo [SourceCodeInfo'Location]@
@@ -3687,6 +3916,11 @@ instance Data.ProtoLens.Message SourceCodeInfo where
         unknownFields
           = Lens.Family2.Unchecked.lens _SourceCodeInfo'_unknownFields
               (\ x__ y__ -> x__{_SourceCodeInfo'_unknownFields = y__})
+instance Control.DeepSeq.NFData SourceCodeInfo where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_SourceCodeInfo'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_SourceCodeInfo'location x__) (()))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.path' @:: Lens' SourceCodeInfo'Location [Data.Int.Int32]@
@@ -3859,6 +4093,20 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
           = Lens.Family2.Unchecked.lens
               _SourceCodeInfo'Location'_unknownFields
               (\ x__ y__ -> x__{_SourceCodeInfo'Location'_unknownFields = y__})
+instance Control.DeepSeq.NFData SourceCodeInfo'Location where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq
+                (_SourceCodeInfo'Location'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_SourceCodeInfo'Location'path x__)
+                   (Control.DeepSeq.deepseq (_SourceCodeInfo'Location'span x__)
+                      (Control.DeepSeq.deepseq
+                         (_SourceCodeInfo'Location'leadingComments x__)
+                         (Control.DeepSeq.deepseq
+                            (_SourceCodeInfo'Location'trailingComments x__)
+                            (Control.DeepSeq.deepseq
+                               (_SourceCodeInfo'Location'leadingDetachedComments x__)
+                               (()))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' UninterpretedOption [UninterpretedOption'NamePart]@
@@ -4102,6 +4350,20 @@ instance Data.ProtoLens.Message UninterpretedOption where
         unknownFields
           = Lens.Family2.Unchecked.lens _UninterpretedOption'_unknownFields
               (\ x__ y__ -> x__{_UninterpretedOption'_unknownFields = y__})
+instance Control.DeepSeq.NFData UninterpretedOption where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq (_UninterpretedOption'_unknownFields x__)
+                (Control.DeepSeq.deepseq (_UninterpretedOption'name x__)
+                   (Control.DeepSeq.deepseq (_UninterpretedOption'identifierValue x__)
+                      (Control.DeepSeq.deepseq
+                         (_UninterpretedOption'positiveIntValue x__)
+                         (Control.DeepSeq.deepseq
+                            (_UninterpretedOption'negativeIntValue x__)
+                            (Control.DeepSeq.deepseq (_UninterpretedOption'doubleValue x__)
+                               (Control.DeepSeq.deepseq (_UninterpretedOption'stringValue x__)
+                                  (Control.DeepSeq.deepseq (_UninterpretedOption'aggregateValue x__)
+                                     (()))))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.namePart' @:: Lens' UninterpretedOption'NamePart Data.Text.Text@
@@ -4180,3 +4442,13 @@ instance Data.ProtoLens.Message UninterpretedOption'NamePart where
               _UninterpretedOption'NamePart'_unknownFields
               (\ x__ y__ ->
                  x__{_UninterpretedOption'NamePart'_unknownFields = y__})
+instance Control.DeepSeq.NFData UninterpretedOption'NamePart where
+        rnf
+          = \ x__ ->
+              Control.DeepSeq.deepseq
+                (_UninterpretedOption'NamePart'_unknownFields x__)
+                (Control.DeepSeq.deepseq
+                   (_UninterpretedOption'NamePart'namePart x__)
+                   (Control.DeepSeq.deepseq
+                      (_UninterpretedOption'NamePart'isExtension x__)
+                      (())))


### PR DESCRIPTION
This helps work around the lack of `Generic` instances (#167) and removes
orphan instances in the benchmarks.

The instances are manually generated for each type, rather than going
via the MessageDescriptor.  This is both for performance (e.g. the benchmarks
use them) and because the MessageDescriptor contains redundant fields (e.g. the
maybe and non-maybe variants of a field).

I examined a couple files for the output of `-ddump-simpl` from `-O` and found
the result was well-optimized, didn't have redundant `seq`s, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/207)
<!-- Reviewable:end -->
