### PR TITLE
Update the list of differences from the standard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,12 +108,9 @@ will generate the haskell files `Proto/Project/{Foo,Bar}.hs`.
 
 # Current differences from the standard
 
-- Services are not supported.
 - Extensions (proto2-only) are not supported.
 - Unknown proto2 enum values cause a decoding error, instead of being preserved
   round-trip.
-- Messages with proto3 syntax preserve unknown fields, the same as for proto2.
-  This behavior tracks a [recent change to the specification](google/protobuf#272).
 - Files with `import public` statements compile correctly, but don't explicitly
   reexport the definitions from those imports.
 


### PR DESCRIPTION
- Services are now supported.
- It's now part of the standard to preserve unknown values in proto3:
  https://developers.google.com/protocol-buffers/docs/proto3#unknowns

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/225)
<!-- Reviewable:end -->
