### PR TITLE
Change enum generation to prevent invalid names

### DIFF
--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -430,7 +430,9 @@ enumDef :: Text -> String -> EnumDescriptorProto
           -> (Text, Definition Name)
 enumDef protoPrefix hsPrefix d = let
     mkText n = protoPrefix <> n
-    mkHsName n = fromString $ hsPrefix ++ unpack n
+    mkHsName n = fromString $ hsPrefix ++ case unpack n of
+      ('_':xs) -> 'X':xs
+      xs       -> xs
     in (mkText (d ^. name)
        , Enum EnumInfo
             { enumName = mkHsName (d ^. name)

--- a/proto-lens-tests/tests/names.proto
+++ b/proto-lens-tests/tests/names.proto
@@ -90,6 +90,7 @@ message ABBREVName {}
 enum Odd_CAsed_enum {
   // TODO: deFA_ult = 0;
   DeFA_ult = 0;
+  _under_scored = 1;
 }
 
 // Messages whose name conflicts with a proto keyword.

--- a/proto-lens-tests/tests/names_test.hs
+++ b/proto-lens-tests/tests/names_test.hs
@@ -121,6 +121,7 @@ testOddCasedMessage = testGroup "oddCasedMessage"
     , testCase "enums" $ do
           trivial (Odd_CAsed_message'DeFA_ult :: Odd_CAsed_message'odd_CAsed_enum)
           trivial (DeFA_ult :: Odd_CAsed_enum)
+          trivial (Xunder_scored :: Odd_CAsed_enum)
     ]
   where
     defMsg = defMessage :: Odd_CAsed_message


### PR DESCRIPTION
An attempt to fix https://github.com/google/proto-lens/issues/199

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/238)
<!-- Reviewable:end -->
