### PR TITLE
Make specialized parsers for `Word32` and `Word64`.

### DIFF
--- a/proto-lens/src/Data/ProtoLens/Encoding/Reflected/Wire.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Reflected/Wire.hs
@@ -113,8 +113,8 @@ instance Ord WireValue where
 
 getWireValue :: WireType a -> Parser a
 getWireValue VarInt = getVarInt
-getWireValue Fixed64 = anyBits
-getWireValue Fixed32 = anyBits
+getWireValue Fixed64 = getFixed64
+getWireValue Fixed32 = getFixed32
 getWireValue Lengthy = getVarInt >>= getBytes . fromIntegral
 getWireValue StartGroup = return ()
 getWireValue EndGroup = return ()


### PR DESCRIPTION
Previously they were implemented by a loop that didn't optimize well.

This speeds up the benchmark from #277 (decoding repeated floats, reflected)
by a factor of 2.6x.  Specifically, the `float-packed/decode` and `float-unpacked/decode` benchmarks dropped from ~225us to ~85us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/278)
<!-- Reviewable:end -->
