### PR TITLE
Bump the upper bound on QuickCheck.

### DIFF
--- a/proto-lens-arbitrary/Changelog.md
+++ b/proto-lens-arbitrary/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-arbitrary`
 
+## v0.1.2.5
+- Bump the dependency for `QuickCheck-2.12`.
+
 ## v0.1.2.4
 - Bump the dependencies on `base` and `containers` to support `ghc-8.6.1`.
 

--- a/proto-lens-arbitrary/package.yaml
+++ b/proto-lens-arbitrary/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-arbitrary
-version: "0.1.2.4"
+version: "0.1.2.5"
 synopsis: Arbitrary instances for proto-lens.
 description: >
   The proto-lens-arbitrary allows generating arbitrary messages for
@@ -20,7 +20,7 @@ dependencies:
   - containers >= 0.5 && < 0.7
   - text == 1.2.*
   - lens-family == 1.2.*
-  - QuickCheck >= 2.8 && < 2.12
+  - QuickCheck >= 2.8 && < 2.13
 
 library:
   source-dirs: src


### PR DESCRIPTION
Verified by editing stack.yaml with:
```
extra-deps:
...
- QuickCheck-2.12.6.1
- test-framework-quickcheck2-0.3.0.5
allow-newer: True
```

This will let proto-lens-arbitrary stay in Stackage nightly when
QuickCheck gets bumped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/253)
<!-- Reviewable:end -->
