### PR TITLE
 Benchmark the reflected and generated encodings against each other.

### DIFF
--- a/proto-lens-benchmarks/benchmarks/IntPacking.hs
+++ b/proto-lens-benchmarks/benchmarks/IntPacking.hs
@@ -27,8 +27,11 @@ populatePacked n k = defMessage & num .~ replicate n k
 
 benchmaker :: Int -> [Benchmark]
 benchmaker size =
-    [ protoBenchmark "int32-unpacked" (populateUnpacked size 5 :: FooUnpacked)
-    , protoBenchmark "int32-packed" (populatePacked size 5 :: FooPacked)
+    -- Run the packing benchmark first; criterion graphs look better
+    -- (less likely for the legend to overlap results) if smaller results
+    -- are first.
+    [ protoBenchmark "int32-packed" (populatePacked size 5 :: FooPacked)
+    , protoBenchmark "int32-unpacked" (populateUnpacked size 5 :: FooUnpacked)
     ]
 
 main :: IO ()

--- a/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
+++ b/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
@@ -22,7 +22,7 @@ import Data.ProtoLens.Message
     , unfinishedParseMessage
     )
 import Data.ProtoLens.Encoding.Bytes (runBuilder, runParser)
-import Options.Applicative
+import qualified Options.Applicative as Options
 import Data.Semigroup ((<>))
 
 -- | Generate a group of benchmarks for encoding and decoding the given proto
@@ -88,15 +88,18 @@ benchmarkMain
     -- ^ Function to generate a set of benchmarks from a provided 'size'.
     -> IO ()
 benchmarkMain defaultSize benchmaker = do
-    (maybeSize, criterionMode) <- execParser $ info (helper <*> options) mempty
+    (maybeSize, criterionMode)
+        <- Options.execParser $ Options.info (Options.helper <*> options) mempty
     runMode criterionMode $ benchmaker (fromMaybe defaultSize maybeSize)
 
-options :: Parser (Maybe Int, Criterion.Mode)
+options :: Options.Parser (Maybe Int, Criterion.Mode)
 options =
     (,) <$>
-    optional
-        (option
-             auto
-             (help "Benchmark data size" <> metavar "N" <> short 's' <>
-              long "size")) <*>
+    Options.optional
+        (Options.option
+             Options.auto
+             (Options.help "Benchmark data size" <>
+                Options.metavar "N" <>
+                Options.short 's' <>
+                Options.long "size")) <*>
     Criterion.parseWith Criterion.defaultConfig

--- a/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
+++ b/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
@@ -13,9 +13,15 @@ module Data.ProtoLens.BenchmarkUtil (protoBenchmark, benchmarkMain) where
 import Control.DeepSeq (NFData)
 import Criterion.Main
 import qualified Criterion.Main.Options as Criterion
-import qualified Data.ByteString as BS (length)
+import qualified Data.ByteString as BS
 import Data.Maybe (fromMaybe)
-import Data.ProtoLens
+import qualified Data.ProtoLens.Encoding.Reflected as Reflected
+import Data.ProtoLens.Message
+    ( Message
+    , unfinishedBuildMessage
+    , unfinishedParseMessage
+    )
+import Data.ProtoLens.Encoding.Bytes (runBuilder, runParser)
 import Options.Applicative
 import Data.Semigroup ((<>))
 
@@ -33,24 +39,35 @@ protoBenchmark
     -- ^ Protocol buffer message to encode/decode.
     -> Benchmark
 protoBenchmark groupName proto =
-    bgroup
-        fullGroupName
-        [ bench "encode" $ nf encodeMessage proto
-        , bgroup
-              "decode"
-              [ bench "whnf" $ whnf decodeMessageOrDie' encodedProto
-              , bench "nf" $ nf decodeMessageOrDie' encodedProto
-              ]
+    bgroup fullGroupName
+        [ bgroup "encode"
+            [ bench "reflected" $ whnf (runBuilder . Reflected.buildMessage) proto
+            , bench "generated" $ whnf (runBuilder . unfinishedBuildMessage) proto
+            ]
+        , bgroup "decode"
+            [ bgroup "whnf"
+                [ bench "reflected" $ whnf reflectedDecodeMessageOrDie encodedProto
+                , bench "generated" $ whnf generatedDecodeMessageOrDie encodedProto
+                ]
+            , bgroup "nf"
+                [ bench "reflected" $ nf reflectedDecodeMessageOrDie encodedProto
+                , bench "generated" $ nf generatedDecodeMessageOrDie encodedProto
+                ]
+            ]
         ]
   where
     -- We must indicate to the compiler that we want to decode to the same
     -- message type as the input proto.
-    -- We use decodeMessageOrDie here (instead of decodeMessage) so that if
-    -- a bug is introduced that causes decoding to fail, the benchmark will
-    -- fail with an error, instead of silently reporting a misleading value
-    -- (the amount of time required to determine that proto decoding failed).
-    decodeMessageOrDie' bytes = (decodeMessageOrDie bytes :: a)
-    encodedProto = encodeMessage proto
+    -- We use `either error id` here so that if a bug is introduced that
+    -- causes decoding to fail, the benchmark will fail with an error, instead of
+    -- silently reporting a misleading value (the amount of time required to
+    -- determine that proto decoding failed).
+    reflectedDecodeMessageOrDie, generatedDecodeMessageOrDie :: BS.ByteString -> a
+    reflectedDecodeMessageOrDie =
+        either error id . runParser Reflected.parseMessage
+    generatedDecodeMessageOrDie =
+        either error id . runParser unfinishedParseMessage
+    encodedProto = runBuilder $ Reflected.buildMessage proto
     fullGroupName =
         groupName ++ "(" ++ prettySize (BS.length encodedProto) ++ ")"
 


### PR DESCRIPTION
Also rearrange the int-packing benchmark so the bar graph looks a little
better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/274)
<!-- Reviewable:end -->
