### PR TITLE
Bump the cache save timeout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: c
 sudo: true
 
 cache:
+  timeout: 600 # 10 minutes
   directories:
   - $HOME/.ghc
   - $HOME/.stack


### PR DESCRIPTION
Previously one of the runs was failing to save its cache at the end; for
example:
https://travis-ci.org/google/proto-lens/jobs/468129199
with the error:
```
running `casher push` took longer than 180 seconds and has been aborted.
You can extend the timeout with `cache.timeout`. See https://docs.travis-ci.com/user/caching/#Setting-the-timeout for details
```

The default limit is 3 minutes.  When I increased the limit, I saw the cache
save took 214 seconds.  This change bumps the limit to 10 minutes to be safe
in case of, e.g., network load.