### PR TITLE
Bump the lowest supported LTS to lts-8 (ghc-8.0.2).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,10 @@ cache:
 
 matrix:
   include:
-  - env: BUILD=cabal GHCVER=8.0.1 CABALVER=1.24
-    addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.1], sources: [hvr-ghc]}}
+  - env: BUILD=cabal GHCVER=8.0.2 CABALVER=1.24
+    addons: {apt: {packages: [cabal-install-1.24, ghc-8.0.2], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=8.2.1 CABALVER=2.0
     addons: {apt: {packages: [cabal-install-2.0, ghc-8.2.1], sources: [hvr-ghc]}}
-  - env: BUILD=stack STACK='stack --resolver=lts-7.4'
-    addons: {apt: {packages: [libgmp-dev]}}
   - env: BUILD=stack STACK='stack --resolver=lts-8.24'
     addons: {apt: {packages: [libgmp-dev]}}
   - env: BUILD=stack STACK='stack --resolver=lts-9.6'

--- a/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
+++ b/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
@@ -17,9 +17,7 @@ import qualified Data.ByteString as BS (length)
 import Data.Maybe (fromMaybe)
 import Data.ProtoLens
 import Options.Applicative
-#if MIN_VERSION_optparse_applicative(0,13,0)
-import Data.Monoid ((<>))
-#endif
+import Data.Semigroup ((<>))
 
 -- | Generate a group of benchmarks for encoding and decoding the given proto
 -- message. Includes benchmarks for decoding to both weak head normal form and

--- a/proto-lens-optparse/package.yaml
+++ b/proto-lens-optparse/package.yaml
@@ -17,7 +17,7 @@ extra-source-files:
 dependencies:
   - proto-lens >= 0.1 && < 0.5
   - base >= 4.9 && < 4.13
-  - optparse-applicative >= 0.12 && < 0.15
+  - optparse-applicative >= 0.13 && < 0.15
   - text == 1.2.*
 
 library:

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -28,7 +28,7 @@ library:
   source-dirs: src
   dependencies:
     - filepath >= 1.4 && < 1.6
-    - haskell-src-exts >= 1.17 && < 1.21
+    - haskell-src-exts >= 1.18 && < 1.21
     - pretty == 1.1.*
   exposed-modules:
     - Data.ProtoLens.Compiler.Combinators

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
@@ -26,29 +26,15 @@ module Data.ProtoLens.Compiler.Combinators
 
 import Data.Char (isAlphaNum, isUpper)
 import Data.String (IsString(..))
-#if MIN_VERSION_haskell_src_exts(1,18,0)
 import qualified Language.Haskell.Exts.Syntax as Syntax
 import qualified Language.Haskell.Exts.Pretty as Pretty
-#else
-import qualified Language.Haskell.Exts.Annotated.Syntax as Syntax
-import qualified Language.Haskell.Exts.Pretty as Pretty
-import Language.Haskell.Exts.SrcLoc (SrcLoc, noLoc)
-#endif
 import Text.PrettyPrint (($+$), (<+>), render, text, vcat, Doc)
 
-#if MIN_VERSION_haskell_src_exts(1,18,0)
 prettyPrint :: Pretty.Pretty a => a -> String
 prettyPrint = Pretty.prettyPrint
 
 prettyPrim :: Pretty.Pretty a => a -> Doc
 prettyPrim = Pretty.prettyPrim
-#else
-prettyPrint :: (Functor m, Pretty.Pretty (m SrcLoc)) => m () -> String
-prettyPrint = Pretty.prettyPrint . fmap (const noLoc)
-
-prettyPrim :: (Functor m, Pretty.Pretty (m SrcLoc)) => m () -> Doc
-prettyPrim = Pretty.prettyPrim . fmap (const noLoc)
-#endif
 
 type Asst = Syntax.Asst ()
 
@@ -260,21 +246,13 @@ exportVar :: QName -> ExportSpec
 exportVar = Syntax.EVar ()
 
 exportAll :: QName -> ExportSpec
-#if MIN_VERSION_haskell_src_exts(1,18,0)
 exportAll q = Syntax.EThingWith () (Syntax.EWildcard () 0) q []
-#else
-exportAll = Syntax.EThingAll ()
-#endif
 
 exportWith :: QName -> [Name] -> ExportSpec
-#if MIN_VERSION_haskell_src_exts(1,18,0)
 exportWith q = Syntax.EThingWith ()
                     (Syntax.NoWildcard ())
                     q
                     . map (Syntax.ConName ())
-#else
-exportWith q = Syntax.EThingWith () q . map (Syntax.ConName ())
-#endif
 
 type Name = Syntax.Name ()
 
@@ -331,11 +309,7 @@ tyForAll vars ctx t = Syntax.TyForall () (Just vars)
                             t
 
 tyBang :: Type -> Type
-#if MIN_VERSION_haskell_src_exts(1,18,0)
 tyBang = Syntax.TyBang () (Syntax.BangedTy ()) (Syntax.NoUnpackPragma ())
-#else
-tyBang = Syntax.TyBang () (Syntax.BangedTy ())
-#endif
 
 -- | Application of a Haskell type or expression to an argument.
 -- For example, to represent @f x y@, you can write


### PR DESCRIPTION
Lets us remove support for lts-8 (ghc-8.0.1), including some
CPP directives for older haskell-src-exts and optparse-applicative.

For bookkeeping I increased the lower bound on optparse-applicative
in proto-lens-optparse, even though technically we didn't lose
support for older versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/272)
<!-- Reviewable:end -->
