### PR TITLE
Fix build of proto-lens-0.3.* on lts-12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ matrix:
     addons: {apt: {packages: [libgmp-dev]}}
   - env: BUILD=stack STACK='stack --resolver=lts-9.6'
     addons: {apt: {packages: [libgmp-dev]}}
-  - env: BUILD=stack STACK=stack # Use the resolver in stack.yaml
+  - env: BUILD=stack STACK=stack --resolver=11.22'
     addons: {apt: {packages: [libgmp-dev]}}
-  - env: BUILD=stack STACK='stack --resolver=nightly-2018-05-04'
+  - env: BUILD=stack STACK='stack'  # Use the resolver in stack.yaml
     addons: {apt: {packages: [libgmp-dev]}}
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,11 +56,14 @@ install:
 script:
   # Separate stack's build and test commands, since build by itself hits some
   # edge cases around custom Setup.hs script dependencies.
+  # Also build the tutorial, with proto-lens-* as extra-deps.  Note that
+  # since stack is not hermetic, the extra-deps for the tutorial reuse some
+  # build outputs from the regular build.
   - case "$BUILD" in
       stack)
         STACK_ARGS=(--haddock --no-haddock-deps --ghc-options="-Wall -Werror");
-        cd proto-lens-tutorial && $STACK build "${STACK_ARGS[@]}" && cd ..
-        $STACK build --bench --no-run-benchmarks "${STACK_ARGS[@]}" && $STACK test "${STACK_ARGS[@]}";;
+        $STACK build --bench --no-run-benchmarks "${STACK_ARGS[@]}" && $STACK test "${STACK_ARGS[@]}";
+        cd proto-lens-tutorial && $STACK build "${STACK_ARGS[@]}" && cd ..;;
       cabal)
         ./travis-cabal.sh;;
     esac

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-protoc`
 
+## v0.3.1.2
+- Bump the upper bound to `temporary-1.3`.
+
 ## v0.3.1.1
 - Fix management of generated files between Cabal components (#171).
 - Bump the lower bound on `base` to indicate we require `ghc>=8.0`.

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -2,6 +2,7 @@
 
 ## v0.3.1.2
 - Bump the upper bound to `temporary-1.3`.
+- Fix warnings.
 
 ## v0.3.1.1
 - Fix management of generated files between Cabal components (#171).

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -37,7 +37,7 @@ library:
     - lens-labels == 0.2.*
     - pretty == 1.1.*
     - process >= 1.2 && < 1.7
-    - temporary == 1.2.*
+    - temporary >= 1.2 && < 1.4
   exposed-modules:
     - Data.ProtoLens.Compiler.Combinators
     - Data.ProtoLens.Compiler.Definitions

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -7,6 +7,7 @@
 -- | This module takes care of collecting all the definitions in a .proto file
 -- and assigning Haskell names to all of the defined things (messages, enums
 -- and field names).
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -39,7 +40,9 @@ import Data.Int (Int32)
 import Data.List (mapAccumL)
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe)
-import Data.Monoid
+#if !MIN_VERSION_base(4,11,0)
+import Data.Monoid ((<>))
+#endif
 import qualified Data.Semigroup as Semigroup
 import qualified Data.Set as Set
 import Data.String (IsString(..))

--- a/proto-lens-tutorial/stack.yaml
+++ b/proto-lens-tutorial/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.7
+resolver: lts-12.7
 packages:
 - person
 - coffee-order

--- a/stack-bootstrap.yaml
+++ b/stack-bootstrap.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.21
+resolver: lts-12.7
 packages:
 - proto-lens-protoc
 # Build the current HEAD proto-lens-protoc against older revisions of proto-lens

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.7
+resolver: lts-12.7
 packages:
 - discrimination-ieee754
 - lens-labels


### PR DESCRIPTION
Also update `stack.yaml` to `lts-12.6` rather than a nightly.

The proto-lens-protoc-0.3.1.1 release had an upper bound
on `temporary` that was too restrictive.  Increase it,
and bump the version to `0.3.1.2`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/211)
<!-- Reviewable:end -->
