### PR TITLE
Update version and changelog for proto-lens-runtime.

### DIFF
--- a/proto-lens-runtime/Changelog.md
+++ b/proto-lens-runtime/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-runtime`
 
+## v0.4.0.2
+- Bump the dependencies on `base` and `containers` to support `ghc-8.6.1.
+
 ## v0.4.0.1
 - Remove an obsolete dependency on `data-default-class`.
 

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-runtime
-version: '0.4.0.1'
+version: '0.4.0.2'
 author: Judah Jacobson
 maintainer: proto-lens@googlegroups.com
 github: google/proto-lens/proto-lens-runtime


### PR DESCRIPTION
It was already at 0.4.0.1, so it bumps to 0.4.0.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/245)
<!-- Reviewable:end -->
