### PR TITLE
Expose Data.ProtoLens.Encoding.Bytes.

### DIFF
--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -19,7 +19,8 @@ import Data.ProtoLens (defMessage)
 -- so that we can run the test suite against the Generated API.
 -- TODO: switch back to Data.ProtoLens.Encoding once the Generated encoding is
 -- good enough.
-import Data.ProtoLens.Encoding.Reflected (decodeMessage, encodeMessage)
+import Data.ProtoLens.Encoding.Bytes (runParser, runBuilder)
+import Data.ProtoLens.Encoding.Reflected (parseMessage, buildMessage)
 import Lens.Family2
 import Proto.Google.Protobuf.Compiler.Plugin
     ( CodeGeneratorRequest
@@ -50,9 +51,9 @@ main :: IO ()
 main = do
     contents <- B.getContents
     progName <- getProgName
-    case decodeMessage contents of
+    case runParser parseMessage contents of
         Left e -> IO.hPutStrLn stderr e >> exitWith (ExitFailure 1)
-        Right x -> B.putStr $ encodeMessage $ makeResponse progName x
+        Right x -> B.putStr $ runBuilder $ buildMessage $ makeResponse progName x
 
 makeResponse :: String -> CodeGeneratorRequest -> CodeGeneratorResponse
 makeResponse prog request = let

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -42,6 +42,7 @@ library:
     - Data.ProtoLens.Combinators
     - Data.ProtoLens.Default
     - Data.ProtoLens.Encoding
+    - Data.ProtoLens.Encoding.Bytes
     - Data.ProtoLens.Encoding.Wire
     - Data.ProtoLens.Message
     - Data.ProtoLens.Message.Enum
@@ -63,7 +64,6 @@ library:
         cpp-options: -DGENERATED_ENCODING=0
 
   other-modules:
-    - Data.ProtoLens.Encoding.Bytes
     - Data.ProtoLens.TextFormat.Parser
     - Data.ProtoLens.Encoding.Reflected.Wire
   dependencies:

--- a/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
@@ -10,13 +10,21 @@
 
 -- | Utility functions for parsing and encoding individual types.
 module Data.ProtoLens.Encoding.Bytes(
+    -- * Running encodings
+    Parser,
+    Builder,
+    runParser,
+    runBuilder,
+    -- * Integral types
     getVarInt,
     putVarInt,
     anyBits,
+    -- * Floating-point types
     wordToFloat,
     wordToDouble,
     floatToWord,
     doubleToWord,
+    -- * Signed types
     signedInt32ToWord,
     wordToSignedInt32,
     signedInt64ToWord,
@@ -25,7 +33,9 @@ module Data.ProtoLens.Encoding.Bytes(
 
 import Data.Attoparsec.ByteString as Parse
 import Data.Bits
+import Data.ByteString (ByteString)
 import Data.ByteString.Lazy.Builder as Builder
+import qualified Data.ByteString.Lazy as L
 import Data.Int (Int32, Int64)
 import Data.Monoid ((<>))
 import Data.Word (Word32, Word64)
@@ -33,6 +43,12 @@ import Foreign.Ptr (castPtr)
 import Foreign.Marshal.Alloc (alloca)
 import Foreign.Storable (Storable, peek, poke)
 import System.IO.Unsafe (unsafePerformIO)
+
+runParser :: Parser a -> ByteString -> Either String a
+runParser = Parse.parseOnly
+
+runBuilder :: Builder -> ByteString
+runBuilder = L.toStrict . Builder.toLazyByteString
 
 -- VarInts are inherently unsigned; there are different ways of encoding
 -- negative numbers for int32/64 and sint32/64.


### PR DESCRIPTION
It'll be used by the generated encodings.

Also add `runParser` and `runBuilder` functions, and use them
to simplify `Data.ProtoLens.Encoding.Reflected` a little.