### PR TITLE
Fix a bug in shrinkMessage for maps.

### DIFF
--- a/proto-lens-tests/src/Data/ProtoLens/TestUtil.hs
+++ b/proto-lens-tests/src/Data/ProtoLens/TestUtil.hs
@@ -3,7 +3,7 @@
 -- Use of this source code is governed by a BSD-style
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
-
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Data.ProtoLens.TestUtil(
     testMain,
@@ -41,7 +41,10 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as L
 import qualified Data.Text.Lazy as LT
-import Test.QuickCheck (noShrinking, withMaxSuccess)
+import Test.QuickCheck (noShrinking)
+#if MIN_VERSION_QuickCheck(2,10,0)
+import Test.QuickCheck (withMaxSuccess)
+#endif
 import Test.Framework (defaultMain, testGroup)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.API (Test)
@@ -120,8 +123,10 @@ roundTripTest name = TypedTest $ testGroup name
             -- Disable automatic shrinking so the test behaves
             -- sensibly if there's a bug in shrinkMessage.
             noShrinking $
+#if MIN_VERSION_QuickCheck(2,10,0)
             -- Limit the number of tests since shrinking is slow for large messages.
             withMaxSuccess 20
+#endif
                 (shrinkSanityProperty :: MessageProperty a)
     , testProperty "wire" (wireRoundTripProperty :: MessageProperty a)
     , testProperty "text" (textRoundTripProperty :: MessageProperty a)


### PR DESCRIPTION
Before, shrinkMessage on a map with default key or value could return the
input unchanged, causing QuickCheck to loop forever.

In map.proto:
```
syntax = "proto2";
message Foo {
  map<int32, string> bar = 1;
}
```

Shrinking a message can return itself:
```
> mapM_ print $ shrinkMessage (defMessage & bar .~ fromList [(0,"")]  :: Foo)
{}
{bar { key: 0 value: "" }}
{bar { key: 0 value: "" }}
```

After this change, such values are filtered out:
```
mapM_ print $ shrinkMessage (defMessage & bar .~ fromList [(0,"")]  :: Foo)
{}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/252)
<!-- Reviewable:end -->
