### PR TITLE
Support haskell-src-exts-1.21.

### DIFF
--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -28,7 +28,7 @@ library:
   source-dirs: src
   dependencies:
     - filepath >= 1.4 && < 1.6
-    - haskell-src-exts >= 1.17 && < 1.21
+    - haskell-src-exts >= 1.17 && < 1.22
     - pretty == 1.1.*
   exposed-modules:
     - Data.ProtoLens.Compiler.Combinators

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
@@ -75,7 +75,9 @@ recDecl dataName fields
 type Decl = Syntax.Decl ()
 
 patSynSig :: Name -> Type -> Decl
-#if MIN_VERSION_haskell_src_exts(1,20,0)
+#if MIN_VERSION_haskell_src_exts(1,21,0)
+patSynSig n t = Syntax.PatSynSig () [n] Nothing Nothing Nothing Nothing t
+#elif MIN_VERSION_haskell_src_exts(1,20,0)
 patSynSig n t = Syntax.PatSynSig () [n] Nothing Nothing Nothing t
 #else
 patSynSig n t = Syntax.PatSynSig () n Nothing Nothing Nothing t


### PR DESCRIPTION
Bump the lower bound to support `haskell-src-exts-1.21.0`, adding a CPP
directive to work around an API change.  Tested manually by adding that package
to the Stack `extra-deps`.

Tested by adding `haskell-src-exts-1.21.0` to the `extra-deps` in `stack.yaml`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/271)
<!-- Reviewable:end -->
