### PR TITLE
Set -Wall -Werror in stack.yaml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ before_install:
   - rm protoc-release.zip
 
 install:
-  # Don't use '-Wall -Werror' to build the snapshot packages.
   - case "$BUILD" in
       stack)
         $STACK setup --no-terminal;
@@ -61,7 +60,7 @@ script:
   # build outputs from the regular build.
   - case "$BUILD" in
       stack)
-        STACK_ARGS=(--haddock --no-haddock-deps --ghc-options="-Wall -Werror");
+        STACK_ARGS=(--haddock --no-haddock-deps);
         $STACK build --bench --no-run-benchmarks "${STACK_ARGS[@]}" && $STACK test "${STACK_ARGS[@]}" &&
         (cd proto-lens-tutorial && $STACK build "${STACK_ARGS[@]}");;
       cabal)

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,3 +17,6 @@ packages:
 extra-deps:
 - discrimination-0.3
 - promises-0.3
+
+ghc-options:
+  "$locals": -Wall -Werror


### PR DESCRIPTION
This makes local `stack build` fail if there's a warning.  Previously,
it only failed when run in CI.  (The current version of Stack handles
`ghc-options` much better than when we first set up this project's config.)

(This does not affect the behavior of the Hackage releases.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/240)
<!-- Reviewable:end -->
