### PR TITLE
Consistently capitalize type names.

### DIFF
--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-protoc`
 
+## Unreleased
+- Capitalize enum values, and capitalize names of enum sub-messages (#270).
+
 ## v0.4.0.1
 - Bump the dependency on `base` and `containers` to support `ghc-8.6.1`.
 - Fix a GHC error on enums with a very large number of cases (#241).

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -430,7 +430,7 @@ enumDef :: Text -> String -> EnumDescriptorProto
           -> (Text, Definition Name)
 enumDef protoPrefix hsPrefix d = let
     mkText n = protoPrefix <> n
-    mkHsName n = fromString $ hsPrefix ++ case unpack n of
+    mkHsName n = fromString $ hsPrefix ++ case hsName n of
       ('_':xs) -> 'X':xs
       xs       -> xs
     in (mkText (d ^. name)

--- a/proto-lens-tests/tests/names.proto
+++ b/proto-lens-tests/tests/names.proto
@@ -81,7 +81,14 @@ message odd_CAsed_message {
   enum odd_CAsed_enum {
     // TODO: deFA_ult = 0;
     DeFA_ult = 0;
+    // For consistency, we munge the names of these cases, even
+    // though it's not necessary since they're nested types and thus
+    // values are prefixed like "Odd_CAsed_message'...".
+    _under_scored = 1;
+    lower_case = 2;
   }
+
+  message sub_message {}
 }
 
 message ABBREVName {}
@@ -91,6 +98,7 @@ enum Odd_CAsed_enum {
   // TODO: deFA_ult = 0;
   DeFA_ult = 0;
   _under_scored = 1;
+  lower_case = 2;
 }
 
 // Messages whose name conflicts with a proto keyword.

--- a/proto-lens-tests/tests/names_test.hs
+++ b/proto-lens-tests/tests/names_test.hs
@@ -119,9 +119,13 @@ testOddCasedMessage = testGroup "oddCasedMessage"
           verifyLens defMsg oneofCase 42
           verifyLens defMsg maybe'oneofCase (Just 42)
     , testCase "enums" $ do
-          trivial (Odd_CAsed_message'DeFA_ult :: Odd_CAsed_message'odd_CAsed_enum)
+          trivial (Odd_CAsed_message'DeFA_ult :: Odd_CAsed_message'Odd_CAsed_enum)
           trivial (DeFA_ult :: Odd_CAsed_enum)
+          trivial (Odd_CAsed_message'Xunder_scored :: Odd_CAsed_message'Odd_CAsed_enum)
           trivial (Xunder_scored :: Odd_CAsed_enum)
+          trivial (Odd_CAsed_message'Lower_case :: Odd_CAsed_message'Odd_CAsed_enum)
+          trivial (Lower_case :: Odd_CAsed_enum)
+    , testCase "submessage" $ trivial (defMessage :: Odd_CAsed_message'Sub_message)
     ]
   where
     defMsg = defMessage :: Odd_CAsed_message


### PR DESCRIPTION
This makes two changes:
1. Previously, we capitalized the names of messages and enums,
  but not enum values.  This makes enum values capitalized.
  (Fixes #152.)

2. Previously, we didn't capitalize sub-enums the same way we did
  submessages; e.g.:
  ```message Foo {
       message bar {}
       enum baz {}
  ```
  would be turned into `Foo'Bar` but `Foo'baz`.  This changes
  it to `Foo'Baz` for consistency.  (It does the same thing
  for values of sub-enums.)

For example, here are the generated Haskell names:

```
message superEnum {      // SuperEnum
   enumValue = 1;        // EnumValue
}
message super {          // Super
  message subMessage {}  // Super'SubMessage
  enum subEnum {         // Super'SubEnum
    enumValue = 1;       // Super'EnumValue
  }
};
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/270)
<!-- Reviewable:end -->
