### PR TITLE
Include message/field names in generated error messages.

### DIFF
--- a/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
@@ -36,8 +36,10 @@ module Data.ProtoLens.Encoding.Bytes(
     wordToSignedInt32,
     signedInt64ToWord,
     wordToSignedInt64,
+    -- * Other utilities
     atEnd,
     runEither,
+    (<?>),
     ) where
 
 import Data.Attoparsec.ByteString as Parse


### PR DESCRIPTION
Tracks behavior that's already done in the reflected parser (#187).

The benchmarks run about 5% slower after this change.  Given our other
known performance issues (e.g., use of Attoparsec itself, better handling
of packed fields) I think this is a reasonable tradeoff and can be revisited
later if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/289)
<!-- Reviewable:end -->
