### PR TITLE
Move more code and types into Data.ProtoLens.Encoding.Bytes.

### DIFF
--- a/proto-lens/src/Data/ProtoLens/Encoding/Reflected.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Reflected.hs
@@ -29,7 +29,7 @@ import Data.ProtoLens.Encoding.Reflected.Wire
 
 import Control.Applicative ((<|>))
 import Control.Monad (guard)
-import Data.Attoparsec.ByteString as Parse
+import Data.Attoparsec.ByteString ((<?>))
 import Data.Bool (bool)
 import Data.Proxy (Proxy(Proxy))
 import Data.Text.Encoding (encodeUtf8, decodeUtf8')
@@ -46,7 +46,7 @@ parseMessage = parseMessageToEnd endOfInput
 -- | Parse a message with the given ending delimiter (which will be EndGroup in
 -- the case of a group, and end-of-input otherwise).
 parseMessageToEnd :: forall msg . Message msg => Parser () -> Parser msg
-parseMessageToEnd end = (Parse.<?> T.unpack (messageName (Proxy @msg))) $ do
+parseMessageToEnd end = (<?> T.unpack (messageName (Proxy @msg))) $ do
     (msg, unsetFields) <- loop defMessage requiredFields
     if Map.null unsetFields
         then return $ over unknownFields reverse
@@ -103,7 +103,7 @@ parseAndAddField
                           wv <- getWireValue fieldWt
                           x <- runEither $ get wv
                           return $! x
-                runEither $ parseOnly (manyReversedTill getElt endOfInput) val
+                runEither $ runParser (manyReversedTill getElt endOfInput) val
           in case accessor of
               PlainField _ f -> do
                   !x <- getSimpleVal

--- a/proto-lens/src/Data/ProtoLens/Message.hs
+++ b/proto-lens/src/Data/ProtoLens/Message.hs
@@ -61,9 +61,8 @@ import Data.Word
 import Lens.Family2 (Lens', over, set)
 import Lens.Family2.Unchecked (lens)
 import qualified Data.Semigroup as Semigroup
-import Data.Attoparsec.ByteString (Parser)
-import Data.ByteString.Builder (Builder)
 
+import Data.ProtoLens.Encoding.Bytes (Builder, Parser)
 import Data.ProtoLens.Encoding.Wire
     ( Tag(..)
     , TaggedValue(..)


### PR DESCRIPTION
This will make it easier to replace the parser with something else,
especially as we work on generated encodings.  See also #62.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/276)
<!-- Reviewable:end -->
