### PR TITLE
Remove an obsolete dependency on data-default-class.

### DIFF
--- a/proto-lens-runtime/Changelog.md
+++ b/proto-lens-runtime/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-runtime`
 
+## v0.4.0.1
+- Remove an obsolete dependency on `data-default-class`.
+
 ## v0.4.0.0
 - Split out from `proto-lens-protoc`.
 - Use simplified lens-labels instances. (#208)

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-runtime
-version: '0.4.0.0'
+version: '0.4.0.1'
 author: Judah Jacobson
 maintainer: proto-lens@googlegroups.com
 github: google/proto-lens/proto-lens-runtime
@@ -19,7 +19,6 @@ library:
     - base >= 4.9 && < 4.12
     - bytestring == 0.10.*
     - containers == 0.5.*
-    - data-default-class >= 0.0 && < 0.2
     - deepseq == 1.4.*
     - filepath >= 1.4 && < 1.6
     - lens-family == 1.2.*


### PR DESCRIPTION
It was missed in #210.

Also bump proto-lens-runtime to 0.4.0.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/222)
<!-- Reviewable:end -->
