### PR TITLE
Rerun bootstrapping, and use a consistent encoding method in proto-le…

### DIFF
--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -14,13 +14,11 @@ import Data.Monoid ((<>))
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import Data.Text (Text, pack)
-import Data.ProtoLens (defMessage)
+import Data.ProtoLens (defMessage, decodeMessage, encodeMessage)
 -- Force the use of the Reflected API when decoding DescriptorProto
 -- so that we can run the test suite against the Generated API.
 -- TODO: switch back to Data.ProtoLens.Encoding once the Generated encoding is
 -- good enough.
-import Data.ProtoLens.Encoding.Bytes (runParser, runBuilder)
-import Data.ProtoLens.Encoding.Reflected (parseMessage, buildMessage)
 import Lens.Family2
 import Proto.Google.Protobuf.Compiler.Plugin
     ( CodeGeneratorRequest
@@ -51,9 +49,9 @@ main :: IO ()
 main = do
     contents <- B.getContents
     progName <- getProgName
-    case runParser parseMessage contents of
+    case decodeMessage contents of
         Left e -> IO.hPutStrLn stderr e >> exitWith (ExitFailure 1)
-        Right x -> B.putStr $ runBuilder $ buildMessage $ makeResponse progName x
+        Right x -> B.putStr $ encodeMessage $ makeResponse progName x
 
 makeResponse :: String -> CodeGeneratorRequest -> CodeGeneratorResponse
 makeResponse prog request = let

--- a/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies,
   UndecidableInstances, GeneralizedNewtypeDeriving,
   MultiParamTypeClasses, FlexibleContexts, FlexibleInstances,
-  PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds #-}
+  PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds,
+  BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports#-}
 {-# OPTIONS_GHC -fno-warn-duplicate-exports#-}
 module Proto.Google.Protobuf.Compiler.Plugin
@@ -16,6 +17,8 @@ import qualified Data.Int
 import qualified Data.Monoid
 import qualified Data.Word
 import qualified Data.ProtoLens
+import qualified Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Encoding.Wire
 import qualified Data.ProtoLens.Message.Enum
 import qualified Data.ProtoLens.Service.Types
 import qualified Lens.Family2
@@ -24,6 +27,7 @@ import qualified Data.Text
 import qualified Data.Map
 import qualified Data.ByteString
 import qualified Data.ByteString.Char8
+import qualified Data.Text.Encoding
 import qualified Lens.Labels
 import qualified Text.Read
 import qualified Proto.Google.Protobuf.Descriptor
@@ -58,51 +62,47 @@ instance a ~ ([Data.Text.Text]) =>
          Lens.Labels.HasLens' CodeGeneratorRequest "fileToGenerate" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'fileToGenerate
-                 (\ x__ y__ -> x__{_CodeGeneratorRequest'fileToGenerate = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'fileToGenerate
+               (\ x__ y__ -> x__{_CodeGeneratorRequest'fileToGenerate = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' CodeGeneratorRequest "parameter" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'parameter
-                 (\ x__ y__ -> x__{_CodeGeneratorRequest'parameter = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'parameter
+               (\ x__ y__ -> x__{_CodeGeneratorRequest'parameter = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' CodeGeneratorRequest "maybe'parameter" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'parameter
-                 (\ x__ y__ -> x__{_CodeGeneratorRequest'parameter = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'parameter
+               (\ x__ y__ -> x__{_CodeGeneratorRequest'parameter = y__}))
+              Prelude.. Prelude.id
 instance a ~
            ([Proto.Google.Protobuf.Descriptor.FileDescriptorProto]) =>
          Lens.Labels.HasLens' CodeGeneratorRequest "protoFile" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'protoFile
-                 (\ x__ y__ -> x__{_CodeGeneratorRequest'protoFile = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'protoFile
+               (\ x__ y__ -> x__{_CodeGeneratorRequest'protoFile = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Version) =>
          Lens.Labels.HasLens' CodeGeneratorRequest "compilerVersion" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'compilerVersion
-                 (\ x__ y__ -> x__{_CodeGeneratorRequest'compilerVersion = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+          = (Lens.Family2.Unchecked.lens
+               _CodeGeneratorRequest'compilerVersion
+               (\ x__ y__ -> x__{_CodeGeneratorRequest'compilerVersion = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.defMessage
 instance a ~ (Prelude.Maybe Version) =>
          Lens.Labels.HasLens' CodeGeneratorRequest "maybe'compilerVersion" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'compilerVersion
-                 (\ x__ y__ -> x__{_CodeGeneratorRequest'compilerVersion = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _CodeGeneratorRequest'compilerVersion
+               (\ x__ y__ -> x__{_CodeGeneratorRequest'compilerVersion = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message CodeGeneratorRequest where
         messageName _
           = Data.Text.pack "google.protobuf.compiler.CodeGeneratorRequest"
@@ -156,18 +156,178 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                                  _CodeGeneratorRequest'protoFile = [],
                                  _CodeGeneratorRequest'compilerVersion = Prelude.Nothing,
                                  _CodeGeneratorRequest'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     CodeGeneratorRequest ->
+                       Data.ProtoLens.Encoding.Bytes.Parser CodeGeneratorRequest
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "fileToGenerate"))
+                                 (\ !t -> Prelude.reverse t)
+                                 (Lens.Family2.over
+                                    (Lens.Labels.lensOf'
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "protoFile"))
+                                    (\ !t -> Prelude.reverse t)
+                                    x)))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "fileToGenerate"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                18 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "parameter"))
+                                              y
+                                              x)
+                                122 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                               Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                 (Prelude.fromIntegral len)
+                                                   Data.ProtoLens.Encoding.Bytes.runEither
+                                                     (Data.ProtoLens.Encoding.Bytes.runParser
+                                                        Data.ProtoLens.unfinishedParseMessage
+                                                        value)
+                                          loop
+                                            (Lens.Family2.over
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "protoFile"))
+                                               (\ !t -> (:) y t)
+                                               x)
+                                26 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (Data.ProtoLens.Encoding.Bytes.runParser
+                                                      Data.ProtoLens.unfinishedParseMessage
+                                                      value)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "compilerVersion"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (Data.Monoid.mconcat
+                  (Prelude.map
+                     (\ _v ->
+                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude.. Data.Text.Encoding.encodeUtf8)
+                            _v)
+                     (Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "fileToGenerate"))
+                        _x)))
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'parameter"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                                           Data.Monoid.<>
+                                           (((\ bs ->
+                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                   (Prelude.fromIntegral
+                                                      (Data.ByteString.length bs)))
+                                                  Data.Monoid.<>
+                                                  Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                              Prelude.. Data.Text.Encoding.encodeUtf8)
+                                             _v)
+                   Data.Monoid.<>
+                   (Data.Monoid.mconcat
+                      (Prelude.map
+                         (\ _v ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt 122) Data.Monoid.<>
+                              (((\ bs ->
+                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                 Prelude..
+                                 (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                   Data.ProtoLens.unfinishedBuildMessage)
+                                _v)
+                         (Lens.Family2.view
+                            (Lens.Labels.lensOf'
+                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "protoFile"))
+                            _x)))
+                     Data.Monoid.<>
+                     (case
+                        Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) ::
+                                (Lens.Labels.Proxy#) "maybe'compilerVersion"))
+                          _x
+                        of
+                          (Prelude.Nothing) -> Data.Monoid.mempty
+                          Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 26)
+                                               Data.Monoid.<>
+                                               (((\ bs ->
+                                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                       (Prelude.fromIntegral
+                                                          (Data.ByteString.length bs)))
+                                                      Data.Monoid.<>
+                                                      Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                  Prelude..
+                                                  (Data.ProtoLens.Encoding.Bytes.runBuilder)
+                                                    Prelude.. Data.ProtoLens.unfinishedBuildMessage)
+                                                 _v)
+                       Data.Monoid.<>
+                       Data.Monoid.mconcat
+                         (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                            (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData CodeGeneratorRequest where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_CodeGeneratorRequest'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_CodeGeneratorRequest'fileToGenerate x__)
-                   (Control.DeepSeq.deepseq (_CodeGeneratorRequest'parameter x__)
-                      (Control.DeepSeq.deepseq (_CodeGeneratorRequest'protoFile x__)
-                         (Control.DeepSeq.deepseq
-                            (_CodeGeneratorRequest'compilerVersion x__)
-                            (())))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_CodeGeneratorRequest'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_CodeGeneratorRequest'fileToGenerate x__)
+                    (Control.DeepSeq.deepseq (_CodeGeneratorRequest'parameter x__)
+                       (Control.DeepSeq.deepseq (_CodeGeneratorRequest'protoFile x__)
+                          (Control.DeepSeq.deepseq
+                             (_CodeGeneratorRequest'compilerVersion x__)
+                             (()))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.error' @:: Lens' CodeGeneratorResponse Data.Text.Text@
@@ -190,26 +350,23 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' CodeGeneratorResponse "error" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'error
-                 (\ x__ y__ -> x__{_CodeGeneratorResponse'error = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'error
+               (\ x__ y__ -> x__{_CodeGeneratorResponse'error = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' CodeGeneratorResponse "maybe'error" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'error
-                 (\ x__ y__ -> x__{_CodeGeneratorResponse'error = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'error
+               (\ x__ y__ -> x__{_CodeGeneratorResponse'error = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([CodeGeneratorResponse'File]) =>
          Lens.Labels.HasLens' CodeGeneratorResponse "file" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'file
-                 (\ x__ y__ -> x__{_CodeGeneratorResponse'file = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'file
+               (\ x__ y__ -> x__{_CodeGeneratorResponse'file = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message CodeGeneratorResponse where
         messageName _
           = Data.Text.pack "google.protobuf.compiler.CodeGeneratorResponse"
@@ -242,14 +399,104 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
                                     Prelude.Nothing,
                                   _CodeGeneratorResponse'file = [],
                                   _CodeGeneratorResponse'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     CodeGeneratorResponse ->
+                       Data.ProtoLens.Encoding.Bytes.Parser CodeGeneratorResponse
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "file"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "error"))
+                                              y
+                                              x)
+                                122 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                               Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                 (Prelude.fromIntegral len)
+                                                   Data.ProtoLens.Encoding.Bytes.runEither
+                                                     (Data.ProtoLens.Encoding.Bytes.runParser
+                                                        Data.ProtoLens.unfinishedParseMessage
+                                                        value)
+                                          loop
+                                            (Lens.Family2.over
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "file"))
+                                               (\ !t -> (:) y t)
+                                               x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'error"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                                         Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
+                 Data.Monoid.<>
+                 (Data.Monoid.mconcat
+                    (Prelude.map
+                       (\ _v ->
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 122) Data.Monoid.<>
+                            (((\ bs ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                               Prelude..
+                               (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                 Data.ProtoLens.unfinishedBuildMessage)
+                              _v)
+                       (Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "file"))
+                          _x)))
+                   Data.Monoid.<>
+                   Data.Monoid.mconcat
+                     (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                        (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData CodeGeneratorResponse where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_CodeGeneratorResponse'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_CodeGeneratorResponse'error x__)
-                   (Control.DeepSeq.deepseq (_CodeGeneratorResponse'file x__) (())))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_CodeGeneratorResponse'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_CodeGeneratorResponse'error x__)
+                    (Control.DeepSeq.deepseq (_CodeGeneratorResponse'file x__) (()))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.name' @:: Lens' CodeGeneratorResponse'File Data.Text.Text@
@@ -277,56 +524,50 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' CodeGeneratorResponse'File "name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'name
-                 (\ x__ y__ -> x__{_CodeGeneratorResponse'File'name = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'name
+               (\ x__ y__ -> x__{_CodeGeneratorResponse'File'name = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' CodeGeneratorResponse'File "maybe'name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'name
-                 (\ x__ y__ -> x__{_CodeGeneratorResponse'File'name = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'name
+               (\ x__ y__ -> x__{_CodeGeneratorResponse'File'name = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' CodeGeneratorResponse'File "insertionPoint" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _CodeGeneratorResponse'File'insertionPoint
-                 (\ x__ y__ ->
-                    x__{_CodeGeneratorResponse'File'insertionPoint = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens
+               _CodeGeneratorResponse'File'insertionPoint
+               (\ x__ y__ ->
+                  x__{_CodeGeneratorResponse'File'insertionPoint = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' CodeGeneratorResponse'File
            "maybe'insertionPoint"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _CodeGeneratorResponse'File'insertionPoint
-                 (\ x__ y__ ->
-                    x__{_CodeGeneratorResponse'File'insertionPoint = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _CodeGeneratorResponse'File'insertionPoint
+               (\ x__ y__ ->
+                  x__{_CodeGeneratorResponse'File'insertionPoint = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' CodeGeneratorResponse'File "content" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'content
-                 (\ x__ y__ -> x__{_CodeGeneratorResponse'File'content = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'content
+               (\ x__ y__ -> x__{_CodeGeneratorResponse'File'content = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' CodeGeneratorResponse'File "maybe'content" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'content
-                 (\ x__ y__ -> x__{_CodeGeneratorResponse'File'content = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'File'content
+               (\ x__ y__ -> x__{_CodeGeneratorResponse'File'content = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message CodeGeneratorResponse'File where
         messageName _
           = Data.Text.pack
@@ -373,18 +614,140 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
                                        _CodeGeneratorResponse'File'insertionPoint = Prelude.Nothing,
                                        _CodeGeneratorResponse'File'content = Prelude.Nothing,
                                        _CodeGeneratorResponse'File'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     CodeGeneratorResponse'File ->
+                       Data.ProtoLens.Encoding.Bytes.Parser CodeGeneratorResponse'File
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              x)
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "name"))
+                                              y
+                                              x)
+                                18 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "insertionPoint"))
+                                              y
+                                              x)
+                                122 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "content"))
+                                               y
+                                               x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'name"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                                         Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) ::
+                            (Lens.Labels.Proxy#) "maybe'insertionPoint"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                                           Data.Monoid.<>
+                                           (((\ bs ->
+                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                   (Prelude.fromIntegral
+                                                      (Data.ByteString.length bs)))
+                                                  Data.Monoid.<>
+                                                  Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                              Prelude.. Data.Text.Encoding.encodeUtf8)
+                                             _v)
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'content"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 122)
+                                             Data.Monoid.<>
+                                             (((\ bs ->
+                                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                     (Prelude.fromIntegral
+                                                        (Data.ByteString.length bs)))
+                                                    Data.Monoid.<>
+                                                    Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                Prelude.. Data.Text.Encoding.encodeUtf8)
+                                               _v)
+                     Data.Monoid.<>
+                     Data.Monoid.mconcat
+                       (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                          (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData CodeGeneratorResponse'File where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq
-                (_CodeGeneratorResponse'File'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_CodeGeneratorResponse'File'name x__)
-                   (Control.DeepSeq.deepseq
-                      (_CodeGeneratorResponse'File'insertionPoint x__)
-                      (Control.DeepSeq.deepseq (_CodeGeneratorResponse'File'content x__)
-                         (()))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq
+                 (_CodeGeneratorResponse'File'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_CodeGeneratorResponse'File'name x__)
+                    (Control.DeepSeq.deepseq
+                       (_CodeGeneratorResponse'File'insertionPoint x__)
+                       (Control.DeepSeq.deepseq (_CodeGeneratorResponse'File'content x__)
+                          (())))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.major' @:: Lens' Version Data.Int.Int32@
@@ -412,66 +775,58 @@ instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' Version "major" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _Version'major
-                 (\ x__ y__ -> x__{_Version'major = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _Version'major
+               (\ x__ y__ -> x__{_Version'major = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' Version "maybe'major" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _Version'major
-                 (\ x__ y__ -> x__{_Version'major = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _Version'major
+               (\ x__ y__ -> x__{_Version'major = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' Version "minor" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _Version'minor
-                 (\ x__ y__ -> x__{_Version'minor = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _Version'minor
+               (\ x__ y__ -> x__{_Version'minor = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' Version "maybe'minor" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _Version'minor
-                 (\ x__ y__ -> x__{_Version'minor = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _Version'minor
+               (\ x__ y__ -> x__{_Version'minor = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' Version "patch" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _Version'patch
-                 (\ x__ y__ -> x__{_Version'patch = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _Version'patch
+               (\ x__ y__ -> x__{_Version'patch = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' Version "maybe'patch" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _Version'patch
-                 (\ x__ y__ -> x__{_Version'patch = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _Version'patch
+               (\ x__ y__ -> x__{_Version'patch = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' Version "suffix" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _Version'suffix
-                 (\ x__ y__ -> x__{_Version'suffix = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _Version'suffix
+               (\ x__ y__ -> x__{_Version'suffix = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' Version "maybe'suffix" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _Version'suffix
-                 (\ x__ y__ -> x__{_Version'suffix = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _Version'suffix
+               (\ x__ y__ -> x__{_Version'suffix = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message Version where
         messageName _ = Data.Text.pack "google.protobuf.compiler.Version"
         fieldsByTag
@@ -520,13 +875,134 @@ instance Data.ProtoLens.Message Version where
           = Version{_Version'major = Prelude.Nothing,
                     _Version'minor = Prelude.Nothing, _Version'patch = Prelude.Nothing,
                     _Version'suffix = Prelude.Nothing, _Version'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     Version -> Data.ProtoLens.Encoding.Bytes.Parser Version
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              x)
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                8 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                               Data.ProtoLens.Encoding.Bytes.getVarInt
+                                        loop
+                                          (Lens.Family2.set
+                                             (Lens.Labels.lensOf'
+                                                ((Lens.Labels.proxy#) ::
+                                                   (Lens.Labels.Proxy#) "major"))
+                                             y
+                                             x)
+                                16 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "minor"))
+                                              y
+                                              x)
+                                24 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "patch"))
+                                              y
+                                              x)
+                                34 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "suffix"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'major"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 8)
+                                         Data.Monoid.<>
+                                         ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                            Prelude.fromIntegral)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'minor"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 16)
+                                           Data.Monoid.<>
+                                           ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                              Prelude.fromIntegral)
+                                             _v)
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'patch"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 24)
+                                             Data.Monoid.<>
+                                             ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                Prelude.fromIntegral)
+                                               _v)
+                     Data.Monoid.<>
+                     (case
+                        Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'suffix"))
+                          _x
+                        of
+                          (Prelude.Nothing) -> Data.Monoid.mempty
+                          Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 34)
+                                               Data.Monoid.<>
+                                               (((\ bs ->
+                                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                       (Prelude.fromIntegral
+                                                          (Data.ByteString.length bs)))
+                                                      Data.Monoid.<>
+                                                      Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                  Prelude.. Data.Text.Encoding.encodeUtf8)
+                                                 _v)
+                       Data.Monoid.<>
+                       Data.Monoid.mconcat
+                         (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                            (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData Version where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_Version'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_Version'major x__)
-                   (Control.DeepSeq.deepseq (_Version'minor x__)
-                      (Control.DeepSeq.deepseq (_Version'patch x__)
-                         (Control.DeepSeq.deepseq (_Version'suffix x__) (())))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_Version'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_Version'major x__)
+                    (Control.DeepSeq.deepseq (_Version'minor x__)
+                       (Control.DeepSeq.deepseq (_Version'patch x__)
+                          (Control.DeepSeq.deepseq (_Version'suffix x__) (()))))))

--- a/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin_Fields.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin_Fields.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies,
   UndecidableInstances, GeneralizedNewtypeDeriving,
   MultiParamTypeClasses, FlexibleContexts, FlexibleInstances,
-  PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds #-}
+  PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds,
+  BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports#-}
 {-# OPTIONS_GHC -fno-warn-duplicate-exports#-}
 module Proto.Google.Protobuf.Compiler.Plugin_Fields where
@@ -11,6 +12,8 @@ import qualified Data.Int
 import qualified Data.Monoid
 import qualified Data.Word
 import qualified Data.ProtoLens
+import qualified Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Encoding.Wire
 import qualified Data.ProtoLens.Message.Enum
 import qualified Data.ProtoLens.Service.Types
 import qualified Lens.Family2
@@ -19,6 +22,7 @@ import qualified Data.Text
 import qualified Data.Map
 import qualified Data.ByteString
 import qualified Data.ByteString.Char8
+import qualified Data.Text.Encoding
 import qualified Lens.Labels
 import qualified Text.Read
 import qualified Proto.Google.Protobuf.Descriptor

--- a/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies,
   UndecidableInstances, GeneralizedNewtypeDeriving,
   MultiParamTypeClasses, FlexibleContexts, FlexibleInstances,
-  PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds #-}
+  PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds,
+  BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports#-}
 {-# OPTIONS_GHC -fno-warn-duplicate-exports#-}
 module Proto.Google.Protobuf.Descriptor
@@ -32,6 +33,8 @@ import qualified Data.Int
 import qualified Data.Monoid
 import qualified Data.Word
 import qualified Data.ProtoLens
+import qualified Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Encoding.Wire
 import qualified Data.ProtoLens.Message.Enum
 import qualified Data.ProtoLens.Service.Types
 import qualified Lens.Family2
@@ -40,6 +43,7 @@ import qualified Data.Text
 import qualified Data.Map
 import qualified Data.ByteString
 import qualified Data.ByteString.Char8
+import qualified Data.Text.Encoding
 import qualified Lens.Labels
 import qualified Text.Read
 
@@ -82,98 +86,86 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' DescriptorProto "name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'name
-                 (\ x__ y__ -> x__{_DescriptorProto'name = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'name
+               (\ x__ y__ -> x__{_DescriptorProto'name = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' DescriptorProto "maybe'name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'name
-                 (\ x__ y__ -> x__{_DescriptorProto'name = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'name
+               (\ x__ y__ -> x__{_DescriptorProto'name = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([FieldDescriptorProto]) =>
          Lens.Labels.HasLens' DescriptorProto "field" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'field
-                 (\ x__ y__ -> x__{_DescriptorProto'field = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'field
+               (\ x__ y__ -> x__{_DescriptorProto'field = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([FieldDescriptorProto]) =>
          Lens.Labels.HasLens' DescriptorProto "extension" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'extension
-                 (\ x__ y__ -> x__{_DescriptorProto'extension = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'extension
+               (\ x__ y__ -> x__{_DescriptorProto'extension = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([DescriptorProto]) =>
          Lens.Labels.HasLens' DescriptorProto "nestedType" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'nestedType
-                 (\ x__ y__ -> x__{_DescriptorProto'nestedType = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'nestedType
+               (\ x__ y__ -> x__{_DescriptorProto'nestedType = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([EnumDescriptorProto]) =>
          Lens.Labels.HasLens' DescriptorProto "enumType" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'enumType
-                 (\ x__ y__ -> x__{_DescriptorProto'enumType = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'enumType
+               (\ x__ y__ -> x__{_DescriptorProto'enumType = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([DescriptorProto'ExtensionRange]) =>
          Lens.Labels.HasLens' DescriptorProto "extensionRange" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'extensionRange
-                 (\ x__ y__ -> x__{_DescriptorProto'extensionRange = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'extensionRange
+               (\ x__ y__ -> x__{_DescriptorProto'extensionRange = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([OneofDescriptorProto]) =>
          Lens.Labels.HasLens' DescriptorProto "oneofDecl" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'oneofDecl
-                 (\ x__ y__ -> x__{_DescriptorProto'oneofDecl = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'oneofDecl
+               (\ x__ y__ -> x__{_DescriptorProto'oneofDecl = y__}))
+              Prelude.. Prelude.id
 instance a ~ (MessageOptions) =>
          Lens.Labels.HasLens' DescriptorProto "options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'options
-                 (\ x__ y__ -> x__{_DescriptorProto'options = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'options
+               (\ x__ y__ -> x__{_DescriptorProto'options = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.defMessage
 instance a ~ (Prelude.Maybe MessageOptions) =>
          Lens.Labels.HasLens' DescriptorProto "maybe'options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'options
-                 (\ x__ y__ -> x__{_DescriptorProto'options = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'options
+               (\ x__ y__ -> x__{_DescriptorProto'options = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([DescriptorProto'ReservedRange]) =>
          Lens.Labels.HasLens' DescriptorProto "reservedRange" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'reservedRange
-                 (\ x__ y__ -> x__{_DescriptorProto'reservedRange = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'reservedRange
+               (\ x__ y__ -> x__{_DescriptorProto'reservedRange = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([Data.Text.Text]) =>
          Lens.Labels.HasLens' DescriptorProto "reservedName" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'reservedName
-                 (\ x__ y__ -> x__{_DescriptorProto'reservedName = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'reservedName
+               (\ x__ y__ -> x__{_DescriptorProto'reservedName = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message DescriptorProto where
         messageName _ = Data.Text.pack "google.protobuf.DescriptorProto"
         fieldsByTag
@@ -282,25 +274,411 @@ instance Data.ProtoLens.Message DescriptorProto where
                             _DescriptorProto'reservedRange = [],
                             _DescriptorProto'reservedName = [],
                             _DescriptorProto'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     DescriptorProto ->
+                       Data.ProtoLens.Encoding.Bytes.Parser DescriptorProto
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "field"))
+                                 (\ !t -> Prelude.reverse t)
+                                 (Lens.Family2.over
+                                    (Lens.Labels.lensOf'
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "extension"))
+                                    (\ !t -> Prelude.reverse t)
+                                    (Lens.Family2.over
+                                       (Lens.Labels.lensOf'
+                                          ((Lens.Labels.proxy#) ::
+                                             (Lens.Labels.Proxy#) "nestedType"))
+                                       (\ !t -> Prelude.reverse t)
+                                       (Lens.Family2.over
+                                          (Lens.Labels.lensOf'
+                                             ((Lens.Labels.proxy#) ::
+                                                (Lens.Labels.Proxy#) "enumType"))
+                                          (\ !t -> Prelude.reverse t)
+                                          (Lens.Family2.over
+                                             (Lens.Labels.lensOf'
+                                                ((Lens.Labels.proxy#) ::
+                                                   (Lens.Labels.Proxy#) "extensionRange"))
+                                             (\ !t -> Prelude.reverse t)
+                                             (Lens.Family2.over
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "oneofDecl"))
+                                                (\ !t -> Prelude.reverse t)
+                                                (Lens.Family2.over
+                                                   (Lens.Labels.lensOf'
+                                                      ((Lens.Labels.proxy#) ::
+                                                         (Lens.Labels.Proxy#) "reservedRange"))
+                                                   (\ !t -> Prelude.reverse t)
+                                                   (Lens.Family2.over
+                                                      (Lens.Labels.lensOf'
+                                                         ((Lens.Labels.proxy#) ::
+                                                            (Lens.Labels.Proxy#) "reservedName"))
+                                                      (\ !t -> Prelude.reverse t)
+                                                      x)))))))))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "name"))
+                                              y
+                                              x)
+                                18 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "field"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                50 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "extension"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                26 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "nestedType"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                34 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "enumType"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                42 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "extensionRange"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                66 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "oneofDecl"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                58 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (Data.ProtoLens.Encoding.Bytes.runParser
+                                                      Data.ProtoLens.unfinishedParseMessage
+                                                      value)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "options"))
+                                              y
+                                              x)
+                                74 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "reservedRange"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                82 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "reservedName"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'name"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                                         Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
+                 Data.Monoid.<>
+                 (Data.Monoid.mconcat
+                    (Prelude.map
+                       (\ _v ->
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                            (((\ bs ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                               Prelude..
+                               (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                 Data.ProtoLens.unfinishedBuildMessage)
+                              _v)
+                       (Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "field"))
+                          _x)))
+                   Data.Monoid.<>
+                   (Data.Monoid.mconcat
+                      (Prelude.map
+                         (\ _v ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
+                              (((\ bs ->
+                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                 Prelude..
+                                 (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                   Data.ProtoLens.unfinishedBuildMessage)
+                                _v)
+                         (Lens.Family2.view
+                            (Lens.Labels.lensOf'
+                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "extension"))
+                            _x)))
+                     Data.Monoid.<>
+                     (Data.Monoid.mconcat
+                        (Prelude.map
+                           (\ _v ->
+                              (Data.ProtoLens.Encoding.Bytes.putVarInt 26) Data.Monoid.<>
+                                (((\ bs ->
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                       Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                   Prelude..
+                                   (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                     Data.ProtoLens.unfinishedBuildMessage)
+                                  _v)
+                           (Lens.Family2.view
+                              (Lens.Labels.lensOf'
+                                 ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "nestedType"))
+                              _x)))
+                       Data.Monoid.<>
+                       (Data.Monoid.mconcat
+                          (Prelude.map
+                             (\ _v ->
+                                (Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
+                                  (((\ bs ->
+                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                          (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                         Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                     Prelude..
+                                     (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                       Data.ProtoLens.unfinishedBuildMessage)
+                                    _v)
+                             (Lens.Family2.view
+                                (Lens.Labels.lensOf'
+                                   ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "enumType"))
+                                _x)))
+                         Data.Monoid.<>
+                         (Data.Monoid.mconcat
+                            (Prelude.map
+                               (\ _v ->
+                                  (Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
+                                    (((\ bs ->
+                                         (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                            (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                           Data.Monoid.<>
+                                           Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                       Prelude..
+                                       (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                         Data.ProtoLens.unfinishedBuildMessage)
+                                      _v)
+                               (Lens.Family2.view
+                                  (Lens.Labels.lensOf'
+                                     ((Lens.Labels.proxy#) ::
+                                        (Lens.Labels.Proxy#) "extensionRange"))
+                                  _x)))
+                           Data.Monoid.<>
+                           (Data.Monoid.mconcat
+                              (Prelude.map
+                                 (\ _v ->
+                                    (Data.ProtoLens.Encoding.Bytes.putVarInt 66) Data.Monoid.<>
+                                      (((\ bs ->
+                                           (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                              (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                             Data.Monoid.<>
+                                             Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                         Prelude..
+                                         (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                           Data.ProtoLens.unfinishedBuildMessage)
+                                        _v)
+                                 (Lens.Family2.view
+                                    (Lens.Labels.lensOf'
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "oneofDecl"))
+                                    _x)))
+                             Data.Monoid.<>
+                             (case
+                                Lens.Family2.view
+                                  (Lens.Labels.lensOf'
+                                     ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'options"))
+                                  _x
+                                of
+                                  (Prelude.Nothing) -> Data.Monoid.mempty
+                                  Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 58)
+                                                       Data.Monoid.<>
+                                                       (((\ bs ->
+                                                            (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                               (Prelude.fromIntegral
+                                                                  (Data.ByteString.length bs)))
+                                                              Data.Monoid.<>
+                                                              Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                bs))
+                                                          Prelude..
+                                                          (Data.ProtoLens.Encoding.Bytes.runBuilder)
+                                                            Prelude..
+                                                            Data.ProtoLens.unfinishedBuildMessage)
+                                                         _v)
+                               Data.Monoid.<>
+                               (Data.Monoid.mconcat
+                                  (Prelude.map
+                                     (\ _v ->
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt 74) Data.Monoid.<>
+                                          (((\ bs ->
+                                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                  (Prelude.fromIntegral
+                                                     (Data.ByteString.length bs)))
+                                                 Data.Monoid.<>
+                                                 Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                             Prelude..
+                                             (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                               Data.ProtoLens.unfinishedBuildMessage)
+                                            _v)
+                                     (Lens.Family2.view
+                                        (Lens.Labels.lensOf'
+                                           ((Lens.Labels.proxy#) ::
+                                              (Lens.Labels.Proxy#) "reservedRange"))
+                                        _x)))
+                                 Data.Monoid.<>
+                                 (Data.Monoid.mconcat
+                                    (Prelude.map
+                                       (\ _v ->
+                                          (Data.ProtoLens.Encoding.Bytes.putVarInt 82)
+                                            Data.Monoid.<>
+                                            (((\ bs ->
+                                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                    (Prelude.fromIntegral
+                                                       (Data.ByteString.length bs)))
+                                                   Data.Monoid.<>
+                                                   Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                               Prelude.. Data.Text.Encoding.encodeUtf8)
+                                              _v)
+                                       (Lens.Family2.view
+                                          (Lens.Labels.lensOf'
+                                             ((Lens.Labels.proxy#) ::
+                                                (Lens.Labels.Proxy#) "reservedName"))
+                                          _x)))
+                                   Data.Monoid.<>
+                                   Data.Monoid.mconcat
+                                     (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                                        (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData DescriptorProto where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_DescriptorProto'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_DescriptorProto'name x__)
-                   (Control.DeepSeq.deepseq (_DescriptorProto'field x__)
-                      (Control.DeepSeq.deepseq (_DescriptorProto'extension x__)
-                         (Control.DeepSeq.deepseq (_DescriptorProto'nestedType x__)
-                            (Control.DeepSeq.deepseq (_DescriptorProto'enumType x__)
-                               (Control.DeepSeq.deepseq (_DescriptorProto'extensionRange x__)
-                                  (Control.DeepSeq.deepseq (_DescriptorProto'oneofDecl x__)
-                                     (Control.DeepSeq.deepseq (_DescriptorProto'options x__)
-                                        (Control.DeepSeq.deepseq
-                                           (_DescriptorProto'reservedRange x__)
-                                           (Control.DeepSeq.deepseq
-                                              (_DescriptorProto'reservedName x__)
-                                              (())))))))))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_DescriptorProto'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_DescriptorProto'name x__)
+                    (Control.DeepSeq.deepseq (_DescriptorProto'field x__)
+                       (Control.DeepSeq.deepseq (_DescriptorProto'extension x__)
+                          (Control.DeepSeq.deepseq (_DescriptorProto'nestedType x__)
+                             (Control.DeepSeq.deepseq (_DescriptorProto'enumType x__)
+                                (Control.DeepSeq.deepseq (_DescriptorProto'extensionRange x__)
+                                   (Control.DeepSeq.deepseq (_DescriptorProto'oneofDecl x__)
+                                      (Control.DeepSeq.deepseq (_DescriptorProto'options x__)
+                                         (Control.DeepSeq.deepseq
+                                            (_DescriptorProto'reservedRange x__)
+                                            (Control.DeepSeq.deepseq
+                                               (_DescriptorProto'reservedName x__)
+                                               (()))))))))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.start' @:: Lens' DescriptorProto'ExtensionRange Data.Int.Int32@
@@ -335,53 +713,49 @@ instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' DescriptorProto'ExtensionRange "start" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'ExtensionRange'start
-                 (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'start = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens
+               _DescriptorProto'ExtensionRange'start
+               (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'start = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' DescriptorProto'ExtensionRange "maybe'start" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'ExtensionRange'start
-                 (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'start = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _DescriptorProto'ExtensionRange'start
+               (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'start = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' DescriptorProto'ExtensionRange "end" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'ExtensionRange'end
-                 (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'end = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'ExtensionRange'end
+               (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'end = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' DescriptorProto'ExtensionRange "maybe'end" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'ExtensionRange'end
-                 (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'end = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'ExtensionRange'end
+               (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'end = y__}))
+              Prelude.. Prelude.id
 instance a ~ (ExtensionRangeOptions) =>
          Lens.Labels.HasLens' DescriptorProto'ExtensionRange "options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _DescriptorProto'ExtensionRange'options
-                 (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'options = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+          = (Lens.Family2.Unchecked.lens
+               _DescriptorProto'ExtensionRange'options
+               (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'options = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.defMessage
 instance a ~ (Prelude.Maybe ExtensionRangeOptions) =>
          Lens.Labels.HasLens' DescriptorProto'ExtensionRange "maybe'options"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _DescriptorProto'ExtensionRange'options
-                 (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'options = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _DescriptorProto'ExtensionRange'options
+               (\ x__ y__ -> x__{_DescriptorProto'ExtensionRange'options = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message DescriptorProto'ExtensionRange
          where
         messageName _
@@ -428,20 +802,121 @@ instance Data.ProtoLens.Message DescriptorProto'ExtensionRange
                                            _DescriptorProto'ExtensionRange'options =
                                              Prelude.Nothing,
                                            _DescriptorProto'ExtensionRange'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     DescriptorProto'ExtensionRange ->
+                       Data.ProtoLens.Encoding.Bytes.Parser DescriptorProto'ExtensionRange
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              x)
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                8 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                               Data.ProtoLens.Encoding.Bytes.getVarInt
+                                        loop
+                                          (Lens.Family2.set
+                                             (Lens.Labels.lensOf'
+                                                ((Lens.Labels.proxy#) ::
+                                                   (Lens.Labels.Proxy#) "start"))
+                                             y
+                                             x)
+                                16 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "end"))
+                                              y
+                                              x)
+                                26 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (Data.ProtoLens.Encoding.Bytes.runParser
+                                                      Data.ProtoLens.unfinishedParseMessage
+                                                      value)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "options"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'start"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 8)
+                                         Data.Monoid.<>
+                                         ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                            Prelude.fromIntegral)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'end"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 16)
+                                           Data.Monoid.<>
+                                           ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                              Prelude.fromIntegral)
+                                             _v)
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'options"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 26)
+                                             Data.Monoid.<>
+                                             (((\ bs ->
+                                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                     (Prelude.fromIntegral
+                                                        (Data.ByteString.length bs)))
+                                                    Data.Monoid.<>
+                                                    Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                Prelude..
+                                                (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                                  Data.ProtoLens.unfinishedBuildMessage)
+                                               _v)
+                     Data.Monoid.<>
+                     Data.Monoid.mconcat
+                       (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                          (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData DescriptorProto'ExtensionRange
          where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq
-                (_DescriptorProto'ExtensionRange'_unknownFields x__)
-                (Control.DeepSeq.deepseq
-                   (_DescriptorProto'ExtensionRange'start x__)
-                   (Control.DeepSeq.deepseq (_DescriptorProto'ExtensionRange'end x__)
-                      (Control.DeepSeq.deepseq
-                         (_DescriptorProto'ExtensionRange'options x__)
-                         (()))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq
+                 (_DescriptorProto'ExtensionRange'_unknownFields x__)
+                 (Control.DeepSeq.deepseq
+                    (_DescriptorProto'ExtensionRange'start x__)
+                    (Control.DeepSeq.deepseq (_DescriptorProto'ExtensionRange'end x__)
+                       (Control.DeepSeq.deepseq
+                          (_DescriptorProto'ExtensionRange'options x__)
+                          (())))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.start' @:: Lens' DescriptorProto'ReservedRange Data.Int.Int32@
@@ -467,34 +942,30 @@ instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' DescriptorProto'ReservedRange "start" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'start
-                 (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'start = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'start
+               (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'start = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' DescriptorProto'ReservedRange "maybe'start" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'start
-                 (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'start = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'start
+               (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'start = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' DescriptorProto'ReservedRange "end" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'end
-                 (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'end = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'end
+               (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'end = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' DescriptorProto'ReservedRange "maybe'end" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'end
-                 (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'end = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'ReservedRange'end
+               (\ x__ y__ -> x__{_DescriptorProto'ReservedRange'end = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message DescriptorProto'ReservedRange where
         messageName _
           = Data.Text.pack "google.protobuf.DescriptorProto.ReservedRange"
@@ -529,16 +1000,83 @@ instance Data.ProtoLens.Message DescriptorProto'ReservedRange where
                                             = Prelude.Nothing,
                                           _DescriptorProto'ReservedRange'end = Prelude.Nothing,
                                           _DescriptorProto'ReservedRange'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     DescriptorProto'ReservedRange ->
+                       Data.ProtoLens.Encoding.Bytes.Parser DescriptorProto'ReservedRange
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              x)
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                8 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                               Data.ProtoLens.Encoding.Bytes.getVarInt
+                                        loop
+                                          (Lens.Family2.set
+                                             (Lens.Labels.lensOf'
+                                                ((Lens.Labels.proxy#) ::
+                                                   (Lens.Labels.Proxy#) "start"))
+                                             y
+                                             x)
+                                16 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "end"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'start"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 8)
+                                         Data.Monoid.<>
+                                         ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                            Prelude.fromIntegral)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'end"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 16)
+                                           Data.Monoid.<>
+                                           ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                              Prelude.fromIntegral)
+                                             _v)
+                   Data.Monoid.<>
+                   Data.Monoid.mconcat
+                     (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                        (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData DescriptorProto'ReservedRange where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq
-                (_DescriptorProto'ReservedRange'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_DescriptorProto'ReservedRange'start x__)
-                   (Control.DeepSeq.deepseq (_DescriptorProto'ReservedRange'end x__)
-                      (())))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq
+                 (_DescriptorProto'ReservedRange'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_DescriptorProto'ReservedRange'start x__)
+                    (Control.DeepSeq.deepseq (_DescriptorProto'ReservedRange'end x__)
+                       (()))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' EnumDescriptorProto Data.Text.Text@
@@ -571,58 +1109,51 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' EnumDescriptorProto "name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumDescriptorProto'name
-                 (\ x__ y__ -> x__{_EnumDescriptorProto'name = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'name
+               (\ x__ y__ -> x__{_EnumDescriptorProto'name = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' EnumDescriptorProto "maybe'name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumDescriptorProto'name
-                 (\ x__ y__ -> x__{_EnumDescriptorProto'name = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'name
+               (\ x__ y__ -> x__{_EnumDescriptorProto'name = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([EnumValueDescriptorProto]) =>
          Lens.Labels.HasLens' EnumDescriptorProto "value" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumDescriptorProto'value
-                 (\ x__ y__ -> x__{_EnumDescriptorProto'value = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'value
+               (\ x__ y__ -> x__{_EnumDescriptorProto'value = y__}))
+              Prelude.. Prelude.id
 instance a ~ (EnumOptions) =>
          Lens.Labels.HasLens' EnumDescriptorProto "options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumDescriptorProto'options
-                 (\ x__ y__ -> x__{_EnumDescriptorProto'options = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+          = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'options
+               (\ x__ y__ -> x__{_EnumDescriptorProto'options = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.defMessage
 instance a ~ (Prelude.Maybe EnumOptions) =>
          Lens.Labels.HasLens' EnumDescriptorProto "maybe'options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumDescriptorProto'options
-                 (\ x__ y__ -> x__{_EnumDescriptorProto'options = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'options
+               (\ x__ y__ -> x__{_EnumDescriptorProto'options = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([EnumDescriptorProto'EnumReservedRange]) =>
          Lens.Labels.HasLens' EnumDescriptorProto "reservedRange" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumDescriptorProto'reservedRange
-                 (\ x__ y__ -> x__{_EnumDescriptorProto'reservedRange = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'reservedRange
+               (\ x__ y__ -> x__{_EnumDescriptorProto'reservedRange = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([Data.Text.Text]) =>
          Lens.Labels.HasLens' EnumDescriptorProto "reservedName" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumDescriptorProto'reservedName
-                 (\ x__ y__ -> x__{_EnumDescriptorProto'reservedName = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'reservedName
+               (\ x__ y__ -> x__{_EnumDescriptorProto'reservedName = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message EnumDescriptorProto where
         messageName _
           = Data.Text.pack "google.protobuf.EnumDescriptorProto"
@@ -685,18 +1216,213 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                                 _EnumDescriptorProto'reservedRange = [],
                                 _EnumDescriptorProto'reservedName = [],
                                 _EnumDescriptorProto'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     EnumDescriptorProto ->
+                       Data.ProtoLens.Encoding.Bytes.Parser EnumDescriptorProto
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "value"))
+                                 (\ !t -> Prelude.reverse t)
+                                 (Lens.Family2.over
+                                    (Lens.Labels.lensOf'
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "reservedRange"))
+                                    (\ !t -> Prelude.reverse t)
+                                    (Lens.Family2.over
+                                       (Lens.Labels.lensOf'
+                                          ((Lens.Labels.proxy#) ::
+                                             (Lens.Labels.Proxy#) "reservedName"))
+                                       (\ !t -> Prelude.reverse t)
+                                       x))))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "name"))
+                                              y
+                                              x)
+                                18 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "value"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                26 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (Data.ProtoLens.Encoding.Bytes.runParser
+                                                      Data.ProtoLens.unfinishedParseMessage
+                                                      value)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "options"))
+                                              y
+                                              x)
+                                34 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "reservedRange"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                42 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "reservedName"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'name"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                                         Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
+                 Data.Monoid.<>
+                 (Data.Monoid.mconcat
+                    (Prelude.map
+                       (\ _v ->
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                            (((\ bs ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                               Prelude..
+                               (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                 Data.ProtoLens.unfinishedBuildMessage)
+                              _v)
+                       (Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "value"))
+                          _x)))
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'options"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 26)
+                                             Data.Monoid.<>
+                                             (((\ bs ->
+                                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                     (Prelude.fromIntegral
+                                                        (Data.ByteString.length bs)))
+                                                    Data.Monoid.<>
+                                                    Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                Prelude..
+                                                (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                                  Data.ProtoLens.unfinishedBuildMessage)
+                                               _v)
+                     Data.Monoid.<>
+                     (Data.Monoid.mconcat
+                        (Prelude.map
+                           (\ _v ->
+                              (Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
+                                (((\ bs ->
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                       Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                   Prelude..
+                                   (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                     Data.ProtoLens.unfinishedBuildMessage)
+                                  _v)
+                           (Lens.Family2.view
+                              (Lens.Labels.lensOf'
+                                 ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "reservedRange"))
+                              _x)))
+                       Data.Monoid.<>
+                       (Data.Monoid.mconcat
+                          (Prelude.map
+                             (\ _v ->
+                                (Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
+                                  (((\ bs ->
+                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                          (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                         Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                     Prelude.. Data.Text.Encoding.encodeUtf8)
+                                    _v)
+                             (Lens.Family2.view
+                                (Lens.Labels.lensOf'
+                                   ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "reservedName"))
+                                _x)))
+                         Data.Monoid.<>
+                         Data.Monoid.mconcat
+                           (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                              (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData EnumDescriptorProto where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_EnumDescriptorProto'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_EnumDescriptorProto'name x__)
-                   (Control.DeepSeq.deepseq (_EnumDescriptorProto'value x__)
-                      (Control.DeepSeq.deepseq (_EnumDescriptorProto'options x__)
-                         (Control.DeepSeq.deepseq (_EnumDescriptorProto'reservedRange x__)
-                            (Control.DeepSeq.deepseq (_EnumDescriptorProto'reservedName x__)
-                               (()))))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_EnumDescriptorProto'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_EnumDescriptorProto'name x__)
+                    (Control.DeepSeq.deepseq (_EnumDescriptorProto'value x__)
+                       (Control.DeepSeq.deepseq (_EnumDescriptorProto'options x__)
+                          (Control.DeepSeq.deepseq (_EnumDescriptorProto'reservedRange x__)
+                             (Control.DeepSeq.deepseq (_EnumDescriptorProto'reservedName x__)
+                                (())))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.start' @:: Lens' EnumDescriptorProto'EnumReservedRange Data.Int.Int32@
@@ -728,46 +1454,42 @@ instance a ~ (Data.Int.Int32) =>
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _EnumDescriptorProto'EnumReservedRange'start
-                 (\ x__ y__ ->
-                    x__{_EnumDescriptorProto'EnumReservedRange'start = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens
+               _EnumDescriptorProto'EnumReservedRange'start
+               (\ x__ y__ ->
+                  x__{_EnumDescriptorProto'EnumReservedRange'start = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' EnumDescriptorProto'EnumReservedRange
            "maybe'start"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _EnumDescriptorProto'EnumReservedRange'start
-                 (\ x__ y__ ->
-                    x__{_EnumDescriptorProto'EnumReservedRange'start = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _EnumDescriptorProto'EnumReservedRange'start
+               (\ x__ y__ ->
+                  x__{_EnumDescriptorProto'EnumReservedRange'start = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' EnumDescriptorProto'EnumReservedRange "end" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _EnumDescriptorProto'EnumReservedRange'end
-                 (\ x__ y__ ->
-                    x__{_EnumDescriptorProto'EnumReservedRange'end = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens
+               _EnumDescriptorProto'EnumReservedRange'end
+               (\ x__ y__ ->
+                  x__{_EnumDescriptorProto'EnumReservedRange'end = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' EnumDescriptorProto'EnumReservedRange
            "maybe'end"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _EnumDescriptorProto'EnumReservedRange'end
-                 (\ x__ y__ ->
-                    x__{_EnumDescriptorProto'EnumReservedRange'end = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _EnumDescriptorProto'EnumReservedRange'end
+               (\ x__ y__ ->
+                  x__{_EnumDescriptorProto'EnumReservedRange'end = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message
            EnumDescriptorProto'EnumReservedRange
          where
@@ -811,20 +1533,88 @@ instance Data.ProtoLens.Message
                                                     Prelude.Nothing,
                                                   _EnumDescriptorProto'EnumReservedRange'_unknownFields
                                                     = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     EnumDescriptorProto'EnumReservedRange ->
+                       Data.ProtoLens.Encoding.Bytes.Parser
+                         EnumDescriptorProto'EnumReservedRange
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              x)
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                8 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                               Data.ProtoLens.Encoding.Bytes.getVarInt
+                                        loop
+                                          (Lens.Family2.set
+                                             (Lens.Labels.lensOf'
+                                                ((Lens.Labels.proxy#) ::
+                                                   (Lens.Labels.Proxy#) "start"))
+                                             y
+                                             x)
+                                16 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "end"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'start"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 8)
+                                         Data.Monoid.<>
+                                         ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                            Prelude.fromIntegral)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'end"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 16)
+                                           Data.Monoid.<>
+                                           ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                              Prelude.fromIntegral)
+                                             _v)
+                   Data.Monoid.<>
+                   Data.Monoid.mconcat
+                     (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                        (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData
            EnumDescriptorProto'EnumReservedRange
          where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq
-                (_EnumDescriptorProto'EnumReservedRange'_unknownFields x__)
-                (Control.DeepSeq.deepseq
-                   (_EnumDescriptorProto'EnumReservedRange'start x__)
-                   (Control.DeepSeq.deepseq
-                      (_EnumDescriptorProto'EnumReservedRange'end x__)
-                      (())))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq
+                 (_EnumDescriptorProto'EnumReservedRange'_unknownFields x__)
+                 (Control.DeepSeq.deepseq
+                    (_EnumDescriptorProto'EnumReservedRange'start x__)
+                    (Control.DeepSeq.deepseq
+                       (_EnumDescriptorProto'EnumReservedRange'end x__)
+                       (()))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.allowAlias' @:: Lens' EnumOptions Prelude.Bool@
@@ -848,42 +1638,37 @@ instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' EnumOptions "allowAlias" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumOptions'allowAlias
-                 (\ x__ y__ -> x__{_EnumOptions'allowAlias = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _EnumOptions'allowAlias
+               (\ x__ y__ -> x__{_EnumOptions'allowAlias = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' EnumOptions "maybe'allowAlias" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumOptions'allowAlias
-                 (\ x__ y__ -> x__{_EnumOptions'allowAlias = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumOptions'allowAlias
+               (\ x__ y__ -> x__{_EnumOptions'allowAlias = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' EnumOptions "deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumOptions'deprecated
-                 (\ x__ y__ -> x__{_EnumOptions'deprecated = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _EnumOptions'deprecated
+               (\ x__ y__ -> x__{_EnumOptions'deprecated = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' EnumOptions "maybe'deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumOptions'deprecated
-                 (\ x__ y__ -> x__{_EnumOptions'deprecated = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumOptions'deprecated
+               (\ x__ y__ -> x__{_EnumOptions'deprecated = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' EnumOptions "uninterpretedOption" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumOptions'uninterpretedOption
-                 (\ x__ y__ -> x__{_EnumOptions'uninterpretedOption = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_EnumOptions'uninterpretedOption = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message EnumOptions where
         messageName _ = Data.Text.pack "google.protobuf.EnumOptions"
         fieldsByTag
@@ -925,16 +1710,119 @@ instance Data.ProtoLens.Message EnumOptions where
                         _EnumOptions'deprecated = Prelude.Nothing,
                         _EnumOptions'uninterpretedOption = [],
                         _EnumOptions'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     EnumOptions -> Data.ProtoLens.Encoding.Bytes.Parser EnumOptions
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                16 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "allowAlias"))
+                                              y
+                                              x)
+                                24 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "deprecated"))
+                                              y
+                                              x)
+                                7994 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                  (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.Encoding.Bytes.runEither
+                                                      (Data.ProtoLens.Encoding.Bytes.runParser
+                                                         Data.ProtoLens.unfinishedParseMessage
+                                                         value)
+                                           loop
+                                             (Lens.Family2.over
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                                (\ !t -> (:) y t)
+                                                x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'allowAlias"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 16)
+                                         Data.Monoid.<>
+                                         ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                            (\ b -> if b then 1 else 0))
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'deprecated"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 24)
+                                           Data.Monoid.<>
+                                           ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                              (\ b -> if b then 1 else 0))
+                                             _v)
+                   Data.Monoid.<>
+                   (Data.Monoid.mconcat
+                      (Prelude.map
+                         (\ _v ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                              (((\ bs ->
+                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                 Prelude..
+                                 (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                   Data.ProtoLens.unfinishedBuildMessage)
+                                _v)
+                         (Lens.Family2.view
+                            (Lens.Labels.lensOf'
+                               ((Lens.Labels.proxy#) ::
+                                  (Lens.Labels.Proxy#) "uninterpretedOption"))
+                            _x)))
+                     Data.Monoid.<>
+                     Data.Monoid.mconcat
+                       (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                          (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData EnumOptions where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_EnumOptions'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_EnumOptions'allowAlias x__)
-                   (Control.DeepSeq.deepseq (_EnumOptions'deprecated x__)
-                      (Control.DeepSeq.deepseq (_EnumOptions'uninterpretedOption x__)
-                         (()))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_EnumOptions'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_EnumOptions'allowAlias x__)
+                    (Control.DeepSeq.deepseq (_EnumOptions'deprecated x__)
+                       (Control.DeepSeq.deepseq (_EnumOptions'uninterpretedOption x__)
+                          (())))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' EnumValueDescriptorProto Data.Text.Text@
@@ -962,50 +1850,44 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' EnumValueDescriptorProto "name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'name
-                 (\ x__ y__ -> x__{_EnumValueDescriptorProto'name = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'name
+               (\ x__ y__ -> x__{_EnumValueDescriptorProto'name = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' EnumValueDescriptorProto "maybe'name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'name
-                 (\ x__ y__ -> x__{_EnumValueDescriptorProto'name = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'name
+               (\ x__ y__ -> x__{_EnumValueDescriptorProto'name = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' EnumValueDescriptorProto "number" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'number
-                 (\ x__ y__ -> x__{_EnumValueDescriptorProto'number = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'number
+               (\ x__ y__ -> x__{_EnumValueDescriptorProto'number = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' EnumValueDescriptorProto "maybe'number" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'number
-                 (\ x__ y__ -> x__{_EnumValueDescriptorProto'number = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'number
+               (\ x__ y__ -> x__{_EnumValueDescriptorProto'number = y__}))
+              Prelude.. Prelude.id
 instance a ~ (EnumValueOptions) =>
          Lens.Labels.HasLens' EnumValueDescriptorProto "options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'options
-                 (\ x__ y__ -> x__{_EnumValueDescriptorProto'options = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+          = (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'options
+               (\ x__ y__ -> x__{_EnumValueDescriptorProto'options = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.defMessage
 instance a ~ (Prelude.Maybe EnumValueOptions) =>
          Lens.Labels.HasLens' EnumValueDescriptorProto "maybe'options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'options
-                 (\ x__ y__ -> x__{_EnumValueDescriptorProto'options = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumValueDescriptorProto'options
+               (\ x__ y__ -> x__{_EnumValueDescriptorProto'options = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message EnumValueDescriptorProto where
         messageName _
           = Data.Text.pack "google.protobuf.EnumValueDescriptorProto"
@@ -1049,17 +1931,128 @@ instance Data.ProtoLens.Message EnumValueDescriptorProto where
                                      _EnumValueDescriptorProto'number = Prelude.Nothing,
                                      _EnumValueDescriptorProto'options = Prelude.Nothing,
                                      _EnumValueDescriptorProto'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     EnumValueDescriptorProto ->
+                       Data.ProtoLens.Encoding.Bytes.Parser EnumValueDescriptorProto
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              x)
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "name"))
+                                              y
+                                              x)
+                                16 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "number"))
+                                              y
+                                              x)
+                                26 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (Data.ProtoLens.Encoding.Bytes.runParser
+                                                      Data.ProtoLens.unfinishedParseMessage
+                                                      value)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "options"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'name"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                                         Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'number"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 16)
+                                           Data.Monoid.<>
+                                           ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                              Prelude.fromIntegral)
+                                             _v)
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'options"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 26)
+                                             Data.Monoid.<>
+                                             (((\ bs ->
+                                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                     (Prelude.fromIntegral
+                                                        (Data.ByteString.length bs)))
+                                                    Data.Monoid.<>
+                                                    Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                Prelude..
+                                                (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                                  Data.ProtoLens.unfinishedBuildMessage)
+                                               _v)
+                     Data.Monoid.<>
+                     Data.Monoid.mconcat
+                       (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                          (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData EnumValueDescriptorProto where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq
-                (_EnumValueDescriptorProto'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_EnumValueDescriptorProto'name x__)
-                   (Control.DeepSeq.deepseq (_EnumValueDescriptorProto'number x__)
-                      (Control.DeepSeq.deepseq (_EnumValueDescriptorProto'options x__)
-                         (()))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq
+                 (_EnumValueDescriptorProto'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_EnumValueDescriptorProto'name x__)
+                    (Control.DeepSeq.deepseq (_EnumValueDescriptorProto'number x__)
+                       (Control.DeepSeq.deepseq (_EnumValueDescriptorProto'options x__)
+                          (())))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' EnumValueOptions Prelude.Bool@
@@ -1082,26 +2075,24 @@ instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' EnumValueOptions "deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumValueOptions'deprecated
-                 (\ x__ y__ -> x__{_EnumValueOptions'deprecated = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _EnumValueOptions'deprecated
+               (\ x__ y__ -> x__{_EnumValueOptions'deprecated = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' EnumValueOptions "maybe'deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumValueOptions'deprecated
-                 (\ x__ y__ -> x__{_EnumValueOptions'deprecated = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _EnumValueOptions'deprecated
+               (\ x__ y__ -> x__{_EnumValueOptions'deprecated = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' EnumValueOptions "uninterpretedOption" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _EnumValueOptions'uninterpretedOption
-                 (\ x__ y__ -> x__{_EnumValueOptions'uninterpretedOption = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _EnumValueOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_EnumValueOptions'uninterpretedOption = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message EnumValueOptions where
         messageName _ = Data.Text.pack "google.protobuf.EnumValueOptions"
         fieldsByTag
@@ -1133,16 +2124,98 @@ instance Data.ProtoLens.Message EnumValueOptions where
           = EnumValueOptions{_EnumValueOptions'deprecated = Prelude.Nothing,
                              _EnumValueOptions'uninterpretedOption = [],
                              _EnumValueOptions'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     EnumValueOptions ->
+                       Data.ProtoLens.Encoding.Bytes.Parser EnumValueOptions
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                8 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                               Data.ProtoLens.Encoding.Bytes.getVarInt
+                                        loop
+                                          (Lens.Family2.set
+                                             (Lens.Labels.lensOf'
+                                                ((Lens.Labels.proxy#) ::
+                                                   (Lens.Labels.Proxy#) "deprecated"))
+                                             y
+                                             x)
+                                7994 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                  (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.Encoding.Bytes.runEither
+                                                      (Data.ProtoLens.Encoding.Bytes.runParser
+                                                         Data.ProtoLens.unfinishedParseMessage
+                                                         value)
+                                           loop
+                                             (Lens.Family2.over
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                                (\ !t -> (:) y t)
+                                                x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'deprecated"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 8)
+                                         Data.Monoid.<>
+                                         ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                            (\ b -> if b then 1 else 0))
+                                           _v)
+                 Data.Monoid.<>
+                 (Data.Monoid.mconcat
+                    (Prelude.map
+                       (\ _v ->
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                            (((\ bs ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                               Prelude..
+                               (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                 Data.ProtoLens.unfinishedBuildMessage)
+                              _v)
+                       (Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) ::
+                                (Lens.Labels.Proxy#) "uninterpretedOption"))
+                          _x)))
+                   Data.Monoid.<>
+                   Data.Monoid.mconcat
+                     (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                        (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData EnumValueOptions where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_EnumValueOptions'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_EnumValueOptions'deprecated x__)
-                   (Control.DeepSeq.deepseq
-                      (_EnumValueOptions'uninterpretedOption x__)
-                      (())))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_EnumValueOptions'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_EnumValueOptions'deprecated x__)
+                    (Control.DeepSeq.deepseq
+                       (_EnumValueOptions'uninterpretedOption x__)
+                       (()))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' ExtensionRangeOptions [UninterpretedOption]@
@@ -1161,12 +2234,11 @@ instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' ExtensionRangeOptions "uninterpretedOption" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _ExtensionRangeOptions'uninterpretedOption
-                 (\ x__ y__ ->
-                    x__{_ExtensionRangeOptions'uninterpretedOption = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _ExtensionRangeOptions'uninterpretedOption
+               (\ x__ y__ ->
+                  x__{_ExtensionRangeOptions'uninterpretedOption = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message ExtensionRangeOptions where
         messageName _
           = Data.Text.pack "google.protobuf.ExtensionRangeOptions"
@@ -1190,15 +2262,75 @@ instance Data.ProtoLens.Message ExtensionRangeOptions where
           = ExtensionRangeOptions{_ExtensionRangeOptions'uninterpretedOption
                                     = [],
                                   _ExtensionRangeOptions'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     ExtensionRangeOptions ->
+                       Data.ProtoLens.Encoding.Bytes.Parser ExtensionRangeOptions
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                7994 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                  (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.Encoding.Bytes.runEither
+                                                      (Data.ProtoLens.Encoding.Bytes.runParser
+                                                         Data.ProtoLens.unfinishedParseMessage
+                                                         value)
+                                           loop
+                                             (Lens.Family2.over
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                                (\ !t -> (:) y t)
+                                                x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (Data.Monoid.mconcat
+                  (Prelude.map
+                     (\ _v ->
+                        (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude..
+                             (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                               Data.ProtoLens.unfinishedBuildMessage)
+                            _v)
+                     (Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) ::
+                              (Lens.Labels.Proxy#) "uninterpretedOption"))
+                        _x)))
+                 Data.Monoid.<>
+                 Data.Monoid.mconcat
+                   (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                      (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData ExtensionRangeOptions where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_ExtensionRangeOptions'_unknownFields x__)
-                (Control.DeepSeq.deepseq
-                   (_ExtensionRangeOptions'uninterpretedOption x__)
-                   (()))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_ExtensionRangeOptions'_unknownFields x__)
+                 (Control.DeepSeq.deepseq
+                    (_ExtensionRangeOptions'uninterpretedOption x__)
+                    (())))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' FieldDescriptorProto Data.Text.Text@
@@ -1256,162 +2388,142 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FieldDescriptorProto "name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'name
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'name = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'name
+               (\ x__ y__ -> x__{_FieldDescriptorProto'name = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FieldDescriptorProto "maybe'name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'name
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'name = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'name
+               (\ x__ y__ -> x__{_FieldDescriptorProto'name = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' FieldDescriptorProto "number" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'number
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'number = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'number
+               (\ x__ y__ -> x__{_FieldDescriptorProto'number = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' FieldDescriptorProto "maybe'number" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'number
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'number = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'number
+               (\ x__ y__ -> x__{_FieldDescriptorProto'number = y__}))
+              Prelude.. Prelude.id
 instance a ~ (FieldDescriptorProto'Label) =>
          Lens.Labels.HasLens' FieldDescriptorProto "label" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'label
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'label = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'label
+               (\ x__ y__ -> x__{_FieldDescriptorProto'label = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe FieldDescriptorProto'Label) =>
          Lens.Labels.HasLens' FieldDescriptorProto "maybe'label" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'label
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'label = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'label
+               (\ x__ y__ -> x__{_FieldDescriptorProto'label = y__}))
+              Prelude.. Prelude.id
 instance a ~ (FieldDescriptorProto'Type) =>
          Lens.Labels.HasLens' FieldDescriptorProto "type'" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'type'
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'type' = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'type'
+               (\ x__ y__ -> x__{_FieldDescriptorProto'type' = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe FieldDescriptorProto'Type) =>
          Lens.Labels.HasLens' FieldDescriptorProto "maybe'type'" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'type'
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'type' = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'type'
+               (\ x__ y__ -> x__{_FieldDescriptorProto'type' = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FieldDescriptorProto "typeName" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'typeName
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'typeName = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'typeName
+               (\ x__ y__ -> x__{_FieldDescriptorProto'typeName = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FieldDescriptorProto "maybe'typeName" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'typeName
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'typeName = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'typeName
+               (\ x__ y__ -> x__{_FieldDescriptorProto'typeName = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FieldDescriptorProto "extendee" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'extendee
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'extendee = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'extendee
+               (\ x__ y__ -> x__{_FieldDescriptorProto'extendee = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FieldDescriptorProto "maybe'extendee" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'extendee
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'extendee = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'extendee
+               (\ x__ y__ -> x__{_FieldDescriptorProto'extendee = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FieldDescriptorProto "defaultValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'defaultValue
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'defaultValue = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'defaultValue
+               (\ x__ y__ -> x__{_FieldDescriptorProto'defaultValue = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FieldDescriptorProto "maybe'defaultValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'defaultValue
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'defaultValue = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'defaultValue
+               (\ x__ y__ -> x__{_FieldDescriptorProto'defaultValue = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' FieldDescriptorProto "oneofIndex" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'oneofIndex
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'oneofIndex = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'oneofIndex
+               (\ x__ y__ -> x__{_FieldDescriptorProto'oneofIndex = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' FieldDescriptorProto "maybe'oneofIndex" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'oneofIndex
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'oneofIndex = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'oneofIndex
+               (\ x__ y__ -> x__{_FieldDescriptorProto'oneofIndex = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FieldDescriptorProto "jsonName" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'jsonName
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'jsonName = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'jsonName
+               (\ x__ y__ -> x__{_FieldDescriptorProto'jsonName = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FieldDescriptorProto "maybe'jsonName" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'jsonName
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'jsonName = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'jsonName
+               (\ x__ y__ -> x__{_FieldDescriptorProto'jsonName = y__}))
+              Prelude.. Prelude.id
 instance a ~ (FieldOptions) =>
          Lens.Labels.HasLens' FieldDescriptorProto "options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'options
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'options = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'options
+               (\ x__ y__ -> x__{_FieldDescriptorProto'options = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.defMessage
 instance a ~ (Prelude.Maybe FieldOptions) =>
          Lens.Labels.HasLens' FieldDescriptorProto "maybe'options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldDescriptorProto'options
-                 (\ x__ y__ -> x__{_FieldDescriptorProto'options = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldDescriptorProto'options
+               (\ x__ y__ -> x__{_FieldDescriptorProto'options = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message FieldDescriptorProto where
         messageName _
           = Data.Text.pack "google.protobuf.FieldDescriptorProto"
@@ -1525,25 +2637,349 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                                  _FieldDescriptorProto'jsonName = Prelude.Nothing,
                                  _FieldDescriptorProto'options = Prelude.Nothing,
                                  _FieldDescriptorProto'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     FieldDescriptorProto ->
+                       Data.ProtoLens.Encoding.Bytes.Parser FieldDescriptorProto
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              x)
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "name"))
+                                              y
+                                              x)
+                                24 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "number"))
+                                              y
+                                              x)
+                                32 -> do y <- Prelude.fmap Prelude.toEnum
+                                                (Prelude.fmap Prelude.fromIntegral
+                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "label"))
+                                              y
+                                              x)
+                                40 -> do y <- Prelude.fmap Prelude.toEnum
+                                                (Prelude.fmap Prelude.fromIntegral
+                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "type'"))
+                                              y
+                                              x)
+                                50 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "typeName"))
+                                              y
+                                              x)
+                                18 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "extendee"))
+                                              y
+                                              x)
+                                58 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "defaultValue"))
+                                              y
+                                              x)
+                                72 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "oneofIndex"))
+                                              y
+                                              x)
+                                82 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "jsonName"))
+                                              y
+                                              x)
+                                66 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (Data.ProtoLens.Encoding.Bytes.runParser
+                                                      Data.ProtoLens.unfinishedParseMessage
+                                                      value)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "options"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'name"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                                         Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'number"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 24)
+                                           Data.Monoid.<>
+                                           ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                              Prelude.fromIntegral)
+                                             _v)
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'label"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 32)
+                                             Data.Monoid.<>
+                                             (((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                 Prelude.fromIntegral)
+                                                Prelude.. Prelude.fromEnum)
+                                               _v)
+                     Data.Monoid.<>
+                     (case
+                        Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'type'"))
+                          _x
+                        of
+                          (Prelude.Nothing) -> Data.Monoid.mempty
+                          Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 40)
+                                               Data.Monoid.<>
+                                               (((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                   Prelude.fromIntegral)
+                                                  Prelude.. Prelude.fromEnum)
+                                                 _v)
+                       Data.Monoid.<>
+                       (case
+                          Lens.Family2.view
+                            (Lens.Labels.lensOf'
+                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'typeName"))
+                            _x
+                          of
+                            (Prelude.Nothing) -> Data.Monoid.mempty
+                            Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 50)
+                                                 Data.Monoid.<>
+                                                 (((\ bs ->
+                                                      (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                         (Prelude.fromIntegral
+                                                            (Data.ByteString.length bs)))
+                                                        Data.Monoid.<>
+                                                        Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                    Prelude.. Data.Text.Encoding.encodeUtf8)
+                                                   _v)
+                         Data.Monoid.<>
+                         (case
+                            Lens.Family2.view
+                              (Lens.Labels.lensOf'
+                                 ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'extendee"))
+                              _x
+                            of
+                              (Prelude.Nothing) -> Data.Monoid.mempty
+                              Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                                                   Data.Monoid.<>
+                                                   (((\ bs ->
+                                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                           (Prelude.fromIntegral
+                                                              (Data.ByteString.length bs)))
+                                                          Data.Monoid.<>
+                                                          Data.ProtoLens.Encoding.Bytes.putBytes
+                                                            bs))
+                                                      Prelude.. Data.Text.Encoding.encodeUtf8)
+                                                     _v)
+                           Data.Monoid.<>
+                           (case
+                              Lens.Family2.view
+                                (Lens.Labels.lensOf'
+                                   ((Lens.Labels.proxy#) ::
+                                      (Lens.Labels.Proxy#) "maybe'defaultValue"))
+                                _x
+                              of
+                                (Prelude.Nothing) -> Data.Monoid.mempty
+                                Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 58)
+                                                     Data.Monoid.<>
+                                                     (((\ bs ->
+                                                          (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                             (Prelude.fromIntegral
+                                                                (Data.ByteString.length bs)))
+                                                            Data.Monoid.<>
+                                                            Data.ProtoLens.Encoding.Bytes.putBytes
+                                                              bs))
+                                                        Prelude.. Data.Text.Encoding.encodeUtf8)
+                                                       _v)
+                             Data.Monoid.<>
+                             (case
+                                Lens.Family2.view
+                                  (Lens.Labels.lensOf'
+                                     ((Lens.Labels.proxy#) ::
+                                        (Lens.Labels.Proxy#) "maybe'oneofIndex"))
+                                  _x
+                                of
+                                  (Prelude.Nothing) -> Data.Monoid.mempty
+                                  Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 72)
+                                                       Data.Monoid.<>
+                                                       ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                          Prelude.. Prelude.fromIntegral)
+                                                         _v)
+                               Data.Monoid.<>
+                               (case
+                                  Lens.Family2.view
+                                    (Lens.Labels.lensOf'
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "maybe'jsonName"))
+                                    _x
+                                  of
+                                    (Prelude.Nothing) -> Data.Monoid.mempty
+                                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 82)
+                                                         Data.Monoid.<>
+                                                         (((\ bs ->
+                                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                 (Prelude.fromIntegral
+                                                                    (Data.ByteString.length bs)))
+                                                                Data.Monoid.<>
+                                                                Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                  bs))
+                                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                                           _v)
+                                 Data.Monoid.<>
+                                 (case
+                                    Lens.Family2.view
+                                      (Lens.Labels.lensOf'
+                                         ((Lens.Labels.proxy#) ::
+                                            (Lens.Labels.Proxy#) "maybe'options"))
+                                      _x
+                                    of
+                                      (Prelude.Nothing) -> Data.Monoid.mempty
+                                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                            66)
+                                                           Data.Monoid.<>
+                                                           (((\ bs ->
+                                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                   (Prelude.fromIntegral
+                                                                      (Data.ByteString.length bs)))
+                                                                  Data.Monoid.<>
+                                                                  Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                    bs))
+                                                              Prelude..
+                                                              (Data.ProtoLens.Encoding.Bytes.runBuilder)
+                                                                Prelude..
+                                                                Data.ProtoLens.unfinishedBuildMessage)
+                                                             _v)
+                                   Data.Monoid.<>
+                                   Data.Monoid.mconcat
+                                     (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                                        (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData FieldDescriptorProto where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_FieldDescriptorProto'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_FieldDescriptorProto'name x__)
-                   (Control.DeepSeq.deepseq (_FieldDescriptorProto'number x__)
-                      (Control.DeepSeq.deepseq (_FieldDescriptorProto'label x__)
-                         (Control.DeepSeq.deepseq (_FieldDescriptorProto'type' x__)
-                            (Control.DeepSeq.deepseq (_FieldDescriptorProto'typeName x__)
-                               (Control.DeepSeq.deepseq (_FieldDescriptorProto'extendee x__)
-                                  (Control.DeepSeq.deepseq (_FieldDescriptorProto'defaultValue x__)
-                                     (Control.DeepSeq.deepseq (_FieldDescriptorProto'oneofIndex x__)
-                                        (Control.DeepSeq.deepseq
-                                           (_FieldDescriptorProto'jsonName x__)
-                                           (Control.DeepSeq.deepseq
-                                              (_FieldDescriptorProto'options x__)
-                                              (())))))))))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_FieldDescriptorProto'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_FieldDescriptorProto'name x__)
+                    (Control.DeepSeq.deepseq (_FieldDescriptorProto'number x__)
+                       (Control.DeepSeq.deepseq (_FieldDescriptorProto'label x__)
+                          (Control.DeepSeq.deepseq (_FieldDescriptorProto'type' x__)
+                             (Control.DeepSeq.deepseq (_FieldDescriptorProto'typeName x__)
+                                (Control.DeepSeq.deepseq (_FieldDescriptorProto'extendee x__)
+                                   (Control.DeepSeq.deepseq (_FieldDescriptorProto'defaultValue x__)
+                                      (Control.DeepSeq.deepseq
+                                         (_FieldDescriptorProto'oneofIndex x__)
+                                         (Control.DeepSeq.deepseq
+                                            (_FieldDescriptorProto'jsonName x__)
+                                            (Control.DeepSeq.deepseq
+                                               (_FieldDescriptorProto'options x__)
+                                               (()))))))))))))
 data FieldDescriptorProto'Label = FieldDescriptorProto'LABEL_OPTIONAL
                                 | FieldDescriptorProto'LABEL_REQUIRED
                                 | FieldDescriptorProto'LABEL_REPEATED
@@ -1558,14 +2994,14 @@ instance Data.ProtoLens.MessageEnum FieldDescriptorProto'Label
         showEnum FieldDescriptorProto'LABEL_REQUIRED = "LABEL_REQUIRED"
         showEnum FieldDescriptorProto'LABEL_REPEATED = "LABEL_REPEATED"
         readEnum k
-          | (Prelude.==) k "LABEL_OPTIONAL" =
+          | (k) Prelude.== "LABEL_OPTIONAL" =
             Prelude.Just FieldDescriptorProto'LABEL_OPTIONAL
-          | (Prelude.==) k "LABEL_REQUIRED" =
+          | (k) Prelude.== "LABEL_REQUIRED" =
             Prelude.Just FieldDescriptorProto'LABEL_REQUIRED
-          | (Prelude.==) k "LABEL_REPEATED" =
+          | (k) Prelude.== "LABEL_REPEATED" =
             Prelude.Just FieldDescriptorProto'LABEL_REPEATED
         readEnum k
-          = (Prelude.>>=) (Text.Read.readMaybe k) Data.ProtoLens.maybeToEnum
+          = (Text.Read.readMaybe k) Prelude.>>= Data.ProtoLens.maybeToEnum
 instance Prelude.Bounded FieldDescriptorProto'Label where
         minBound = FieldDescriptorProto'LABEL_OPTIONAL
         maxBound = FieldDescriptorProto'LABEL_REPEATED
@@ -1573,8 +3009,8 @@ instance Prelude.Enum FieldDescriptorProto'Label where
         toEnum k__
           = Prelude.maybe
               (Prelude.error
-                 ((Prelude.++) "toEnum: unknown value for enum Label: "
-                    (Prelude.show k__)))
+                 (("toEnum: unknown value for enum Label: ") Prelude.++
+                    Prelude.show k__))
               Prelude.id
               (Data.ProtoLens.maybeToEnum k__)
         fromEnum FieldDescriptorProto'LABEL_OPTIONAL = 1
@@ -1661,44 +3097,44 @@ instance Data.ProtoLens.MessageEnum FieldDescriptorProto'Type where
         showEnum FieldDescriptorProto'TYPE_SINT32 = "TYPE_SINT32"
         showEnum FieldDescriptorProto'TYPE_SINT64 = "TYPE_SINT64"
         readEnum k
-          | (Prelude.==) k "TYPE_DOUBLE" =
+          | (k) Prelude.== "TYPE_DOUBLE" =
             Prelude.Just FieldDescriptorProto'TYPE_DOUBLE
-          | (Prelude.==) k "TYPE_FLOAT" =
+          | (k) Prelude.== "TYPE_FLOAT" =
             Prelude.Just FieldDescriptorProto'TYPE_FLOAT
-          | (Prelude.==) k "TYPE_INT64" =
+          | (k) Prelude.== "TYPE_INT64" =
             Prelude.Just FieldDescriptorProto'TYPE_INT64
-          | (Prelude.==) k "TYPE_UINT64" =
+          | (k) Prelude.== "TYPE_UINT64" =
             Prelude.Just FieldDescriptorProto'TYPE_UINT64
-          | (Prelude.==) k "TYPE_INT32" =
+          | (k) Prelude.== "TYPE_INT32" =
             Prelude.Just FieldDescriptorProto'TYPE_INT32
-          | (Prelude.==) k "TYPE_FIXED64" =
+          | (k) Prelude.== "TYPE_FIXED64" =
             Prelude.Just FieldDescriptorProto'TYPE_FIXED64
-          | (Prelude.==) k "TYPE_FIXED32" =
+          | (k) Prelude.== "TYPE_FIXED32" =
             Prelude.Just FieldDescriptorProto'TYPE_FIXED32
-          | (Prelude.==) k "TYPE_BOOL" =
+          | (k) Prelude.== "TYPE_BOOL" =
             Prelude.Just FieldDescriptorProto'TYPE_BOOL
-          | (Prelude.==) k "TYPE_STRING" =
+          | (k) Prelude.== "TYPE_STRING" =
             Prelude.Just FieldDescriptorProto'TYPE_STRING
-          | (Prelude.==) k "TYPE_GROUP" =
+          | (k) Prelude.== "TYPE_GROUP" =
             Prelude.Just FieldDescriptorProto'TYPE_GROUP
-          | (Prelude.==) k "TYPE_MESSAGE" =
+          | (k) Prelude.== "TYPE_MESSAGE" =
             Prelude.Just FieldDescriptorProto'TYPE_MESSAGE
-          | (Prelude.==) k "TYPE_BYTES" =
+          | (k) Prelude.== "TYPE_BYTES" =
             Prelude.Just FieldDescriptorProto'TYPE_BYTES
-          | (Prelude.==) k "TYPE_UINT32" =
+          | (k) Prelude.== "TYPE_UINT32" =
             Prelude.Just FieldDescriptorProto'TYPE_UINT32
-          | (Prelude.==) k "TYPE_ENUM" =
+          | (k) Prelude.== "TYPE_ENUM" =
             Prelude.Just FieldDescriptorProto'TYPE_ENUM
-          | (Prelude.==) k "TYPE_SFIXED32" =
+          | (k) Prelude.== "TYPE_SFIXED32" =
             Prelude.Just FieldDescriptorProto'TYPE_SFIXED32
-          | (Prelude.==) k "TYPE_SFIXED64" =
+          | (k) Prelude.== "TYPE_SFIXED64" =
             Prelude.Just FieldDescriptorProto'TYPE_SFIXED64
-          | (Prelude.==) k "TYPE_SINT32" =
+          | (k) Prelude.== "TYPE_SINT32" =
             Prelude.Just FieldDescriptorProto'TYPE_SINT32
-          | (Prelude.==) k "TYPE_SINT64" =
+          | (k) Prelude.== "TYPE_SINT64" =
             Prelude.Just FieldDescriptorProto'TYPE_SINT64
         readEnum k
-          = (Prelude.>>=) (Text.Read.readMaybe k) Data.ProtoLens.maybeToEnum
+          = (Text.Read.readMaybe k) Prelude.>>= Data.ProtoLens.maybeToEnum
 instance Prelude.Bounded FieldDescriptorProto'Type where
         minBound = FieldDescriptorProto'TYPE_DOUBLE
         maxBound = FieldDescriptorProto'TYPE_SINT64
@@ -1706,8 +3142,8 @@ instance Prelude.Enum FieldDescriptorProto'Type where
         toEnum k__
           = Prelude.maybe
               (Prelude.error
-                 ((Prelude.++) "toEnum: unknown value for enum Type: "
-                    (Prelude.show k__)))
+                 (("toEnum: unknown value for enum Type: ") Prelude.++
+                    Prelude.show k__))
               Prelude.id
               (Data.ProtoLens.maybeToEnum k__)
         fromEnum FieldDescriptorProto'TYPE_DOUBLE = 1
@@ -1846,106 +3282,93 @@ instance a ~ (FieldOptions'CType) =>
          Lens.Labels.HasLens' FieldOptions "ctype" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'ctype
-                 (\ x__ y__ -> x__{_FieldOptions'ctype = y__}))
-              (Data.ProtoLens.maybeLens FieldOptions'STRING)
+          = (Lens.Family2.Unchecked.lens _FieldOptions'ctype
+               (\ x__ y__ -> x__{_FieldOptions'ctype = y__}))
+              Prelude.. Data.ProtoLens.maybeLens FieldOptions'STRING
 instance a ~ (Prelude.Maybe FieldOptions'CType) =>
          Lens.Labels.HasLens' FieldOptions "maybe'ctype" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'ctype
-                 (\ x__ y__ -> x__{_FieldOptions'ctype = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldOptions'ctype
+               (\ x__ y__ -> x__{_FieldOptions'ctype = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FieldOptions "packed" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'packed
-                 (\ x__ y__ -> x__{_FieldOptions'packed = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FieldOptions'packed
+               (\ x__ y__ -> x__{_FieldOptions'packed = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FieldOptions "maybe'packed" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'packed
-                 (\ x__ y__ -> x__{_FieldOptions'packed = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldOptions'packed
+               (\ x__ y__ -> x__{_FieldOptions'packed = y__}))
+              Prelude.. Prelude.id
 instance a ~ (FieldOptions'JSType) =>
          Lens.Labels.HasLens' FieldOptions "jstype" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'jstype
-                 (\ x__ y__ -> x__{_FieldOptions'jstype = y__}))
-              (Data.ProtoLens.maybeLens FieldOptions'JS_NORMAL)
+          = (Lens.Family2.Unchecked.lens _FieldOptions'jstype
+               (\ x__ y__ -> x__{_FieldOptions'jstype = y__}))
+              Prelude.. Data.ProtoLens.maybeLens FieldOptions'JS_NORMAL
 instance a ~ (Prelude.Maybe FieldOptions'JSType) =>
          Lens.Labels.HasLens' FieldOptions "maybe'jstype" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'jstype
-                 (\ x__ y__ -> x__{_FieldOptions'jstype = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldOptions'jstype
+               (\ x__ y__ -> x__{_FieldOptions'jstype = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FieldOptions "lazy" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'lazy
-                 (\ x__ y__ -> x__{_FieldOptions'lazy = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _FieldOptions'lazy
+               (\ x__ y__ -> x__{_FieldOptions'lazy = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FieldOptions "maybe'lazy" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'lazy
-                 (\ x__ y__ -> x__{_FieldOptions'lazy = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldOptions'lazy
+               (\ x__ y__ -> x__{_FieldOptions'lazy = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FieldOptions "deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'deprecated
-                 (\ x__ y__ -> x__{_FieldOptions'deprecated = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _FieldOptions'deprecated
+               (\ x__ y__ -> x__{_FieldOptions'deprecated = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FieldOptions "maybe'deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'deprecated
-                 (\ x__ y__ -> x__{_FieldOptions'deprecated = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldOptions'deprecated
+               (\ x__ y__ -> x__{_FieldOptions'deprecated = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FieldOptions "weak" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'weak
-                 (\ x__ y__ -> x__{_FieldOptions'weak = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _FieldOptions'weak
+               (\ x__ y__ -> x__{_FieldOptions'weak = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FieldOptions "maybe'weak" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'weak
-                 (\ x__ y__ -> x__{_FieldOptions'weak = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldOptions'weak
+               (\ x__ y__ -> x__{_FieldOptions'weak = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' FieldOptions "uninterpretedOption" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FieldOptions'uninterpretedOption
-                 (\ x__ y__ -> x__{_FieldOptions'uninterpretedOption = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FieldOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_FieldOptions'uninterpretedOption = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message FieldOptions where
         messageName _ = Data.Text.pack "google.protobuf.FieldOptions"
         fieldsByTag
@@ -2027,20 +3450,216 @@ instance Data.ProtoLens.Message FieldOptions where
                          _FieldOptions'weak = Prelude.Nothing,
                          _FieldOptions'uninterpretedOption = [],
                          _FieldOptions'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     FieldOptions -> Data.ProtoLens.Encoding.Bytes.Parser FieldOptions
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                8 -> do y <- Prelude.fmap Prelude.toEnum
+                                               (Prelude.fmap Prelude.fromIntegral
+                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                        loop
+                                          (Lens.Family2.set
+                                             (Lens.Labels.lensOf'
+                                                ((Lens.Labels.proxy#) ::
+                                                   (Lens.Labels.Proxy#) "ctype"))
+                                             y
+                                             x)
+                                16 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "packed"))
+                                              y
+                                              x)
+                                48 -> do y <- Prelude.fmap Prelude.toEnum
+                                                (Prelude.fmap Prelude.fromIntegral
+                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "jstype"))
+                                              y
+                                              x)
+                                40 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "lazy"))
+                                              y
+                                              x)
+                                24 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "deprecated"))
+                                              y
+                                              x)
+                                80 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "weak"))
+                                              y
+                                              x)
+                                7994 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                  (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.Encoding.Bytes.runEither
+                                                      (Data.ProtoLens.Encoding.Bytes.runParser
+                                                         Data.ProtoLens.unfinishedParseMessage
+                                                         value)
+                                           loop
+                                             (Lens.Family2.over
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                                (\ !t -> (:) y t)
+                                                x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'ctype"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 8)
+                                         Data.Monoid.<>
+                                         (((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                             Prelude.fromIntegral)
+                                            Prelude.. Prelude.fromEnum)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'packed"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 16)
+                                           Data.Monoid.<>
+                                           ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                              (\ b -> if b then 1 else 0))
+                                             _v)
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'jstype"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 48)
+                                             Data.Monoid.<>
+                                             (((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                 Prelude.fromIntegral)
+                                                Prelude.. Prelude.fromEnum)
+                                               _v)
+                     Data.Monoid.<>
+                     (case
+                        Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'lazy"))
+                          _x
+                        of
+                          (Prelude.Nothing) -> Data.Monoid.mempty
+                          Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 40)
+                                               Data.Monoid.<>
+                                               ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                  (\ b -> if b then 1 else 0))
+                                                 _v)
+                       Data.Monoid.<>
+                       (case
+                          Lens.Family2.view
+                            (Lens.Labels.lensOf'
+                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'deprecated"))
+                            _x
+                          of
+                            (Prelude.Nothing) -> Data.Monoid.mempty
+                            Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 24)
+                                                 Data.Monoid.<>
+                                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                    Prelude.. (\ b -> if b then 1 else 0))
+                                                   _v)
+                         Data.Monoid.<>
+                         (case
+                            Lens.Family2.view
+                              (Lens.Labels.lensOf'
+                                 ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'weak"))
+                              _x
+                            of
+                              (Prelude.Nothing) -> Data.Monoid.mempty
+                              Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 80)
+                                                   Data.Monoid.<>
+                                                   ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                      Prelude.. (\ b -> if b then 1 else 0))
+                                                     _v)
+                           Data.Monoid.<>
+                           (Data.Monoid.mconcat
+                              (Prelude.map
+                                 (\ _v ->
+                                    (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                                      (((\ bs ->
+                                           (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                              (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                             Data.Monoid.<>
+                                             Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                         Prelude..
+                                         (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                           Data.ProtoLens.unfinishedBuildMessage)
+                                        _v)
+                                 (Lens.Family2.view
+                                    (Lens.Labels.lensOf'
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                    _x)))
+                             Data.Monoid.<>
+                             Data.Monoid.mconcat
+                               (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                                  (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData FieldOptions where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_FieldOptions'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_FieldOptions'ctype x__)
-                   (Control.DeepSeq.deepseq (_FieldOptions'packed x__)
-                      (Control.DeepSeq.deepseq (_FieldOptions'jstype x__)
-                         (Control.DeepSeq.deepseq (_FieldOptions'lazy x__)
-                            (Control.DeepSeq.deepseq (_FieldOptions'deprecated x__)
-                               (Control.DeepSeq.deepseq (_FieldOptions'weak x__)
-                                  (Control.DeepSeq.deepseq (_FieldOptions'uninterpretedOption x__)
-                                     (()))))))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_FieldOptions'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_FieldOptions'ctype x__)
+                    (Control.DeepSeq.deepseq (_FieldOptions'packed x__)
+                       (Control.DeepSeq.deepseq (_FieldOptions'jstype x__)
+                          (Control.DeepSeq.deepseq (_FieldOptions'lazy x__)
+                             (Control.DeepSeq.deepseq (_FieldOptions'deprecated x__)
+                                (Control.DeepSeq.deepseq (_FieldOptions'weak x__)
+                                   (Control.DeepSeq.deepseq (_FieldOptions'uninterpretedOption x__)
+                                      (())))))))))
 data FieldOptions'CType = FieldOptions'STRING
                         | FieldOptions'CORD
                         | FieldOptions'STRING_PIECE
@@ -2054,12 +3673,12 @@ instance Data.ProtoLens.MessageEnum FieldOptions'CType where
         showEnum FieldOptions'CORD = "CORD"
         showEnum FieldOptions'STRING_PIECE = "STRING_PIECE"
         readEnum k
-          | (Prelude.==) k "STRING" = Prelude.Just FieldOptions'STRING
-          | (Prelude.==) k "CORD" = Prelude.Just FieldOptions'CORD
-          | (Prelude.==) k "STRING_PIECE" =
+          | (k) Prelude.== "STRING" = Prelude.Just FieldOptions'STRING
+          | (k) Prelude.== "CORD" = Prelude.Just FieldOptions'CORD
+          | (k) Prelude.== "STRING_PIECE" =
             Prelude.Just FieldOptions'STRING_PIECE
         readEnum k
-          = (Prelude.>>=) (Text.Read.readMaybe k) Data.ProtoLens.maybeToEnum
+          = (Text.Read.readMaybe k) Prelude.>>= Data.ProtoLens.maybeToEnum
 instance Prelude.Bounded FieldOptions'CType where
         minBound = FieldOptions'STRING
         maxBound = FieldOptions'STRING_PIECE
@@ -2067,8 +3686,8 @@ instance Prelude.Enum FieldOptions'CType where
         toEnum k__
           = Prelude.maybe
               (Prelude.error
-                 ((Prelude.++) "toEnum: unknown value for enum CType: "
-                    (Prelude.show k__)))
+                 (("toEnum: unknown value for enum CType: ") Prelude.++
+                    Prelude.show k__))
               Prelude.id
               (Data.ProtoLens.maybeToEnum k__)
         fromEnum FieldOptions'STRING = 0
@@ -2105,11 +3724,11 @@ instance Data.ProtoLens.MessageEnum FieldOptions'JSType where
         showEnum FieldOptions'JS_STRING = "JS_STRING"
         showEnum FieldOptions'JS_NUMBER = "JS_NUMBER"
         readEnum k
-          | (Prelude.==) k "JS_NORMAL" = Prelude.Just FieldOptions'JS_NORMAL
-          | (Prelude.==) k "JS_STRING" = Prelude.Just FieldOptions'JS_STRING
-          | (Prelude.==) k "JS_NUMBER" = Prelude.Just FieldOptions'JS_NUMBER
+          | (k) Prelude.== "JS_NORMAL" = Prelude.Just FieldOptions'JS_NORMAL
+          | (k) Prelude.== "JS_STRING" = Prelude.Just FieldOptions'JS_STRING
+          | (k) Prelude.== "JS_NUMBER" = Prelude.Just FieldOptions'JS_NUMBER
         readEnum k
-          = (Prelude.>>=) (Text.Read.readMaybe k) Data.ProtoLens.maybeToEnum
+          = (Text.Read.readMaybe k) Prelude.>>= Data.ProtoLens.maybeToEnum
 instance Prelude.Bounded FieldOptions'JSType where
         minBound = FieldOptions'JS_NORMAL
         maxBound = FieldOptions'JS_NUMBER
@@ -2117,8 +3736,8 @@ instance Prelude.Enum FieldOptions'JSType where
         toEnum k__
           = Prelude.maybe
               (Prelude.error
-                 ((Prelude.++) "toEnum: unknown value for enum JSType: "
-                    (Prelude.show k__)))
+                 (("toEnum: unknown value for enum JSType: ") Prelude.++
+                    Prelude.show k__))
               Prelude.id
               (Data.ProtoLens.maybeToEnum k__)
         fromEnum FieldOptions'JS_NORMAL = 0
@@ -2197,138 +3816,122 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileDescriptorProto "name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'name
-                 (\ x__ y__ -> x__{_FileDescriptorProto'name = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'name
+               (\ x__ y__ -> x__{_FileDescriptorProto'name = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileDescriptorProto "maybe'name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'name
-                 (\ x__ y__ -> x__{_FileDescriptorProto'name = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'name
+               (\ x__ y__ -> x__{_FileDescriptorProto'name = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileDescriptorProto "package" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'package
-                 (\ x__ y__ -> x__{_FileDescriptorProto'package = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'package
+               (\ x__ y__ -> x__{_FileDescriptorProto'package = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileDescriptorProto "maybe'package" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'package
-                 (\ x__ y__ -> x__{_FileDescriptorProto'package = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'package
+               (\ x__ y__ -> x__{_FileDescriptorProto'package = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([Data.Text.Text]) =>
          Lens.Labels.HasLens' FileDescriptorProto "dependency" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'dependency
-                 (\ x__ y__ -> x__{_FileDescriptorProto'dependency = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'dependency
+               (\ x__ y__ -> x__{_FileDescriptorProto'dependency = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([Data.Int.Int32]) =>
          Lens.Labels.HasLens' FileDescriptorProto "publicDependency" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'publicDependency
-                 (\ x__ y__ -> x__{_FileDescriptorProto'publicDependency = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _FileDescriptorProto'publicDependency
+               (\ x__ y__ -> x__{_FileDescriptorProto'publicDependency = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([Data.Int.Int32]) =>
          Lens.Labels.HasLens' FileDescriptorProto "weakDependency" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'weakDependency
-                 (\ x__ y__ -> x__{_FileDescriptorProto'weakDependency = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'weakDependency
+               (\ x__ y__ -> x__{_FileDescriptorProto'weakDependency = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([DescriptorProto]) =>
          Lens.Labels.HasLens' FileDescriptorProto "messageType" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'messageType
-                 (\ x__ y__ -> x__{_FileDescriptorProto'messageType = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'messageType
+               (\ x__ y__ -> x__{_FileDescriptorProto'messageType = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([EnumDescriptorProto]) =>
          Lens.Labels.HasLens' FileDescriptorProto "enumType" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'enumType
-                 (\ x__ y__ -> x__{_FileDescriptorProto'enumType = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'enumType
+               (\ x__ y__ -> x__{_FileDescriptorProto'enumType = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([ServiceDescriptorProto]) =>
          Lens.Labels.HasLens' FileDescriptorProto "service" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'service
-                 (\ x__ y__ -> x__{_FileDescriptorProto'service = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'service
+               (\ x__ y__ -> x__{_FileDescriptorProto'service = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([FieldDescriptorProto]) =>
          Lens.Labels.HasLens' FileDescriptorProto "extension" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'extension
-                 (\ x__ y__ -> x__{_FileDescriptorProto'extension = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'extension
+               (\ x__ y__ -> x__{_FileDescriptorProto'extension = y__}))
+              Prelude.. Prelude.id
 instance a ~ (FileOptions) =>
          Lens.Labels.HasLens' FileDescriptorProto "options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'options
-                 (\ x__ y__ -> x__{_FileDescriptorProto'options = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'options
+               (\ x__ y__ -> x__{_FileDescriptorProto'options = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.defMessage
 instance a ~ (Prelude.Maybe FileOptions) =>
          Lens.Labels.HasLens' FileDescriptorProto "maybe'options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'options
-                 (\ x__ y__ -> x__{_FileDescriptorProto'options = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'options
+               (\ x__ y__ -> x__{_FileDescriptorProto'options = y__}))
+              Prelude.. Prelude.id
 instance a ~ (SourceCodeInfo) =>
          Lens.Labels.HasLens' FileDescriptorProto "sourceCodeInfo" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'sourceCodeInfo
-                 (\ x__ y__ -> x__{_FileDescriptorProto'sourceCodeInfo = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'sourceCodeInfo
+               (\ x__ y__ -> x__{_FileDescriptorProto'sourceCodeInfo = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.defMessage
 instance a ~ (Prelude.Maybe SourceCodeInfo) =>
          Lens.Labels.HasLens' FileDescriptorProto "maybe'sourceCodeInfo" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'sourceCodeInfo
-                 (\ x__ y__ -> x__{_FileDescriptorProto'sourceCodeInfo = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'sourceCodeInfo
+               (\ x__ y__ -> x__{_FileDescriptorProto'sourceCodeInfo = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileDescriptorProto "syntax" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'syntax
-                 (\ x__ y__ -> x__{_FileDescriptorProto'syntax = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'syntax
+               (\ x__ y__ -> x__{_FileDescriptorProto'syntax = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileDescriptorProto "maybe'syntax" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorProto'syntax
-                 (\ x__ y__ -> x__{_FileDescriptorProto'syntax = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'syntax
+               (\ x__ y__ -> x__{_FileDescriptorProto'syntax = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message FileDescriptorProto where
         messageName _
           = Data.Text.pack "google.protobuf.FileDescriptorProto"
@@ -2461,30 +4064,511 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                 _FileDescriptorProto'sourceCodeInfo = Prelude.Nothing,
                                 _FileDescriptorProto'syntax = Prelude.Nothing,
                                 _FileDescriptorProto'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     FileDescriptorProto ->
+                       Data.ProtoLens.Encoding.Bytes.Parser FileDescriptorProto
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "dependency"))
+                                 (\ !t -> Prelude.reverse t)
+                                 (Lens.Family2.over
+                                    (Lens.Labels.lensOf'
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "publicDependency"))
+                                    (\ !t -> Prelude.reverse t)
+                                    (Lens.Family2.over
+                                       (Lens.Labels.lensOf'
+                                          ((Lens.Labels.proxy#) ::
+                                             (Lens.Labels.Proxy#) "weakDependency"))
+                                       (\ !t -> Prelude.reverse t)
+                                       (Lens.Family2.over
+                                          (Lens.Labels.lensOf'
+                                             ((Lens.Labels.proxy#) ::
+                                                (Lens.Labels.Proxy#) "messageType"))
+                                          (\ !t -> Prelude.reverse t)
+                                          (Lens.Family2.over
+                                             (Lens.Labels.lensOf'
+                                                ((Lens.Labels.proxy#) ::
+                                                   (Lens.Labels.Proxy#) "enumType"))
+                                             (\ !t -> Prelude.reverse t)
+                                             (Lens.Family2.over
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "service"))
+                                                (\ !t -> Prelude.reverse t)
+                                                (Lens.Family2.over
+                                                   (Lens.Labels.lensOf'
+                                                      ((Lens.Labels.proxy#) ::
+                                                         (Lens.Labels.Proxy#) "extension"))
+                                                   (\ !t -> Prelude.reverse t)
+                                                   x))))))))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "name"))
+                                              y
+                                              x)
+                                18 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "package"))
+                                              y
+                                              x)
+                                26 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "dependency"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                80 -> do !y <- Prelude.fmap Prelude.fromIntegral
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "publicDependency"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                82 -> do bytes <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.getBytes
+                                                       (Prelude.fromIntegral len)
+                                         y <- Data.ProtoLens.Encoding.Bytes.runEither
+                                                (Data.ProtoLens.Encoding.Bytes.runParser
+                                                   (let ploop qs
+                                                          = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                               if packedEnd then Prelude.return qs
+                                                                 else
+                                                                 do !q <- Prelude.fmap
+                                                                            Prelude.fromIntegral
+                                                                            Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                    ploop ((:) q qs)
+                                                      in ploop [])
+                                                   bytes)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "publicDependency"))
+                                              (\ !t -> (y) Prelude.++ t)
+                                              x)
+                                88 -> do !y <- Prelude.fmap Prelude.fromIntegral
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "weakDependency"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                90 -> do bytes <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.getBytes
+                                                       (Prelude.fromIntegral len)
+                                         y <- Data.ProtoLens.Encoding.Bytes.runEither
+                                                (Data.ProtoLens.Encoding.Bytes.runParser
+                                                   (let ploop qs
+                                                          = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                               if packedEnd then Prelude.return qs
+                                                                 else
+                                                                 do !q <- Prelude.fmap
+                                                                            Prelude.fromIntegral
+                                                                            Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                    ploop ((:) q qs)
+                                                      in ploop [])
+                                                   bytes)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "weakDependency"))
+                                              (\ !t -> (y) Prelude.++ t)
+                                              x)
+                                34 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "messageType"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                42 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "enumType"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                50 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "service"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                58 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "extension"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                66 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (Data.ProtoLens.Encoding.Bytes.runParser
+                                                      Data.ProtoLens.unfinishedParseMessage
+                                                      value)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "options"))
+                                              y
+                                              x)
+                                74 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (Data.ProtoLens.Encoding.Bytes.runParser
+                                                      Data.ProtoLens.unfinishedParseMessage
+                                                      value)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "sourceCodeInfo"))
+                                              y
+                                              x)
+                                98 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "syntax"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'name"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                                         Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'package"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                                           Data.Monoid.<>
+                                           (((\ bs ->
+                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                   (Prelude.fromIntegral
+                                                      (Data.ByteString.length bs)))
+                                                  Data.Monoid.<>
+                                                  Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                              Prelude.. Data.Text.Encoding.encodeUtf8)
+                                             _v)
+                   Data.Monoid.<>
+                   (Data.Monoid.mconcat
+                      (Prelude.map
+                         (\ _v ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt 26) Data.Monoid.<>
+                              (((\ bs ->
+                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                 Prelude.. Data.Text.Encoding.encodeUtf8)
+                                _v)
+                         (Lens.Family2.view
+                            (Lens.Labels.lensOf'
+                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "dependency"))
+                            _x)))
+                     Data.Monoid.<>
+                     (Data.Monoid.mconcat
+                        (Prelude.map
+                           (\ _v ->
+                              (Data.ProtoLens.Encoding.Bytes.putVarInt 80) Data.Monoid.<>
+                                ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                   Prelude.fromIntegral)
+                                  _v)
+                           (Lens.Family2.view
+                              (Lens.Labels.lensOf'
+                                 ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "publicDependency"))
+                              _x)))
+                       Data.Monoid.<>
+                       (Data.Monoid.mconcat
+                          (Prelude.map
+                             (\ _v ->
+                                (Data.ProtoLens.Encoding.Bytes.putVarInt 88) Data.Monoid.<>
+                                  ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                     Prelude.fromIntegral)
+                                    _v)
+                             (Lens.Family2.view
+                                (Lens.Labels.lensOf'
+                                   ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "weakDependency"))
+                                _x)))
+                         Data.Monoid.<>
+                         (Data.Monoid.mconcat
+                            (Prelude.map
+                               (\ _v ->
+                                  (Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
+                                    (((\ bs ->
+                                         (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                            (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                           Data.Monoid.<>
+                                           Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                       Prelude..
+                                       (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                         Data.ProtoLens.unfinishedBuildMessage)
+                                      _v)
+                               (Lens.Family2.view
+                                  (Lens.Labels.lensOf'
+                                     ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "messageType"))
+                                  _x)))
+                           Data.Monoid.<>
+                           (Data.Monoid.mconcat
+                              (Prelude.map
+                                 (\ _v ->
+                                    (Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
+                                      (((\ bs ->
+                                           (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                              (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                             Data.Monoid.<>
+                                             Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                         Prelude..
+                                         (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                           Data.ProtoLens.unfinishedBuildMessage)
+                                        _v)
+                                 (Lens.Family2.view
+                                    (Lens.Labels.lensOf'
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "enumType"))
+                                    _x)))
+                             Data.Monoid.<>
+                             (Data.Monoid.mconcat
+                                (Prelude.map
+                                   (\ _v ->
+                                      (Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
+                                        (((\ bs ->
+                                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                               Data.Monoid.<>
+                                               Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                           Prelude..
+                                           (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                             Data.ProtoLens.unfinishedBuildMessage)
+                                          _v)
+                                   (Lens.Family2.view
+                                      (Lens.Labels.lensOf'
+                                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "service"))
+                                      _x)))
+                               Data.Monoid.<>
+                               (Data.Monoid.mconcat
+                                  (Prelude.map
+                                     (\ _v ->
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt 58) Data.Monoid.<>
+                                          (((\ bs ->
+                                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                  (Prelude.fromIntegral
+                                                     (Data.ByteString.length bs)))
+                                                 Data.Monoid.<>
+                                                 Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                             Prelude..
+                                             (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                               Data.ProtoLens.unfinishedBuildMessage)
+                                            _v)
+                                     (Lens.Family2.view
+                                        (Lens.Labels.lensOf'
+                                           ((Lens.Labels.proxy#) ::
+                                              (Lens.Labels.Proxy#) "extension"))
+                                        _x)))
+                                 Data.Monoid.<>
+                                 (case
+                                    Lens.Family2.view
+                                      (Lens.Labels.lensOf'
+                                         ((Lens.Labels.proxy#) ::
+                                            (Lens.Labels.Proxy#) "maybe'options"))
+                                      _x
+                                    of
+                                      (Prelude.Nothing) -> Data.Monoid.mempty
+                                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                            66)
+                                                           Data.Monoid.<>
+                                                           (((\ bs ->
+                                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                   (Prelude.fromIntegral
+                                                                      (Data.ByteString.length bs)))
+                                                                  Data.Monoid.<>
+                                                                  Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                    bs))
+                                                              Prelude..
+                                                              (Data.ProtoLens.Encoding.Bytes.runBuilder)
+                                                                Prelude..
+                                                                Data.ProtoLens.unfinishedBuildMessage)
+                                                             _v)
+                                   Data.Monoid.<>
+                                   (case
+                                      Lens.Family2.view
+                                        (Lens.Labels.lensOf'
+                                           ((Lens.Labels.proxy#) ::
+                                              (Lens.Labels.Proxy#) "maybe'sourceCodeInfo"))
+                                        _x
+                                      of
+                                        (Prelude.Nothing) -> Data.Monoid.mempty
+                                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                              74)
+                                                             Data.Monoid.<>
+                                                             (((\ bs ->
+                                                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                     (Prelude.fromIntegral
+                                                                        (Data.ByteString.length
+                                                                           bs)))
+                                                                    Data.Monoid.<>
+                                                                    Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                      bs))
+                                                                Prelude..
+                                                                (Data.ProtoLens.Encoding.Bytes.runBuilder)
+                                                                  Prelude..
+                                                                  Data.ProtoLens.unfinishedBuildMessage)
+                                                               _v)
+                                     Data.Monoid.<>
+                                     (case
+                                        Lens.Family2.view
+                                          (Lens.Labels.lensOf'
+                                             ((Lens.Labels.proxy#) ::
+                                                (Lens.Labels.Proxy#) "maybe'syntax"))
+                                          _x
+                                        of
+                                          (Prelude.Nothing) -> Data.Monoid.mempty
+                                          Prelude.Just
+                                            _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 98)
+                                                    Data.Monoid.<>
+                                                    (((\ bs ->
+                                                         (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                            (Prelude.fromIntegral
+                                                               (Data.ByteString.length bs)))
+                                                           Data.Monoid.<>
+                                                           Data.ProtoLens.Encoding.Bytes.putBytes
+                                                             bs))
+                                                       Prelude.. Data.Text.Encoding.encodeUtf8)
+                                                      _v)
+                                       Data.Monoid.<>
+                                       Data.Monoid.mconcat
+                                         (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                                            (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData FileDescriptorProto where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_FileDescriptorProto'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_FileDescriptorProto'name x__)
-                   (Control.DeepSeq.deepseq (_FileDescriptorProto'package x__)
-                      (Control.DeepSeq.deepseq (_FileDescriptorProto'dependency x__)
-                         (Control.DeepSeq.deepseq
-                            (_FileDescriptorProto'publicDependency x__)
-                            (Control.DeepSeq.deepseq (_FileDescriptorProto'weakDependency x__)
-                               (Control.DeepSeq.deepseq (_FileDescriptorProto'messageType x__)
-                                  (Control.DeepSeq.deepseq (_FileDescriptorProto'enumType x__)
-                                     (Control.DeepSeq.deepseq (_FileDescriptorProto'service x__)
-                                        (Control.DeepSeq.deepseq
-                                           (_FileDescriptorProto'extension x__)
-                                           (Control.DeepSeq.deepseq
-                                              (_FileDescriptorProto'options x__)
-                                              (Control.DeepSeq.deepseq
-                                                 (_FileDescriptorProto'sourceCodeInfo x__)
-                                                 (Control.DeepSeq.deepseq
-                                                    (_FileDescriptorProto'syntax x__)
-                                                    (())))))))))))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_FileDescriptorProto'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_FileDescriptorProto'name x__)
+                    (Control.DeepSeq.deepseq (_FileDescriptorProto'package x__)
+                       (Control.DeepSeq.deepseq (_FileDescriptorProto'dependency x__)
+                          (Control.DeepSeq.deepseq
+                             (_FileDescriptorProto'publicDependency x__)
+                             (Control.DeepSeq.deepseq (_FileDescriptorProto'weakDependency x__)
+                                (Control.DeepSeq.deepseq (_FileDescriptorProto'messageType x__)
+                                   (Control.DeepSeq.deepseq (_FileDescriptorProto'enumType x__)
+                                      (Control.DeepSeq.deepseq (_FileDescriptorProto'service x__)
+                                         (Control.DeepSeq.deepseq
+                                            (_FileDescriptorProto'extension x__)
+                                            (Control.DeepSeq.deepseq
+                                               (_FileDescriptorProto'options x__)
+                                               (Control.DeepSeq.deepseq
+                                                  (_FileDescriptorProto'sourceCodeInfo x__)
+                                                  (Control.DeepSeq.deepseq
+                                                     (_FileDescriptorProto'syntax x__)
+                                                     (()))))))))))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.file' @:: Lens' FileDescriptorSet [FileDescriptorProto]@
@@ -2503,10 +4587,9 @@ instance a ~ ([FileDescriptorProto]) =>
          Lens.Labels.HasLens' FileDescriptorSet "file" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileDescriptorSet'file
-                 (\ x__ y__ -> x__{_FileDescriptorSet'file = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileDescriptorSet'file
+               (\ x__ y__ -> x__{_FileDescriptorSet'file = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message FileDescriptorSet where
         messageName _ = Data.Text.pack "google.protobuf.FileDescriptorSet"
         fieldsByTag
@@ -2526,13 +4609,71 @@ instance Data.ProtoLens.Message FileDescriptorSet where
         defMessage
           = FileDescriptorSet{_FileDescriptorSet'file = [],
                               _FileDescriptorSet'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     FileDescriptorSet ->
+                       Data.ProtoLens.Encoding.Bytes.Parser FileDescriptorSet
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "file"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "file"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (Data.Monoid.mconcat
+                  (Prelude.map
+                     (\ _v ->
+                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude..
+                             (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                               Data.ProtoLens.unfinishedBuildMessage)
+                            _v)
+                     (Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "file"))
+                        _x)))
+                 Data.Monoid.<>
+                 Data.Monoid.mconcat
+                   (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                      (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData FileDescriptorSet where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_FileDescriptorSet'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_FileDescriptorSet'file x__) (()))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_FileDescriptorSet'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_FileDescriptorSet'file x__) (())))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.javaPackage' @:: Lens' FileOptions Data.Text.Text@
@@ -2613,331 +4754,292 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "javaPackage" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaPackage
-                 (\ x__ y__ -> x__{_FileOptions'javaPackage = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileOptions'javaPackage
+               (\ x__ y__ -> x__{_FileOptions'javaPackage = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "maybe'javaPackage" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaPackage
-                 (\ x__ y__ -> x__{_FileOptions'javaPackage = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'javaPackage
+               (\ x__ y__ -> x__{_FileOptions'javaPackage = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "javaOuterClassname" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaOuterClassname
-                 (\ x__ y__ -> x__{_FileOptions'javaOuterClassname = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileOptions'javaOuterClassname
+               (\ x__ y__ -> x__{_FileOptions'javaOuterClassname = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "maybe'javaOuterClassname" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaOuterClassname
-                 (\ x__ y__ -> x__{_FileOptions'javaOuterClassname = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'javaOuterClassname
+               (\ x__ y__ -> x__{_FileOptions'javaOuterClassname = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "javaMultipleFiles" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaMultipleFiles
-                 (\ x__ y__ -> x__{_FileOptions'javaMultipleFiles = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _FileOptions'javaMultipleFiles
+               (\ x__ y__ -> x__{_FileOptions'javaMultipleFiles = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "maybe'javaMultipleFiles" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaMultipleFiles
-                 (\ x__ y__ -> x__{_FileOptions'javaMultipleFiles = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'javaMultipleFiles
+               (\ x__ y__ -> x__{_FileOptions'javaMultipleFiles = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "javaGenerateEqualsAndHash" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaGenerateEqualsAndHash
-                 (\ x__ y__ -> x__{_FileOptions'javaGenerateEqualsAndHash = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens
+               _FileOptions'javaGenerateEqualsAndHash
+               (\ x__ y__ -> x__{_FileOptions'javaGenerateEqualsAndHash = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "maybe'javaGenerateEqualsAndHash"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaGenerateEqualsAndHash
-                 (\ x__ y__ -> x__{_FileOptions'javaGenerateEqualsAndHash = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _FileOptions'javaGenerateEqualsAndHash
+               (\ x__ y__ -> x__{_FileOptions'javaGenerateEqualsAndHash = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "javaStringCheckUtf8" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaStringCheckUtf8
-                 (\ x__ y__ -> x__{_FileOptions'javaStringCheckUtf8 = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _FileOptions'javaStringCheckUtf8
+               (\ x__ y__ -> x__{_FileOptions'javaStringCheckUtf8 = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "maybe'javaStringCheckUtf8" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaStringCheckUtf8
-                 (\ x__ y__ -> x__{_FileOptions'javaStringCheckUtf8 = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'javaStringCheckUtf8
+               (\ x__ y__ -> x__{_FileOptions'javaStringCheckUtf8 = y__}))
+              Prelude.. Prelude.id
 instance a ~ (FileOptions'OptimizeMode) =>
          Lens.Labels.HasLens' FileOptions "optimizeFor" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'optimizeFor
-                 (\ x__ y__ -> x__{_FileOptions'optimizeFor = y__}))
-              (Data.ProtoLens.maybeLens FileOptions'SPEED)
+          = (Lens.Family2.Unchecked.lens _FileOptions'optimizeFor
+               (\ x__ y__ -> x__{_FileOptions'optimizeFor = y__}))
+              Prelude.. Data.ProtoLens.maybeLens FileOptions'SPEED
 instance a ~ (Prelude.Maybe FileOptions'OptimizeMode) =>
          Lens.Labels.HasLens' FileOptions "maybe'optimizeFor" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'optimizeFor
-                 (\ x__ y__ -> x__{_FileOptions'optimizeFor = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'optimizeFor
+               (\ x__ y__ -> x__{_FileOptions'optimizeFor = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "goPackage" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'goPackage
-                 (\ x__ y__ -> x__{_FileOptions'goPackage = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileOptions'goPackage
+               (\ x__ y__ -> x__{_FileOptions'goPackage = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "maybe'goPackage" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'goPackage
-                 (\ x__ y__ -> x__{_FileOptions'goPackage = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'goPackage
+               (\ x__ y__ -> x__{_FileOptions'goPackage = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "ccGenericServices" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'ccGenericServices
-                 (\ x__ y__ -> x__{_FileOptions'ccGenericServices = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _FileOptions'ccGenericServices
+               (\ x__ y__ -> x__{_FileOptions'ccGenericServices = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "maybe'ccGenericServices" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'ccGenericServices
-                 (\ x__ y__ -> x__{_FileOptions'ccGenericServices = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'ccGenericServices
+               (\ x__ y__ -> x__{_FileOptions'ccGenericServices = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "javaGenericServices" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaGenericServices
-                 (\ x__ y__ -> x__{_FileOptions'javaGenericServices = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _FileOptions'javaGenericServices
+               (\ x__ y__ -> x__{_FileOptions'javaGenericServices = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "maybe'javaGenericServices" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'javaGenericServices
-                 (\ x__ y__ -> x__{_FileOptions'javaGenericServices = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'javaGenericServices
+               (\ x__ y__ -> x__{_FileOptions'javaGenericServices = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "pyGenericServices" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'pyGenericServices
-                 (\ x__ y__ -> x__{_FileOptions'pyGenericServices = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _FileOptions'pyGenericServices
+               (\ x__ y__ -> x__{_FileOptions'pyGenericServices = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "maybe'pyGenericServices" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'pyGenericServices
-                 (\ x__ y__ -> x__{_FileOptions'pyGenericServices = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'pyGenericServices
+               (\ x__ y__ -> x__{_FileOptions'pyGenericServices = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "phpGenericServices" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'phpGenericServices
-                 (\ x__ y__ -> x__{_FileOptions'phpGenericServices = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _FileOptions'phpGenericServices
+               (\ x__ y__ -> x__{_FileOptions'phpGenericServices = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "maybe'phpGenericServices" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'phpGenericServices
-                 (\ x__ y__ -> x__{_FileOptions'phpGenericServices = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'phpGenericServices
+               (\ x__ y__ -> x__{_FileOptions'phpGenericServices = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'deprecated
-                 (\ x__ y__ -> x__{_FileOptions'deprecated = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _FileOptions'deprecated
+               (\ x__ y__ -> x__{_FileOptions'deprecated = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "maybe'deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'deprecated
-                 (\ x__ y__ -> x__{_FileOptions'deprecated = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'deprecated
+               (\ x__ y__ -> x__{_FileOptions'deprecated = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "ccEnableArenas" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'ccEnableArenas
-                 (\ x__ y__ -> x__{_FileOptions'ccEnableArenas = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _FileOptions'ccEnableArenas
+               (\ x__ y__ -> x__{_FileOptions'ccEnableArenas = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' FileOptions "maybe'ccEnableArenas" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'ccEnableArenas
-                 (\ x__ y__ -> x__{_FileOptions'ccEnableArenas = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'ccEnableArenas
+               (\ x__ y__ -> x__{_FileOptions'ccEnableArenas = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "objcClassPrefix" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'objcClassPrefix
-                 (\ x__ y__ -> x__{_FileOptions'objcClassPrefix = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileOptions'objcClassPrefix
+               (\ x__ y__ -> x__{_FileOptions'objcClassPrefix = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "maybe'objcClassPrefix" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'objcClassPrefix
-                 (\ x__ y__ -> x__{_FileOptions'objcClassPrefix = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'objcClassPrefix
+               (\ x__ y__ -> x__{_FileOptions'objcClassPrefix = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "csharpNamespace" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'csharpNamespace
-                 (\ x__ y__ -> x__{_FileOptions'csharpNamespace = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileOptions'csharpNamespace
+               (\ x__ y__ -> x__{_FileOptions'csharpNamespace = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "maybe'csharpNamespace" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'csharpNamespace
-                 (\ x__ y__ -> x__{_FileOptions'csharpNamespace = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'csharpNamespace
+               (\ x__ y__ -> x__{_FileOptions'csharpNamespace = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "swiftPrefix" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'swiftPrefix
-                 (\ x__ y__ -> x__{_FileOptions'swiftPrefix = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileOptions'swiftPrefix
+               (\ x__ y__ -> x__{_FileOptions'swiftPrefix = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "maybe'swiftPrefix" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'swiftPrefix
-                 (\ x__ y__ -> x__{_FileOptions'swiftPrefix = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'swiftPrefix
+               (\ x__ y__ -> x__{_FileOptions'swiftPrefix = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "phpClassPrefix" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'phpClassPrefix
-                 (\ x__ y__ -> x__{_FileOptions'phpClassPrefix = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileOptions'phpClassPrefix
+               (\ x__ y__ -> x__{_FileOptions'phpClassPrefix = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "maybe'phpClassPrefix" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'phpClassPrefix
-                 (\ x__ y__ -> x__{_FileOptions'phpClassPrefix = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'phpClassPrefix
+               (\ x__ y__ -> x__{_FileOptions'phpClassPrefix = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "phpNamespace" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'phpNamespace
-                 (\ x__ y__ -> x__{_FileOptions'phpNamespace = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileOptions'phpNamespace
+               (\ x__ y__ -> x__{_FileOptions'phpNamespace = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "maybe'phpNamespace" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'phpNamespace
-                 (\ x__ y__ -> x__{_FileOptions'phpNamespace = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'phpNamespace
+               (\ x__ y__ -> x__{_FileOptions'phpNamespace = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "phpMetadataNamespace" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'phpMetadataNamespace
-                 (\ x__ y__ -> x__{_FileOptions'phpMetadataNamespace = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileOptions'phpMetadataNamespace
+               (\ x__ y__ -> x__{_FileOptions'phpMetadataNamespace = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "maybe'phpMetadataNamespace" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'phpMetadataNamespace
-                 (\ x__ y__ -> x__{_FileOptions'phpMetadataNamespace = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'phpMetadataNamespace
+               (\ x__ y__ -> x__{_FileOptions'phpMetadataNamespace = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "rubyPackage" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'rubyPackage
-                 (\ x__ y__ -> x__{_FileOptions'rubyPackage = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _FileOptions'rubyPackage
+               (\ x__ y__ -> x__{_FileOptions'rubyPackage = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' FileOptions "maybe'rubyPackage" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'rubyPackage
-                 (\ x__ y__ -> x__{_FileOptions'rubyPackage = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'rubyPackage
+               (\ x__ y__ -> x__{_FileOptions'rubyPackage = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' FileOptions "uninterpretedOption" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _FileOptions'uninterpretedOption
-                 (\ x__ y__ -> x__{_FileOptions'uninterpretedOption = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _FileOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_FileOptions'uninterpretedOption = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message FileOptions where
         messageName _ = Data.Text.pack "google.protobuf.FileOptions"
         fieldsByTag
@@ -3178,52 +5280,732 @@ instance Data.ProtoLens.Message FileOptions where
                         _FileOptions'rubyPackage = Prelude.Nothing,
                         _FileOptions'uninterpretedOption = [],
                         _FileOptions'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     FileOptions -> Data.ProtoLens.Encoding.Bytes.Parser FileOptions
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "javaPackage"))
+                                              y
+                                              x)
+                                66 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "javaOuterClassname"))
+                                              y
+                                              x)
+                                80 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "javaMultipleFiles"))
+                                              y
+                                              x)
+                                160 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#)
+                                                       "javaGenerateEqualsAndHash"))
+                                               y
+                                               x)
+                                216 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "javaStringCheckUtf8"))
+                                               y
+                                               x)
+                                72 -> do y <- Prelude.fmap Prelude.toEnum
+                                                (Prelude.fmap Prelude.fromIntegral
+                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "optimizeFor"))
+                                              y
+                                              x)
+                                90 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "goPackage"))
+                                              y
+                                              x)
+                                128 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "ccGenericServices"))
+                                               y
+                                               x)
+                                136 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "javaGenericServices"))
+                                               y
+                                               x)
+                                144 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "pyGenericServices"))
+                                               y
+                                               x)
+                                336 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "phpGenericServices"))
+                                               y
+                                               x)
+                                184 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "deprecated"))
+                                               y
+                                               x)
+                                248 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "ccEnableArenas"))
+                                               y
+                                               x)
+                                290 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "objcClassPrefix"))
+                                               y
+                                               x)
+                                298 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "csharpNamespace"))
+                                               y
+                                               x)
+                                314 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "swiftPrefix"))
+                                               y
+                                               x)
+                                322 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "phpClassPrefix"))
+                                               y
+                                               x)
+                                330 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "phpNamespace"))
+                                               y
+                                               x)
+                                354 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "phpMetadataNamespace"))
+                                               y
+                                               x)
+                                362 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "rubyPackage"))
+                                               y
+                                               x)
+                                7994 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                  (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.Encoding.Bytes.runEither
+                                                      (Data.ProtoLens.Encoding.Bytes.runParser
+                                                         Data.ProtoLens.unfinishedParseMessage
+                                                         value)
+                                           loop
+                                             (Lens.Family2.over
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                                (\ !t -> (:) y t)
+                                                x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'javaPackage"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                                         Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) ::
+                            (Lens.Labels.Proxy#) "maybe'javaOuterClassname"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 66)
+                                           Data.Monoid.<>
+                                           (((\ bs ->
+                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                   (Prelude.fromIntegral
+                                                      (Data.ByteString.length bs)))
+                                                  Data.Monoid.<>
+                                                  Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                              Prelude.. Data.Text.Encoding.encodeUtf8)
+                                             _v)
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) ::
+                              (Lens.Labels.Proxy#) "maybe'javaMultipleFiles"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 80)
+                                             Data.Monoid.<>
+                                             ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                (\ b -> if b then 1 else 0))
+                                               _v)
+                     Data.Monoid.<>
+                     (case
+                        Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) ::
+                                (Lens.Labels.Proxy#) "maybe'javaGenerateEqualsAndHash"))
+                          _x
+                        of
+                          (Prelude.Nothing) -> Data.Monoid.mempty
+                          Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 160)
+                                               Data.Monoid.<>
+                                               ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                  (\ b -> if b then 1 else 0))
+                                                 _v)
+                       Data.Monoid.<>
+                       (case
+                          Lens.Family2.view
+                            (Lens.Labels.lensOf'
+                               ((Lens.Labels.proxy#) ::
+                                  (Lens.Labels.Proxy#) "maybe'javaStringCheckUtf8"))
+                            _x
+                          of
+                            (Prelude.Nothing) -> Data.Monoid.mempty
+                            Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 216)
+                                                 Data.Monoid.<>
+                                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                    Prelude.. (\ b -> if b then 1 else 0))
+                                                   _v)
+                         Data.Monoid.<>
+                         (case
+                            Lens.Family2.view
+                              (Lens.Labels.lensOf'
+                                 ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'optimizeFor"))
+                              _x
+                            of
+                              (Prelude.Nothing) -> Data.Monoid.mempty
+                              Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 72)
+                                                   Data.Monoid.<>
+                                                   (((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                       Prelude.. Prelude.fromIntegral)
+                                                      Prelude.. Prelude.fromEnum)
+                                                     _v)
+                           Data.Monoid.<>
+                           (case
+                              Lens.Family2.view
+                                (Lens.Labels.lensOf'
+                                   ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'goPackage"))
+                                _x
+                              of
+                                (Prelude.Nothing) -> Data.Monoid.mempty
+                                Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 90)
+                                                     Data.Monoid.<>
+                                                     (((\ bs ->
+                                                          (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                             (Prelude.fromIntegral
+                                                                (Data.ByteString.length bs)))
+                                                            Data.Monoid.<>
+                                                            Data.ProtoLens.Encoding.Bytes.putBytes
+                                                              bs))
+                                                        Prelude.. Data.Text.Encoding.encodeUtf8)
+                                                       _v)
+                             Data.Monoid.<>
+                             (case
+                                Lens.Family2.view
+                                  (Lens.Labels.lensOf'
+                                     ((Lens.Labels.proxy#) ::
+                                        (Lens.Labels.Proxy#) "maybe'ccGenericServices"))
+                                  _x
+                                of
+                                  (Prelude.Nothing) -> Data.Monoid.mempty
+                                  Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 128)
+                                                       Data.Monoid.<>
+                                                       ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                          Prelude.. (\ b -> if b then 1 else 0))
+                                                         _v)
+                               Data.Monoid.<>
+                               (case
+                                  Lens.Family2.view
+                                    (Lens.Labels.lensOf'
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "maybe'javaGenericServices"))
+                                    _x
+                                  of
+                                    (Prelude.Nothing) -> Data.Monoid.mempty
+                                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 136)
+                                                         Data.Monoid.<>
+                                                         ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                            Prelude.. (\ b -> if b then 1 else 0))
+                                                           _v)
+                                 Data.Monoid.<>
+                                 (case
+                                    Lens.Family2.view
+                                      (Lens.Labels.lensOf'
+                                         ((Lens.Labels.proxy#) ::
+                                            (Lens.Labels.Proxy#) "maybe'pyGenericServices"))
+                                      _x
+                                    of
+                                      (Prelude.Nothing) -> Data.Monoid.mempty
+                                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                            144)
+                                                           Data.Monoid.<>
+                                                           ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                              Prelude.. (\ b -> if b then 1 else 0))
+                                                             _v)
+                                   Data.Monoid.<>
+                                   (case
+                                      Lens.Family2.view
+                                        (Lens.Labels.lensOf'
+                                           ((Lens.Labels.proxy#) ::
+                                              (Lens.Labels.Proxy#) "maybe'phpGenericServices"))
+                                        _x
+                                      of
+                                        (Prelude.Nothing) -> Data.Monoid.mempty
+                                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                              336)
+                                                             Data.Monoid.<>
+                                                             ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                                Prelude..
+                                                                (\ b -> if b then 1 else 0))
+                                                               _v)
+                                     Data.Monoid.<>
+                                     (case
+                                        Lens.Family2.view
+                                          (Lens.Labels.lensOf'
+                                             ((Lens.Labels.proxy#) ::
+                                                (Lens.Labels.Proxy#) "maybe'deprecated"))
+                                          _x
+                                        of
+                                          (Prelude.Nothing) -> Data.Monoid.mempty
+                                          Prelude.Just
+                                            _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 184)
+                                                    Data.Monoid.<>
+                                                    ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                       Prelude.. (\ b -> if b then 1 else 0))
+                                                      _v)
+                                       Data.Monoid.<>
+                                       (case
+                                          Lens.Family2.view
+                                            (Lens.Labels.lensOf'
+                                               ((Lens.Labels.proxy#) ::
+                                                  (Lens.Labels.Proxy#) "maybe'ccEnableArenas"))
+                                            _x
+                                          of
+                                            (Prelude.Nothing) -> Data.Monoid.mempty
+                                            Prelude.Just
+                                              _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 248)
+                                                      Data.Monoid.<>
+                                                      ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                         Prelude.. (\ b -> if b then 1 else 0))
+                                                        _v)
+                                         Data.Monoid.<>
+                                         (case
+                                            Lens.Family2.view
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "maybe'objcClassPrefix"))
+                                              _x
+                                            of
+                                              (Prelude.Nothing) -> Data.Monoid.mempty
+                                              Prelude.Just
+                                                _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 290)
+                                                        Data.Monoid.<>
+                                                        (((\ bs ->
+                                                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                (Prelude.fromIntegral
+                                                                   (Data.ByteString.length bs)))
+                                                               Data.Monoid.<>
+                                                               Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                 bs))
+                                                           Prelude.. Data.Text.Encoding.encodeUtf8)
+                                                          _v)
+                                           Data.Monoid.<>
+                                           (case
+                                              Lens.Family2.view
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "maybe'csharpNamespace"))
+                                                _x
+                                              of
+                                                (Prelude.Nothing) -> Data.Monoid.mempty
+                                                Prelude.Just
+                                                  _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                           298)
+                                                          Data.Monoid.<>
+                                                          (((\ bs ->
+                                                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                  (Prelude.fromIntegral
+                                                                     (Data.ByteString.length bs)))
+                                                                 Data.Monoid.<>
+                                                                 Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                   bs))
+                                                             Prelude..
+                                                             Data.Text.Encoding.encodeUtf8)
+                                                            _v)
+                                             Data.Monoid.<>
+                                             (case
+                                                Lens.Family2.view
+                                                  (Lens.Labels.lensOf'
+                                                     ((Lens.Labels.proxy#) ::
+                                                        (Lens.Labels.Proxy#) "maybe'swiftPrefix"))
+                                                  _x
+                                                of
+                                                  (Prelude.Nothing) -> Data.Monoid.mempty
+                                                  Prelude.Just
+                                                    _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                             314)
+                                                            Data.Monoid.<>
+                                                            (((\ bs ->
+                                                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                    (Prelude.fromIntegral
+                                                                       (Data.ByteString.length bs)))
+                                                                   Data.Monoid.<>
+                                                                   Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                     bs))
+                                                               Prelude..
+                                                               Data.Text.Encoding.encodeUtf8)
+                                                              _v)
+                                               Data.Monoid.<>
+                                               (case
+                                                  Lens.Family2.view
+                                                    (Lens.Labels.lensOf'
+                                                       ((Lens.Labels.proxy#) ::
+                                                          (Lens.Labels.Proxy#)
+                                                            "maybe'phpClassPrefix"))
+                                                    _x
+                                                  of
+                                                    (Prelude.Nothing) -> Data.Monoid.mempty
+                                                    Prelude.Just
+                                                      _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                               322)
+                                                              Data.Monoid.<>
+                                                              (((\ bs ->
+                                                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                      (Prelude.fromIntegral
+                                                                         (Data.ByteString.length
+                                                                            bs)))
+                                                                     Data.Monoid.<>
+                                                                     Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                       bs))
+                                                                 Prelude..
+                                                                 Data.Text.Encoding.encodeUtf8)
+                                                                _v)
+                                                 Data.Monoid.<>
+                                                 (case
+                                                    Lens.Family2.view
+                                                      (Lens.Labels.lensOf'
+                                                         ((Lens.Labels.proxy#) ::
+                                                            (Lens.Labels.Proxy#)
+                                                              "maybe'phpNamespace"))
+                                                      _x
+                                                    of
+                                                      (Prelude.Nothing) -> Data.Monoid.mempty
+                                                      Prelude.Just
+                                                        _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                 330)
+                                                                Data.Monoid.<>
+                                                                (((\ bs ->
+                                                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                        (Prelude.fromIntegral
+                                                                           (Data.ByteString.length
+                                                                              bs)))
+                                                                       Data.Monoid.<>
+                                                                       Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                         bs))
+                                                                   Prelude..
+                                                                   Data.Text.Encoding.encodeUtf8)
+                                                                  _v)
+                                                   Data.Monoid.<>
+                                                   (case
+                                                      Lens.Family2.view
+                                                        (Lens.Labels.lensOf'
+                                                           ((Lens.Labels.proxy#) ::
+                                                              (Lens.Labels.Proxy#)
+                                                                "maybe'phpMetadataNamespace"))
+                                                        _x
+                                                      of
+                                                        (Prelude.Nothing) -> Data.Monoid.mempty
+                                                        Prelude.Just
+                                                          _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                   354)
+                                                                  Data.Monoid.<>
+                                                                  (((\ bs ->
+                                                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                          (Prelude.fromIntegral
+                                                                             (Data.ByteString.length
+                                                                                bs)))
+                                                                         Data.Monoid.<>
+                                                                         Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                           bs))
+                                                                     Prelude..
+                                                                     Data.Text.Encoding.encodeUtf8)
+                                                                    _v)
+                                                     Data.Monoid.<>
+                                                     (case
+                                                        Lens.Family2.view
+                                                          (Lens.Labels.lensOf'
+                                                             ((Lens.Labels.proxy#) ::
+                                                                (Lens.Labels.Proxy#)
+                                                                  "maybe'rubyPackage"))
+                                                          _x
+                                                        of
+                                                          (Prelude.Nothing) -> Data.Monoid.mempty
+                                                          Prelude.Just
+                                                            _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                     362)
+                                                                    Data.Monoid.<>
+                                                                    (((\ bs ->
+                                                                         (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                            (Prelude.fromIntegral
+                                                                               (Data.ByteString.length
+                                                                                  bs)))
+                                                                           Data.Monoid.<>
+                                                                           Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                             bs))
+                                                                       Prelude..
+                                                                       Data.Text.Encoding.encodeUtf8)
+                                                                      _v)
+                                                       Data.Monoid.<>
+                                                       (Data.Monoid.mconcat
+                                                          (Prelude.map
+                                                             (\ _v ->
+                                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                   7994)
+                                                                  Data.Monoid.<>
+                                                                  (((\ bs ->
+                                                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                          (Prelude.fromIntegral
+                                                                             (Data.ByteString.length
+                                                                                bs)))
+                                                                         Data.Monoid.<>
+                                                                         Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                           bs))
+                                                                     Prelude..
+                                                                     (Data.ProtoLens.Encoding.Bytes.runBuilder)
+                                                                       Prelude..
+                                                                       Data.ProtoLens.unfinishedBuildMessage)
+                                                                    _v)
+                                                             (Lens.Family2.view
+                                                                (Lens.Labels.lensOf'
+                                                                   ((Lens.Labels.proxy#) ::
+                                                                      (Lens.Labels.Proxy#)
+                                                                        "uninterpretedOption"))
+                                                                _x)))
+                                                         Data.Monoid.<>
+                                                         Data.Monoid.mconcat
+                                                           (Prelude.map
+                                                              Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                                                              (Lens.Family2.view
+                                                                 Data.ProtoLens.unknownFields
+                                                                 _x)))
 instance Control.DeepSeq.NFData FileOptions where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_FileOptions'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_FileOptions'javaPackage x__)
-                   (Control.DeepSeq.deepseq (_FileOptions'javaOuterClassname x__)
-                      (Control.DeepSeq.deepseq (_FileOptions'javaMultipleFiles x__)
-                         (Control.DeepSeq.deepseq
-                            (_FileOptions'javaGenerateEqualsAndHash x__)
-                            (Control.DeepSeq.deepseq (_FileOptions'javaStringCheckUtf8 x__)
-                               (Control.DeepSeq.deepseq (_FileOptions'optimizeFor x__)
-                                  (Control.DeepSeq.deepseq (_FileOptions'goPackage x__)
-                                     (Control.DeepSeq.deepseq (_FileOptions'ccGenericServices x__)
-                                        (Control.DeepSeq.deepseq
-                                           (_FileOptions'javaGenericServices x__)
-                                           (Control.DeepSeq.deepseq
-                                              (_FileOptions'pyGenericServices x__)
-                                              (Control.DeepSeq.deepseq
-                                                 (_FileOptions'phpGenericServices x__)
-                                                 (Control.DeepSeq.deepseq
-                                                    (_FileOptions'deprecated x__)
-                                                    (Control.DeepSeq.deepseq
-                                                       (_FileOptions'ccEnableArenas x__)
-                                                       (Control.DeepSeq.deepseq
-                                                          (_FileOptions'objcClassPrefix x__)
-                                                          (Control.DeepSeq.deepseq
-                                                             (_FileOptions'csharpNamespace x__)
-                                                             (Control.DeepSeq.deepseq
-                                                                (_FileOptions'swiftPrefix x__)
-                                                                (Control.DeepSeq.deepseq
-                                                                   (_FileOptions'phpClassPrefix x__)
-                                                                   (Control.DeepSeq.deepseq
-                                                                      (_FileOptions'phpNamespace
-                                                                         x__)
-                                                                      (Control.DeepSeq.deepseq
-                                                                         (_FileOptions'phpMetadataNamespace
-                                                                            x__)
-                                                                         (Control.DeepSeq.deepseq
-                                                                            (_FileOptions'rubyPackage
-                                                                               x__)
-                                                                            (Control.DeepSeq.deepseq
-                                                                               (_FileOptions'uninterpretedOption
-                                                                                  x__)
-                                                                               (()))))))))))))))))))))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_FileOptions'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_FileOptions'javaPackage x__)
+                    (Control.DeepSeq.deepseq (_FileOptions'javaOuterClassname x__)
+                       (Control.DeepSeq.deepseq (_FileOptions'javaMultipleFiles x__)
+                          (Control.DeepSeq.deepseq
+                             (_FileOptions'javaGenerateEqualsAndHash x__)
+                             (Control.DeepSeq.deepseq (_FileOptions'javaStringCheckUtf8 x__)
+                                (Control.DeepSeq.deepseq (_FileOptions'optimizeFor x__)
+                                   (Control.DeepSeq.deepseq (_FileOptions'goPackage x__)
+                                      (Control.DeepSeq.deepseq (_FileOptions'ccGenericServices x__)
+                                         (Control.DeepSeq.deepseq
+                                            (_FileOptions'javaGenericServices x__)
+                                            (Control.DeepSeq.deepseq
+                                               (_FileOptions'pyGenericServices x__)
+                                               (Control.DeepSeq.deepseq
+                                                  (_FileOptions'phpGenericServices x__)
+                                                  (Control.DeepSeq.deepseq
+                                                     (_FileOptions'deprecated x__)
+                                                     (Control.DeepSeq.deepseq
+                                                        (_FileOptions'ccEnableArenas x__)
+                                                        (Control.DeepSeq.deepseq
+                                                           (_FileOptions'objcClassPrefix x__)
+                                                           (Control.DeepSeq.deepseq
+                                                              (_FileOptions'csharpNamespace x__)
+                                                              (Control.DeepSeq.deepseq
+                                                                 (_FileOptions'swiftPrefix x__)
+                                                                 (Control.DeepSeq.deepseq
+                                                                    (_FileOptions'phpClassPrefix
+                                                                       x__)
+                                                                    (Control.DeepSeq.deepseq
+                                                                       (_FileOptions'phpNamespace
+                                                                          x__)
+                                                                       (Control.DeepSeq.deepseq
+                                                                          (_FileOptions'phpMetadataNamespace
+                                                                             x__)
+                                                                          (Control.DeepSeq.deepseq
+                                                                             (_FileOptions'rubyPackage
+                                                                                x__)
+                                                                             (Control.DeepSeq.deepseq
+                                                                                (_FileOptions'uninterpretedOption
+                                                                                   x__)
+                                                                                (())))))))))))))))))))))))
 data FileOptions'OptimizeMode = FileOptions'SPEED
                               | FileOptions'CODE_SIZE
                               | FileOptions'LITE_RUNTIME
@@ -3237,12 +6019,12 @@ instance Data.ProtoLens.MessageEnum FileOptions'OptimizeMode where
         showEnum FileOptions'CODE_SIZE = "CODE_SIZE"
         showEnum FileOptions'LITE_RUNTIME = "LITE_RUNTIME"
         readEnum k
-          | (Prelude.==) k "SPEED" = Prelude.Just FileOptions'SPEED
-          | (Prelude.==) k "CODE_SIZE" = Prelude.Just FileOptions'CODE_SIZE
-          | (Prelude.==) k "LITE_RUNTIME" =
+          | (k) Prelude.== "SPEED" = Prelude.Just FileOptions'SPEED
+          | (k) Prelude.== "CODE_SIZE" = Prelude.Just FileOptions'CODE_SIZE
+          | (k) Prelude.== "LITE_RUNTIME" =
             Prelude.Just FileOptions'LITE_RUNTIME
         readEnum k
-          = (Prelude.>>=) (Text.Read.readMaybe k) Data.ProtoLens.maybeToEnum
+          = (Text.Read.readMaybe k) Prelude.>>= Data.ProtoLens.maybeToEnum
 instance Prelude.Bounded FileOptions'OptimizeMode where
         minBound = FileOptions'SPEED
         maxBound = FileOptions'LITE_RUNTIME
@@ -3250,8 +6032,8 @@ instance Prelude.Enum FileOptions'OptimizeMode where
         toEnum k__
           = Prelude.maybe
               (Prelude.error
-                 ((Prelude.++) "toEnum: unknown value for enum OptimizeMode: "
-                    (Prelude.show k__)))
+                 (("toEnum: unknown value for enum OptimizeMode: ") Prelude.++
+                    Prelude.show k__))
               Prelude.id
               (Data.ProtoLens.maybeToEnum k__)
         fromEnum FileOptions'SPEED = 1
@@ -3293,10 +6075,9 @@ instance a ~ ([GeneratedCodeInfo'Annotation]) =>
          Lens.Labels.HasLens' GeneratedCodeInfo "annotation" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'annotation
-                 (\ x__ y__ -> x__{_GeneratedCodeInfo'annotation = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'annotation
+               (\ x__ y__ -> x__{_GeneratedCodeInfo'annotation = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message GeneratedCodeInfo where
         messageName _ = Data.Text.pack "google.protobuf.GeneratedCodeInfo"
         fieldsByTag
@@ -3317,13 +6098,71 @@ instance Data.ProtoLens.Message GeneratedCodeInfo where
         defMessage
           = GeneratedCodeInfo{_GeneratedCodeInfo'annotation = [],
                               _GeneratedCodeInfo'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     GeneratedCodeInfo ->
+                       Data.ProtoLens.Encoding.Bytes.Parser GeneratedCodeInfo
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "annotation"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "annotation"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (Data.Monoid.mconcat
+                  (Prelude.map
+                     (\ _v ->
+                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude..
+                             (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                               Data.ProtoLens.unfinishedBuildMessage)
+                            _v)
+                     (Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "annotation"))
+                        _x)))
+                 Data.Monoid.<>
+                 Data.Monoid.mconcat
+                   (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                      (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData GeneratedCodeInfo where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_GeneratedCodeInfo'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_GeneratedCodeInfo'annotation x__) (()))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_GeneratedCodeInfo'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_GeneratedCodeInfo'annotation x__) (())))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.path' @:: Lens' GeneratedCodeInfo'Annotation [Data.Int.Int32]@
@@ -3354,62 +6193,55 @@ instance a ~ ([Data.Int.Int32]) =>
          Lens.Labels.HasLens' GeneratedCodeInfo'Annotation "path" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'path
-                 (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'path = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'path
+               (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'path = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' GeneratedCodeInfo'Annotation "sourceFile" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _GeneratedCodeInfo'Annotation'sourceFile
-                 (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'sourceFile = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens
+               _GeneratedCodeInfo'Annotation'sourceFile
+               (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'sourceFile = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' GeneratedCodeInfo'Annotation
            "maybe'sourceFile"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _GeneratedCodeInfo'Annotation'sourceFile
-                 (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'sourceFile = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _GeneratedCodeInfo'Annotation'sourceFile
+               (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'sourceFile = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' GeneratedCodeInfo'Annotation "begin" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'begin
-                 (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'begin = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'begin
+               (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'begin = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' GeneratedCodeInfo'Annotation "maybe'begin" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'begin
-                 (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'begin = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'begin
+               (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'begin = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Int.Int32) =>
          Lens.Labels.HasLens' GeneratedCodeInfo'Annotation "end" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'end
-                 (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'end = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'end
+               (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'end = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int32) =>
          Lens.Labels.HasLens' GeneratedCodeInfo'Annotation "maybe'end" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'end
-                 (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'end = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'end
+               (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'end = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
         messageName _
           = Data.Text.pack "google.protobuf.GeneratedCodeInfo.Annotation"
@@ -3464,19 +6296,172 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                                          _GeneratedCodeInfo'Annotation'begin = Prelude.Nothing,
                                          _GeneratedCodeInfo'Annotation'end = Prelude.Nothing,
                                          _GeneratedCodeInfo'Annotation'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     GeneratedCodeInfo'Annotation ->
+                       Data.ProtoLens.Encoding.Bytes.Parser GeneratedCodeInfo'Annotation
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "path"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                8 -> do !y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                        loop
+                                          (Lens.Family2.over
+                                             (Lens.Labels.lensOf'
+                                                ((Lens.Labels.proxy#) ::
+                                                   (Lens.Labels.Proxy#) "path"))
+                                             (\ !t -> (:) y t)
+                                             x)
+                                10 -> do bytes <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.getBytes
+                                                       (Prelude.fromIntegral len)
+                                         y <- Data.ProtoLens.Encoding.Bytes.runEither
+                                                (Data.ProtoLens.Encoding.Bytes.runParser
+                                                   (let ploop qs
+                                                          = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                               if packedEnd then Prelude.return qs
+                                                                 else
+                                                                 do !q <- Prelude.fmap
+                                                                            Prelude.fromIntegral
+                                                                            Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                    ploop ((:) q qs)
+                                                      in ploop [])
+                                                   bytes)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "path"))
+                                              (\ !t -> (y) Prelude.++ t)
+                                              x)
+                                18 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "sourceFile"))
+                                              y
+                                              x)
+                                24 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "begin"))
+                                              y
+                                              x)
+                                32 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "end"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (let p = Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "path"))
+                          _x
+                  in
+                  if Prelude.null p then Data.Monoid.mempty else
+                    (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                      (\ bs ->
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt
+                            (Prelude.fromIntegral (Data.ByteString.length bs)))
+                           Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs)
+                        (Data.ProtoLens.Encoding.Bytes.runBuilder
+                           (Data.Monoid.mconcat
+                              (Prelude.map
+                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                    Prelude.fromIntegral)
+                                 p))))
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'sourceFile"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                                           Data.Monoid.<>
+                                           (((\ bs ->
+                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                   (Prelude.fromIntegral
+                                                      (Data.ByteString.length bs)))
+                                                  Data.Monoid.<>
+                                                  Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                              Prelude.. Data.Text.Encoding.encodeUtf8)
+                                             _v)
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'begin"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 24)
+                                             Data.Monoid.<>
+                                             ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                Prelude.fromIntegral)
+                                               _v)
+                     Data.Monoid.<>
+                     (case
+                        Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'end"))
+                          _x
+                        of
+                          (Prelude.Nothing) -> Data.Monoid.mempty
+                          Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 32)
+                                               Data.Monoid.<>
+                                               ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                  Prelude.fromIntegral)
+                                                 _v)
+                       Data.Monoid.<>
+                       Data.Monoid.mconcat
+                         (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                            (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData GeneratedCodeInfo'Annotation where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq
-                (_GeneratedCodeInfo'Annotation'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_GeneratedCodeInfo'Annotation'path x__)
-                   (Control.DeepSeq.deepseq
-                      (_GeneratedCodeInfo'Annotation'sourceFile x__)
-                      (Control.DeepSeq.deepseq (_GeneratedCodeInfo'Annotation'begin x__)
-                         (Control.DeepSeq.deepseq (_GeneratedCodeInfo'Annotation'end x__)
-                            (())))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq
+                 (_GeneratedCodeInfo'Annotation'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_GeneratedCodeInfo'Annotation'path x__)
+                    (Control.DeepSeq.deepseq
+                       (_GeneratedCodeInfo'Annotation'sourceFile x__)
+                       (Control.DeepSeq.deepseq (_GeneratedCodeInfo'Annotation'begin x__)
+                          (Control.DeepSeq.deepseq (_GeneratedCodeInfo'Annotation'end x__)
+                             (()))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.messageSetWireFormat' @:: Lens' MessageOptions Prelude.Bool@
@@ -3507,81 +6492,72 @@ instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' MessageOptions "messageSetWireFormat" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MessageOptions'messageSetWireFormat
-                 (\ x__ y__ -> x__{_MessageOptions'messageSetWireFormat = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _MessageOptions'messageSetWireFormat
+               (\ x__ y__ -> x__{_MessageOptions'messageSetWireFormat = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' MessageOptions "maybe'messageSetWireFormat" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MessageOptions'messageSetWireFormat
-                 (\ x__ y__ -> x__{_MessageOptions'messageSetWireFormat = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _MessageOptions'messageSetWireFormat
+               (\ x__ y__ -> x__{_MessageOptions'messageSetWireFormat = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' MessageOptions "noStandardDescriptorAccessor"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _MessageOptions'noStandardDescriptorAccessor
-                 (\ x__ y__ ->
-                    x__{_MessageOptions'noStandardDescriptorAccessor = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens
+               _MessageOptions'noStandardDescriptorAccessor
+               (\ x__ y__ ->
+                  x__{_MessageOptions'noStandardDescriptorAccessor = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' MessageOptions
            "maybe'noStandardDescriptorAccessor"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _MessageOptions'noStandardDescriptorAccessor
-                 (\ x__ y__ ->
-                    x__{_MessageOptions'noStandardDescriptorAccessor = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _MessageOptions'noStandardDescriptorAccessor
+               (\ x__ y__ ->
+                  x__{_MessageOptions'noStandardDescriptorAccessor = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' MessageOptions "deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MessageOptions'deprecated
-                 (\ x__ y__ -> x__{_MessageOptions'deprecated = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _MessageOptions'deprecated
+               (\ x__ y__ -> x__{_MessageOptions'deprecated = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' MessageOptions "maybe'deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MessageOptions'deprecated
-                 (\ x__ y__ -> x__{_MessageOptions'deprecated = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _MessageOptions'deprecated
+               (\ x__ y__ -> x__{_MessageOptions'deprecated = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' MessageOptions "mapEntry" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MessageOptions'mapEntry
-                 (\ x__ y__ -> x__{_MessageOptions'mapEntry = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _MessageOptions'mapEntry
+               (\ x__ y__ -> x__{_MessageOptions'mapEntry = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' MessageOptions "maybe'mapEntry" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MessageOptions'mapEntry
-                 (\ x__ y__ -> x__{_MessageOptions'mapEntry = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _MessageOptions'mapEntry
+               (\ x__ y__ -> x__{_MessageOptions'mapEntry = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' MessageOptions "uninterpretedOption" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MessageOptions'uninterpretedOption
-                 (\ x__ y__ -> x__{_MessageOptions'uninterpretedOption = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _MessageOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_MessageOptions'uninterpretedOption = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message MessageOptions where
         messageName _ = Data.Text.pack "google.protobuf.MessageOptions"
         fieldsByTag
@@ -3647,19 +6623,170 @@ instance Data.ProtoLens.Message MessageOptions where
                            _MessageOptions'mapEntry = Prelude.Nothing,
                            _MessageOptions'uninterpretedOption = [],
                            _MessageOptions'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     MessageOptions ->
+                       Data.ProtoLens.Encoding.Bytes.Parser MessageOptions
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                8 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                               Data.ProtoLens.Encoding.Bytes.getVarInt
+                                        loop
+                                          (Lens.Family2.set
+                                             (Lens.Labels.lensOf'
+                                                ((Lens.Labels.proxy#) ::
+                                                   (Lens.Labels.Proxy#) "messageSetWireFormat"))
+                                             y
+                                             x)
+                                16 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#)
+                                                      "noStandardDescriptorAccessor"))
+                                              y
+                                              x)
+                                24 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "deprecated"))
+                                              y
+                                              x)
+                                56 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "mapEntry"))
+                                              y
+                                              x)
+                                7994 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                  (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.Encoding.Bytes.runEither
+                                                      (Data.ProtoLens.Encoding.Bytes.runParser
+                                                         Data.ProtoLens.unfinishedParseMessage
+                                                         value)
+                                           loop
+                                             (Lens.Family2.over
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                                (\ !t -> (:) y t)
+                                                x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) ::
+                          (Lens.Labels.Proxy#) "maybe'messageSetWireFormat"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 8)
+                                         Data.Monoid.<>
+                                         ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                            (\ b -> if b then 1 else 0))
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) ::
+                            (Lens.Labels.Proxy#) "maybe'noStandardDescriptorAccessor"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 16)
+                                           Data.Monoid.<>
+                                           ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                              (\ b -> if b then 1 else 0))
+                                             _v)
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'deprecated"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 24)
+                                             Data.Monoid.<>
+                                             ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                (\ b -> if b then 1 else 0))
+                                               _v)
+                     Data.Monoid.<>
+                     (case
+                        Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'mapEntry"))
+                          _x
+                        of
+                          (Prelude.Nothing) -> Data.Monoid.mempty
+                          Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 56)
+                                               Data.Monoid.<>
+                                               ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                  (\ b -> if b then 1 else 0))
+                                                 _v)
+                       Data.Monoid.<>
+                       (Data.Monoid.mconcat
+                          (Prelude.map
+                             (\ _v ->
+                                (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                                  (((\ bs ->
+                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                          (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                         Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                     Prelude..
+                                     (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                       Data.ProtoLens.unfinishedBuildMessage)
+                                    _v)
+                             (Lens.Family2.view
+                                (Lens.Labels.lensOf'
+                                   ((Lens.Labels.proxy#) ::
+                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                _x)))
+                         Data.Monoid.<>
+                         Data.Monoid.mconcat
+                           (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                              (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData MessageOptions where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_MessageOptions'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_MessageOptions'messageSetWireFormat x__)
-                   (Control.DeepSeq.deepseq
-                      (_MessageOptions'noStandardDescriptorAccessor x__)
-                      (Control.DeepSeq.deepseq (_MessageOptions'deprecated x__)
-                         (Control.DeepSeq.deepseq (_MessageOptions'mapEntry x__)
-                            (Control.DeepSeq.deepseq (_MessageOptions'uninterpretedOption x__)
-                               (()))))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_MessageOptions'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_MessageOptions'messageSetWireFormat x__)
+                    (Control.DeepSeq.deepseq
+                       (_MessageOptions'noStandardDescriptorAccessor x__)
+                       (Control.DeepSeq.deepseq (_MessageOptions'deprecated x__)
+                          (Control.DeepSeq.deepseq (_MessageOptions'mapEntry x__)
+                             (Control.DeepSeq.deepseq (_MessageOptions'uninterpretedOption x__)
+                                (())))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' MethodDescriptorProto Data.Text.Text@
@@ -3699,100 +6826,92 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' MethodDescriptorProto "name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'name
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'name = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _MethodDescriptorProto'name
+               (\ x__ y__ -> x__{_MethodDescriptorProto'name = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' MethodDescriptorProto "maybe'name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'name
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'name = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _MethodDescriptorProto'name
+               (\ x__ y__ -> x__{_MethodDescriptorProto'name = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' MethodDescriptorProto "inputType" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'inputType
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'inputType = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _MethodDescriptorProto'inputType
+               (\ x__ y__ -> x__{_MethodDescriptorProto'inputType = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' MethodDescriptorProto "maybe'inputType" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'inputType
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'inputType = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _MethodDescriptorProto'inputType
+               (\ x__ y__ -> x__{_MethodDescriptorProto'inputType = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' MethodDescriptorProto "outputType" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'outputType
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'outputType = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _MethodDescriptorProto'outputType
+               (\ x__ y__ -> x__{_MethodDescriptorProto'outputType = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' MethodDescriptorProto "maybe'outputType" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'outputType
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'outputType = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _MethodDescriptorProto'outputType
+               (\ x__ y__ -> x__{_MethodDescriptorProto'outputType = y__}))
+              Prelude.. Prelude.id
 instance a ~ (MethodOptions) =>
          Lens.Labels.HasLens' MethodDescriptorProto "options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'options
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'options = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+          = (Lens.Family2.Unchecked.lens _MethodDescriptorProto'options
+               (\ x__ y__ -> x__{_MethodDescriptorProto'options = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.defMessage
 instance a ~ (Prelude.Maybe MethodOptions) =>
          Lens.Labels.HasLens' MethodDescriptorProto "maybe'options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'options
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'options = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _MethodDescriptorProto'options
+               (\ x__ y__ -> x__{_MethodDescriptorProto'options = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' MethodDescriptorProto "clientStreaming" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'clientStreaming
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'clientStreaming = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens
+               _MethodDescriptorProto'clientStreaming
+               (\ x__ y__ -> x__{_MethodDescriptorProto'clientStreaming = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' MethodDescriptorProto "maybe'clientStreaming"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'clientStreaming
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'clientStreaming = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _MethodDescriptorProto'clientStreaming
+               (\ x__ y__ -> x__{_MethodDescriptorProto'clientStreaming = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' MethodDescriptorProto "serverStreaming" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'serverStreaming
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'serverStreaming = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens
+               _MethodDescriptorProto'serverStreaming
+               (\ x__ y__ -> x__{_MethodDescriptorProto'serverStreaming = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' MethodDescriptorProto "maybe'serverStreaming"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodDescriptorProto'serverStreaming
-                 (\ x__ y__ -> x__{_MethodDescriptorProto'serverStreaming = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _MethodDescriptorProto'serverStreaming
+               (\ x__ y__ -> x__{_MethodDescriptorProto'serverStreaming = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message MethodDescriptorProto where
         messageName _
           = Data.Text.pack "google.protobuf.MethodDescriptorProto"
@@ -3867,21 +6986,222 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
                                   _MethodDescriptorProto'clientStreaming = Prelude.Nothing,
                                   _MethodDescriptorProto'serverStreaming = Prelude.Nothing,
                                   _MethodDescriptorProto'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     MethodDescriptorProto ->
+                       Data.ProtoLens.Encoding.Bytes.Parser MethodDescriptorProto
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              x)
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "name"))
+                                              y
+                                              x)
+                                18 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "inputType"))
+                                              y
+                                              x)
+                                26 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "outputType"))
+                                              y
+                                              x)
+                                34 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (Data.ProtoLens.Encoding.Bytes.runParser
+                                                      Data.ProtoLens.unfinishedParseMessage
+                                                      value)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "options"))
+                                              y
+                                              x)
+                                40 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "clientStreaming"))
+                                              y
+                                              x)
+                                48 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "serverStreaming"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'name"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                                         Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'inputType"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                                           Data.Monoid.<>
+                                           (((\ bs ->
+                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                   (Prelude.fromIntegral
+                                                      (Data.ByteString.length bs)))
+                                                  Data.Monoid.<>
+                                                  Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                              Prelude.. Data.Text.Encoding.encodeUtf8)
+                                             _v)
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'outputType"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 26)
+                                             Data.Monoid.<>
+                                             (((\ bs ->
+                                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                     (Prelude.fromIntegral
+                                                        (Data.ByteString.length bs)))
+                                                    Data.Monoid.<>
+                                                    Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                Prelude.. Data.Text.Encoding.encodeUtf8)
+                                               _v)
+                     Data.Monoid.<>
+                     (case
+                        Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'options"))
+                          _x
+                        of
+                          (Prelude.Nothing) -> Data.Monoid.mempty
+                          Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 34)
+                                               Data.Monoid.<>
+                                               (((\ bs ->
+                                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                       (Prelude.fromIntegral
+                                                          (Data.ByteString.length bs)))
+                                                      Data.Monoid.<>
+                                                      Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                  Prelude..
+                                                  (Data.ProtoLens.Encoding.Bytes.runBuilder)
+                                                    Prelude.. Data.ProtoLens.unfinishedBuildMessage)
+                                                 _v)
+                       Data.Monoid.<>
+                       (case
+                          Lens.Family2.view
+                            (Lens.Labels.lensOf'
+                               ((Lens.Labels.proxy#) ::
+                                  (Lens.Labels.Proxy#) "maybe'clientStreaming"))
+                            _x
+                          of
+                            (Prelude.Nothing) -> Data.Monoid.mempty
+                            Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 40)
+                                                 Data.Monoid.<>
+                                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                    Prelude.. (\ b -> if b then 1 else 0))
+                                                   _v)
+                         Data.Monoid.<>
+                         (case
+                            Lens.Family2.view
+                              (Lens.Labels.lensOf'
+                                 ((Lens.Labels.proxy#) ::
+                                    (Lens.Labels.Proxy#) "maybe'serverStreaming"))
+                              _x
+                            of
+                              (Prelude.Nothing) -> Data.Monoid.mempty
+                              Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 48)
+                                                   Data.Monoid.<>
+                                                   ((Data.ProtoLens.Encoding.Bytes.putVarInt)
+                                                      Prelude.. (\ b -> if b then 1 else 0))
+                                                     _v)
+                           Data.Monoid.<>
+                           Data.Monoid.mconcat
+                             (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                                (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData MethodDescriptorProto where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_MethodDescriptorProto'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_MethodDescriptorProto'name x__)
-                   (Control.DeepSeq.deepseq (_MethodDescriptorProto'inputType x__)
-                      (Control.DeepSeq.deepseq (_MethodDescriptorProto'outputType x__)
-                         (Control.DeepSeq.deepseq (_MethodDescriptorProto'options x__)
-                            (Control.DeepSeq.deepseq
-                               (_MethodDescriptorProto'clientStreaming x__)
-                               (Control.DeepSeq.deepseq
-                                  (_MethodDescriptorProto'serverStreaming x__)
-                                  (())))))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_MethodDescriptorProto'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_MethodDescriptorProto'name x__)
+                    (Control.DeepSeq.deepseq (_MethodDescriptorProto'inputType x__)
+                       (Control.DeepSeq.deepseq (_MethodDescriptorProto'outputType x__)
+                          (Control.DeepSeq.deepseq (_MethodDescriptorProto'options x__)
+                             (Control.DeepSeq.deepseq
+                                (_MethodDescriptorProto'clientStreaming x__)
+                                (Control.DeepSeq.deepseq
+                                   (_MethodDescriptorProto'serverStreaming x__)
+                                   (()))))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' MethodOptions Prelude.Bool@
@@ -3906,42 +7226,38 @@ instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' MethodOptions "deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodOptions'deprecated
-                 (\ x__ y__ -> x__{_MethodOptions'deprecated = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _MethodOptions'deprecated
+               (\ x__ y__ -> x__{_MethodOptions'deprecated = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' MethodOptions "maybe'deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodOptions'deprecated
-                 (\ x__ y__ -> x__{_MethodOptions'deprecated = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _MethodOptions'deprecated
+               (\ x__ y__ -> x__{_MethodOptions'deprecated = y__}))
+              Prelude.. Prelude.id
 instance a ~ (MethodOptions'IdempotencyLevel) =>
          Lens.Labels.HasLens' MethodOptions "idempotencyLevel" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodOptions'idempotencyLevel
-                 (\ x__ y__ -> x__{_MethodOptions'idempotencyLevel = y__}))
-              (Data.ProtoLens.maybeLens MethodOptions'IDEMPOTENCY_UNKNOWN)
+          = (Lens.Family2.Unchecked.lens _MethodOptions'idempotencyLevel
+               (\ x__ y__ -> x__{_MethodOptions'idempotencyLevel = y__}))
+              Prelude..
+              Data.ProtoLens.maybeLens MethodOptions'IDEMPOTENCY_UNKNOWN
 instance a ~ (Prelude.Maybe MethodOptions'IdempotencyLevel) =>
          Lens.Labels.HasLens' MethodOptions "maybe'idempotencyLevel" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodOptions'idempotencyLevel
-                 (\ x__ y__ -> x__{_MethodOptions'idempotencyLevel = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _MethodOptions'idempotencyLevel
+               (\ x__ y__ -> x__{_MethodOptions'idempotencyLevel = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' MethodOptions "uninterpretedOption" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _MethodOptions'uninterpretedOption
-                 (\ x__ y__ -> x__{_MethodOptions'uninterpretedOption = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _MethodOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_MethodOptions'uninterpretedOption = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message MethodOptions where
         messageName _ = Data.Text.pack "google.protobuf.MethodOptions"
         fieldsByTag
@@ -3984,16 +7300,122 @@ instance Data.ProtoLens.Message MethodOptions where
                           _MethodOptions'idempotencyLevel = Prelude.Nothing,
                           _MethodOptions'uninterpretedOption = [],
                           _MethodOptions'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     MethodOptions -> Data.ProtoLens.Encoding.Bytes.Parser MethodOptions
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                264 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "deprecated"))
+                                               y
+                                               x)
+                                272 -> do y <- Prelude.fmap Prelude.toEnum
+                                                 (Prelude.fmap Prelude.fromIntegral
+                                                    Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "idempotencyLevel"))
+                                               y
+                                               x)
+                                7994 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                  (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.Encoding.Bytes.runEither
+                                                      (Data.ProtoLens.Encoding.Bytes.runParser
+                                                         Data.ProtoLens.unfinishedParseMessage
+                                                         value)
+                                           loop
+                                             (Lens.Family2.over
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                                (\ !t -> (:) y t)
+                                                x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'deprecated"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 264)
+                                         Data.Monoid.<>
+                                         ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                            (\ b -> if b then 1 else 0))
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) ::
+                            (Lens.Labels.Proxy#) "maybe'idempotencyLevel"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 272)
+                                           Data.Monoid.<>
+                                           (((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                               Prelude.fromIntegral)
+                                              Prelude.. Prelude.fromEnum)
+                                             _v)
+                   Data.Monoid.<>
+                   (Data.Monoid.mconcat
+                      (Prelude.map
+                         (\ _v ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                              (((\ bs ->
+                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                 Prelude..
+                                 (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                   Data.ProtoLens.unfinishedBuildMessage)
+                                _v)
+                         (Lens.Family2.view
+                            (Lens.Labels.lensOf'
+                               ((Lens.Labels.proxy#) ::
+                                  (Lens.Labels.Proxy#) "uninterpretedOption"))
+                            _x)))
+                     Data.Monoid.<>
+                     Data.Monoid.mconcat
+                       (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                          (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData MethodOptions where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_MethodOptions'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_MethodOptions'deprecated x__)
-                   (Control.DeepSeq.deepseq (_MethodOptions'idempotencyLevel x__)
-                      (Control.DeepSeq.deepseq (_MethodOptions'uninterpretedOption x__)
-                         (()))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_MethodOptions'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_MethodOptions'deprecated x__)
+                    (Control.DeepSeq.deepseq (_MethodOptions'idempotencyLevel x__)
+                       (Control.DeepSeq.deepseq (_MethodOptions'uninterpretedOption x__)
+                          (())))))
 data MethodOptions'IdempotencyLevel = MethodOptions'IDEMPOTENCY_UNKNOWN
                                     | MethodOptions'NO_SIDE_EFFECTS
                                     | MethodOptions'IDEMPOTENT
@@ -4008,14 +7430,14 @@ instance Data.ProtoLens.MessageEnum MethodOptions'IdempotencyLevel
         showEnum MethodOptions'NO_SIDE_EFFECTS = "NO_SIDE_EFFECTS"
         showEnum MethodOptions'IDEMPOTENT = "IDEMPOTENT"
         readEnum k
-          | (Prelude.==) k "IDEMPOTENCY_UNKNOWN" =
+          | (k) Prelude.== "IDEMPOTENCY_UNKNOWN" =
             Prelude.Just MethodOptions'IDEMPOTENCY_UNKNOWN
-          | (Prelude.==) k "NO_SIDE_EFFECTS" =
+          | (k) Prelude.== "NO_SIDE_EFFECTS" =
             Prelude.Just MethodOptions'NO_SIDE_EFFECTS
-          | (Prelude.==) k "IDEMPOTENT" =
+          | (k) Prelude.== "IDEMPOTENT" =
             Prelude.Just MethodOptions'IDEMPOTENT
         readEnum k
-          = (Prelude.>>=) (Text.Read.readMaybe k) Data.ProtoLens.maybeToEnum
+          = (Text.Read.readMaybe k) Prelude.>>= Data.ProtoLens.maybeToEnum
 instance Prelude.Bounded MethodOptions'IdempotencyLevel where
         minBound = MethodOptions'IDEMPOTENCY_UNKNOWN
         maxBound = MethodOptions'IDEMPOTENT
@@ -4023,8 +7445,8 @@ instance Prelude.Enum MethodOptions'IdempotencyLevel where
         toEnum k__
           = Prelude.maybe
               (Prelude.error
-                 ((Prelude.++) "toEnum: unknown value for enum IdempotencyLevel: "
-                    (Prelude.show k__)))
+                 (("toEnum: unknown value for enum IdempotencyLevel: ") Prelude.++
+                    Prelude.show k__))
               Prelude.id
               (Data.ProtoLens.maybeToEnum k__)
         fromEnum MethodOptions'IDEMPOTENCY_UNKNOWN = 0
@@ -4075,34 +7497,30 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' OneofDescriptorProto "name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _OneofDescriptorProto'name
-                 (\ x__ y__ -> x__{_OneofDescriptorProto'name = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _OneofDescriptorProto'name
+               (\ x__ y__ -> x__{_OneofDescriptorProto'name = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' OneofDescriptorProto "maybe'name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _OneofDescriptorProto'name
-                 (\ x__ y__ -> x__{_OneofDescriptorProto'name = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _OneofDescriptorProto'name
+               (\ x__ y__ -> x__{_OneofDescriptorProto'name = y__}))
+              Prelude.. Prelude.id
 instance a ~ (OneofOptions) =>
          Lens.Labels.HasLens' OneofDescriptorProto "options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _OneofDescriptorProto'options
-                 (\ x__ y__ -> x__{_OneofDescriptorProto'options = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+          = (Lens.Family2.Unchecked.lens _OneofDescriptorProto'options
+               (\ x__ y__ -> x__{_OneofDescriptorProto'options = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.defMessage
 instance a ~ (Prelude.Maybe OneofOptions) =>
          Lens.Labels.HasLens' OneofDescriptorProto "maybe'options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _OneofDescriptorProto'options
-                 (\ x__ y__ -> x__{_OneofDescriptorProto'options = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _OneofDescriptorProto'options
+               (\ x__ y__ -> x__{_OneofDescriptorProto'options = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message OneofDescriptorProto where
         messageName _
           = Data.Text.pack "google.protobuf.OneofDescriptorProto"
@@ -4135,14 +7553,104 @@ instance Data.ProtoLens.Message OneofDescriptorProto where
                                    Prelude.Nothing,
                                  _OneofDescriptorProto'options = Prelude.Nothing,
                                  _OneofDescriptorProto'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     OneofDescriptorProto ->
+                       Data.ProtoLens.Encoding.Bytes.Parser OneofDescriptorProto
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              x)
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "name"))
+                                              y
+                                              x)
+                                18 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (Data.ProtoLens.Encoding.Bytes.runParser
+                                                      Data.ProtoLens.unfinishedParseMessage
+                                                      value)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "options"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'name"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                                         Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'options"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 18)
+                                           Data.Monoid.<>
+                                           (((\ bs ->
+                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                   (Prelude.fromIntegral
+                                                      (Data.ByteString.length bs)))
+                                                  Data.Monoid.<>
+                                                  Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                              Prelude..
+                                              (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                                Data.ProtoLens.unfinishedBuildMessage)
+                                             _v)
+                   Data.Monoid.<>
+                   Data.Monoid.mconcat
+                     (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                        (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData OneofDescriptorProto where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_OneofDescriptorProto'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_OneofDescriptorProto'name x__)
-                   (Control.DeepSeq.deepseq (_OneofDescriptorProto'options x__) (())))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_OneofDescriptorProto'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_OneofDescriptorProto'name x__)
+                    (Control.DeepSeq.deepseq (_OneofDescriptorProto'options x__)
+                       (()))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' OneofOptions [UninterpretedOption]@
@@ -4160,10 +7668,9 @@ instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' OneofOptions "uninterpretedOption" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _OneofOptions'uninterpretedOption
-                 (\ x__ y__ -> x__{_OneofOptions'uninterpretedOption = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _OneofOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_OneofOptions'uninterpretedOption = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message OneofOptions where
         messageName _ = Data.Text.pack "google.protobuf.OneofOptions"
         fieldsByTag
@@ -4185,14 +7692,73 @@ instance Data.ProtoLens.Message OneofOptions where
         defMessage
           = OneofOptions{_OneofOptions'uninterpretedOption = [],
                          _OneofOptions'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     OneofOptions -> Data.ProtoLens.Encoding.Bytes.Parser OneofOptions
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                7994 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                  (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.Encoding.Bytes.runEither
+                                                      (Data.ProtoLens.Encoding.Bytes.runParser
+                                                         Data.ProtoLens.unfinishedParseMessage
+                                                         value)
+                                           loop
+                                             (Lens.Family2.over
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                                (\ !t -> (:) y t)
+                                                x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (Data.Monoid.mconcat
+                  (Prelude.map
+                     (\ _v ->
+                        (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude..
+                             (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                               Data.ProtoLens.unfinishedBuildMessage)
+                            _v)
+                     (Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) ::
+                              (Lens.Labels.Proxy#) "uninterpretedOption"))
+                        _x)))
+                 Data.Monoid.<>
+                 Data.Monoid.mconcat
+                   (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                      (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData OneofOptions where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_OneofOptions'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_OneofOptions'uninterpretedOption x__)
-                   (()))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_OneofOptions'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_OneofOptions'uninterpretedOption x__)
+                    (())))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' ServiceDescriptorProto Data.Text.Text@
@@ -4219,42 +7785,37 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' ServiceDescriptorProto "name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'name
-                 (\ x__ y__ -> x__{_ServiceDescriptorProto'name = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'name
+               (\ x__ y__ -> x__{_ServiceDescriptorProto'name = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' ServiceDescriptorProto "maybe'name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'name
-                 (\ x__ y__ -> x__{_ServiceDescriptorProto'name = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'name
+               (\ x__ y__ -> x__{_ServiceDescriptorProto'name = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([MethodDescriptorProto]) =>
          Lens.Labels.HasLens' ServiceDescriptorProto "method" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'method
-                 (\ x__ y__ -> x__{_ServiceDescriptorProto'method = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'method
+               (\ x__ y__ -> x__{_ServiceDescriptorProto'method = y__}))
+              Prelude.. Prelude.id
 instance a ~ (ServiceOptions) =>
          Lens.Labels.HasLens' ServiceDescriptorProto "options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'options
-                 (\ x__ y__ -> x__{_ServiceDescriptorProto'options = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+          = (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'options
+               (\ x__ y__ -> x__{_ServiceDescriptorProto'options = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.defMessage
 instance a ~ (Prelude.Maybe ServiceOptions) =>
          Lens.Labels.HasLens' ServiceDescriptorProto "maybe'options" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'options
-                 (\ x__ y__ -> x__{_ServiceDescriptorProto'options = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'options
+               (\ x__ y__ -> x__{_ServiceDescriptorProto'options = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message ServiceDescriptorProto where
         messageName _
           = Data.Text.pack "google.protobuf.ServiceDescriptorProto"
@@ -4298,17 +7859,141 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
                                    _ServiceDescriptorProto'method = [],
                                    _ServiceDescriptorProto'options = Prelude.Nothing,
                                    _ServiceDescriptorProto'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     ServiceDescriptorProto ->
+                       Data.ProtoLens.Encoding.Bytes.Parser ServiceDescriptorProto
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "method"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "name"))
+                                              y
+                                              x)
+                                18 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "method"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                26 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (Data.ProtoLens.Encoding.Bytes.runParser
+                                                      Data.ProtoLens.unfinishedParseMessage
+                                                      value)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "options"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'name"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 10)
+                                         Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
+                 Data.Monoid.<>
+                 (Data.Monoid.mconcat
+                    (Prelude.map
+                       (\ _v ->
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                            (((\ bs ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                               Prelude..
+                               (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                 Data.ProtoLens.unfinishedBuildMessage)
+                              _v)
+                       (Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "method"))
+                          _x)))
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'options"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 26)
+                                             Data.Monoid.<>
+                                             (((\ bs ->
+                                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                     (Prelude.fromIntegral
+                                                        (Data.ByteString.length bs)))
+                                                    Data.Monoid.<>
+                                                    Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                Prelude..
+                                                (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                                  Data.ProtoLens.unfinishedBuildMessage)
+                                               _v)
+                     Data.Monoid.<>
+                     Data.Monoid.mconcat
+                       (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                          (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData ServiceDescriptorProto where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq
-                (_ServiceDescriptorProto'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_ServiceDescriptorProto'name x__)
-                   (Control.DeepSeq.deepseq (_ServiceDescriptorProto'method x__)
-                      (Control.DeepSeq.deepseq (_ServiceDescriptorProto'options x__)
-                         (()))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq
+                 (_ServiceDescriptorProto'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_ServiceDescriptorProto'name x__)
+                    (Control.DeepSeq.deepseq (_ServiceDescriptorProto'method x__)
+                       (Control.DeepSeq.deepseq (_ServiceDescriptorProto'options x__)
+                          (())))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' ServiceOptions Prelude.Bool@
@@ -4329,26 +8014,23 @@ instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' ServiceOptions "deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _ServiceOptions'deprecated
-                 (\ x__ y__ -> x__{_ServiceOptions'deprecated = y__}))
-              (Data.ProtoLens.maybeLens Prelude.False)
+          = (Lens.Family2.Unchecked.lens _ServiceOptions'deprecated
+               (\ x__ y__ -> x__{_ServiceOptions'deprecated = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Prelude.False
 instance a ~ (Prelude.Maybe Prelude.Bool) =>
          Lens.Labels.HasLens' ServiceOptions "maybe'deprecated" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _ServiceOptions'deprecated
-                 (\ x__ y__ -> x__{_ServiceOptions'deprecated = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _ServiceOptions'deprecated
+               (\ x__ y__ -> x__{_ServiceOptions'deprecated = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' ServiceOptions "uninterpretedOption" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _ServiceOptions'uninterpretedOption
-                 (\ x__ y__ -> x__{_ServiceOptions'uninterpretedOption = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _ServiceOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_ServiceOptions'uninterpretedOption = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message ServiceOptions where
         messageName _ = Data.Text.pack "google.protobuf.ServiceOptions"
         fieldsByTag
@@ -4380,15 +8062,97 @@ instance Data.ProtoLens.Message ServiceOptions where
           = ServiceOptions{_ServiceOptions'deprecated = Prelude.Nothing,
                            _ServiceOptions'uninterpretedOption = [],
                            _ServiceOptions'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     ServiceOptions ->
+                       Data.ProtoLens.Encoding.Bytes.Parser ServiceOptions
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                264 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                          loop
+                                            (Lens.Family2.set
+                                               (Lens.Labels.lensOf'
+                                                  ((Lens.Labels.proxy#) ::
+                                                     (Lens.Labels.Proxy#) "deprecated"))
+                                               y
+                                               x)
+                                7994 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                  (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.Encoding.Bytes.runEither
+                                                      (Data.ProtoLens.Encoding.Bytes.runParser
+                                                         Data.ProtoLens.unfinishedParseMessage
+                                                         value)
+                                           loop
+                                             (Lens.Family2.over
+                                                (Lens.Labels.lensOf'
+                                                   ((Lens.Labels.proxy#) ::
+                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
+                                                (\ !t -> (:) y t)
+                                                x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (case
+                  Lens.Family2.view
+                    (Lens.Labels.lensOf'
+                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'deprecated"))
+                    _x
+                  of
+                    (Prelude.Nothing) -> Data.Monoid.mempty
+                    Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 264)
+                                         Data.Monoid.<>
+                                         ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                            (\ b -> if b then 1 else 0))
+                                           _v)
+                 Data.Monoid.<>
+                 (Data.Monoid.mconcat
+                    (Prelude.map
+                       (\ _v ->
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                            (((\ bs ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                               Prelude..
+                               (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                                 Data.ProtoLens.unfinishedBuildMessage)
+                              _v)
+                       (Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) ::
+                                (Lens.Labels.Proxy#) "uninterpretedOption"))
+                          _x)))
+                   Data.Monoid.<>
+                   Data.Monoid.mconcat
+                     (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                        (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData ServiceOptions where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_ServiceOptions'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_ServiceOptions'deprecated x__)
-                   (Control.DeepSeq.deepseq (_ServiceOptions'uninterpretedOption x__)
-                      (())))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_ServiceOptions'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_ServiceOptions'deprecated x__)
+                    (Control.DeepSeq.deepseq (_ServiceOptions'uninterpretedOption x__)
+                       (()))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.location' @:: Lens' SourceCodeInfo [SourceCodeInfo'Location]@
@@ -4406,10 +8170,9 @@ instance a ~ ([SourceCodeInfo'Location]) =>
          Lens.Labels.HasLens' SourceCodeInfo "location" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _SourceCodeInfo'location
-                 (\ x__ y__ -> x__{_SourceCodeInfo'location = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _SourceCodeInfo'location
+               (\ x__ y__ -> x__{_SourceCodeInfo'location = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message SourceCodeInfo where
         messageName _ = Data.Text.pack "google.protobuf.SourceCodeInfo"
         fieldsByTag
@@ -4430,13 +8193,71 @@ instance Data.ProtoLens.Message SourceCodeInfo where
         defMessage
           = SourceCodeInfo{_SourceCodeInfo'location = [],
                            _SourceCodeInfo'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     SourceCodeInfo ->
+                       Data.ProtoLens.Encoding.Bytes.Parser SourceCodeInfo
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "location"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "location"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (Data.Monoid.mconcat
+                  (Prelude.map
+                     (\ _v ->
+                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude..
+                             (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                               Data.ProtoLens.unfinishedBuildMessage)
+                            _v)
+                     (Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "location"))
+                        _x)))
+                 Data.Monoid.<>
+                 Data.Monoid.mconcat
+                   (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                      (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData SourceCodeInfo where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_SourceCodeInfo'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_SourceCodeInfo'location x__) (()))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_SourceCodeInfo'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_SourceCodeInfo'location x__) (())))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.path' @:: Lens' SourceCodeInfo'Location [Data.Int.Int32]@
@@ -4469,72 +8290,65 @@ instance a ~ ([Data.Int.Int32]) =>
          Lens.Labels.HasLens' SourceCodeInfo'Location "path" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'path
-                 (\ x__ y__ -> x__{_SourceCodeInfo'Location'path = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'path
+               (\ x__ y__ -> x__{_SourceCodeInfo'Location'path = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([Data.Int.Int32]) =>
          Lens.Labels.HasLens' SourceCodeInfo'Location "span" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'span
-                 (\ x__ y__ -> x__{_SourceCodeInfo'Location'span = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'span
+               (\ x__ y__ -> x__{_SourceCodeInfo'Location'span = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' SourceCodeInfo'Location "leadingComments" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _SourceCodeInfo'Location'leadingComments
-                 (\ x__ y__ -> x__{_SourceCodeInfo'Location'leadingComments = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens
+               _SourceCodeInfo'Location'leadingComments
+               (\ x__ y__ -> x__{_SourceCodeInfo'Location'leadingComments = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' SourceCodeInfo'Location
            "maybe'leadingComments"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _SourceCodeInfo'Location'leadingComments
-                 (\ x__ y__ -> x__{_SourceCodeInfo'Location'leadingComments = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _SourceCodeInfo'Location'leadingComments
+               (\ x__ y__ -> x__{_SourceCodeInfo'Location'leadingComments = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' SourceCodeInfo'Location "trailingComments" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _SourceCodeInfo'Location'trailingComments
-                 (\ x__ y__ ->
-                    x__{_SourceCodeInfo'Location'trailingComments = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens
+               _SourceCodeInfo'Location'trailingComments
+               (\ x__ y__ ->
+                  x__{_SourceCodeInfo'Location'trailingComments = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' SourceCodeInfo'Location
            "maybe'trailingComments"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _SourceCodeInfo'Location'trailingComments
-                 (\ x__ y__ ->
-                    x__{_SourceCodeInfo'Location'trailingComments = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _SourceCodeInfo'Location'trailingComments
+               (\ x__ y__ ->
+                  x__{_SourceCodeInfo'Location'trailingComments = y__}))
+              Prelude.. Prelude.id
 instance a ~ ([Data.Text.Text]) =>
          Lens.Labels.HasLens' SourceCodeInfo'Location
            "leadingDetachedComments"
            a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _SourceCodeInfo'Location'leadingDetachedComments
-                 (\ x__ y__ ->
-                    x__{_SourceCodeInfo'Location'leadingDetachedComments = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _SourceCodeInfo'Location'leadingDetachedComments
+               (\ x__ y__ ->
+                  x__{_SourceCodeInfo'Location'leadingDetachedComments = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message SourceCodeInfo'Location where
         messageName _
           = Data.Text.pack "google.protobuf.SourceCodeInfo.Location"
@@ -4600,22 +8414,255 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                                     _SourceCodeInfo'Location'trailingComments = Prelude.Nothing,
                                     _SourceCodeInfo'Location'leadingDetachedComments = [],
                                     _SourceCodeInfo'Location'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     SourceCodeInfo'Location ->
+                       Data.ProtoLens.Encoding.Bytes.Parser SourceCodeInfo'Location
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "path"))
+                                 (\ !t -> Prelude.reverse t)
+                                 (Lens.Family2.over
+                                    (Lens.Labels.lensOf'
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "span"))
+                                    (\ !t -> Prelude.reverse t)
+                                    (Lens.Family2.over
+                                       (Lens.Labels.lensOf'
+                                          ((Lens.Labels.proxy#) ::
+                                             (Lens.Labels.Proxy#) "leadingDetachedComments"))
+                                       (\ !t -> Prelude.reverse t)
+                                       x))))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                8 -> do !y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                        loop
+                                          (Lens.Family2.over
+                                             (Lens.Labels.lensOf'
+                                                ((Lens.Labels.proxy#) ::
+                                                   (Lens.Labels.Proxy#) "path"))
+                                             (\ !t -> (:) y t)
+                                             x)
+                                10 -> do bytes <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.getBytes
+                                                       (Prelude.fromIntegral len)
+                                         y <- Data.ProtoLens.Encoding.Bytes.runEither
+                                                (Data.ProtoLens.Encoding.Bytes.runParser
+                                                   (let ploop qs
+                                                          = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                               if packedEnd then Prelude.return qs
+                                                                 else
+                                                                 do !q <- Prelude.fmap
+                                                                            Prelude.fromIntegral
+                                                                            Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                    ploop ((:) q qs)
+                                                      in ploop [])
+                                                   bytes)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "path"))
+                                              (\ !t -> (y) Prelude.++ t)
+                                              x)
+                                16 -> do !y <- Prelude.fmap Prelude.fromIntegral
+                                                 Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "span"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                18 -> do bytes <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.getBytes
+                                                       (Prelude.fromIntegral len)
+                                         y <- Data.ProtoLens.Encoding.Bytes.runEither
+                                                (Data.ProtoLens.Encoding.Bytes.runParser
+                                                   (let ploop qs
+                                                          = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                               if packedEnd then Prelude.return qs
+                                                                 else
+                                                                 do !q <- Prelude.fmap
+                                                                            Prelude.fromIntegral
+                                                                            Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                                    ploop ((:) q qs)
+                                                      in ploop [])
+                                                   bytes)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "span"))
+                                              (\ !t -> (y) Prelude.++ t)
+                                              x)
+                                26 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "leadingComments"))
+                                              y
+                                              x)
+                                34 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "trailingComments"))
+                                              y
+                                              x)
+                                50 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (case Data.Text.Encoding.decodeUtf8' value of
+                                                         Prelude.Left err -> Prelude.Left
+                                                                               (Prelude.show err)
+                                                         Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "leadingDetachedComments"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (let p = Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "path"))
+                          _x
+                  in
+                  if Prelude.null p then Data.Monoid.mempty else
+                    (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                      (\ bs ->
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt
+                            (Prelude.fromIntegral (Data.ByteString.length bs)))
+                           Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs)
+                        (Data.ProtoLens.Encoding.Bytes.runBuilder
+                           (Data.Monoid.mconcat
+                              (Prelude.map
+                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                    Prelude.fromIntegral)
+                                 p))))
+                 Data.Monoid.<>
+                 (let p = Lens.Family2.view
+                            (Lens.Labels.lensOf'
+                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "span"))
+                            _x
+                    in
+                    if Prelude.null p then Data.Monoid.mempty else
+                      (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                        (\ bs ->
+                           (Data.ProtoLens.Encoding.Bytes.putVarInt
+                              (Prelude.fromIntegral (Data.ByteString.length bs)))
+                             Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs)
+                          (Data.ProtoLens.Encoding.Bytes.runBuilder
+                             (Data.Monoid.mconcat
+                                (Prelude.map
+                                   ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                      Prelude.fromIntegral)
+                                   p))))
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) ::
+                              (Lens.Labels.Proxy#) "maybe'leadingComments"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 26)
+                                             Data.Monoid.<>
+                                             (((\ bs ->
+                                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                     (Prelude.fromIntegral
+                                                        (Data.ByteString.length bs)))
+                                                    Data.Monoid.<>
+                                                    Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                Prelude.. Data.Text.Encoding.encodeUtf8)
+                                               _v)
+                     Data.Monoid.<>
+                     (case
+                        Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) ::
+                                (Lens.Labels.Proxy#) "maybe'trailingComments"))
+                          _x
+                        of
+                          (Prelude.Nothing) -> Data.Monoid.mempty
+                          Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 34)
+                                               Data.Monoid.<>
+                                               (((\ bs ->
+                                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                       (Prelude.fromIntegral
+                                                          (Data.ByteString.length bs)))
+                                                      Data.Monoid.<>
+                                                      Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                                  Prelude.. Data.Text.Encoding.encodeUtf8)
+                                                 _v)
+                       Data.Monoid.<>
+                       (Data.Monoid.mconcat
+                          (Prelude.map
+                             (\ _v ->
+                                (Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
+                                  (((\ bs ->
+                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                          (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                         Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                     Prelude.. Data.Text.Encoding.encodeUtf8)
+                                    _v)
+                             (Lens.Family2.view
+                                (Lens.Labels.lensOf'
+                                   ((Lens.Labels.proxy#) ::
+                                      (Lens.Labels.Proxy#) "leadingDetachedComments"))
+                                _x)))
+                         Data.Monoid.<>
+                         Data.Monoid.mconcat
+                           (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                              (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData SourceCodeInfo'Location where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq
-                (_SourceCodeInfo'Location'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_SourceCodeInfo'Location'path x__)
-                   (Control.DeepSeq.deepseq (_SourceCodeInfo'Location'span x__)
-                      (Control.DeepSeq.deepseq
-                         (_SourceCodeInfo'Location'leadingComments x__)
-                         (Control.DeepSeq.deepseq
-                            (_SourceCodeInfo'Location'trailingComments x__)
-                            (Control.DeepSeq.deepseq
-                               (_SourceCodeInfo'Location'leadingDetachedComments x__)
-                               (()))))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq
+                 (_SourceCodeInfo'Location'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_SourceCodeInfo'Location'path x__)
+                    (Control.DeepSeq.deepseq (_SourceCodeInfo'Location'span x__)
+                       (Control.DeepSeq.deepseq
+                          (_SourceCodeInfo'Location'leadingComments x__)
+                          (Control.DeepSeq.deepseq
+                             (_SourceCodeInfo'Location'trailingComments x__)
+                             (Control.DeepSeq.deepseq
+                                (_SourceCodeInfo'Location'leadingDetachedComments x__)
+                                (())))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' UninterpretedOption [UninterpretedOption'NamePart]@
@@ -4659,106 +8706,97 @@ instance a ~ ([UninterpretedOption'NamePart]) =>
          Lens.Labels.HasLens' UninterpretedOption "name" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'name
-                 (\ x__ y__ -> x__{_UninterpretedOption'name = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _UninterpretedOption'name
+               (\ x__ y__ -> x__{_UninterpretedOption'name = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' UninterpretedOption "identifierValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'identifierValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'identifierValue = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _UninterpretedOption'identifierValue
+               (\ x__ y__ -> x__{_UninterpretedOption'identifierValue = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' UninterpretedOption "maybe'identifierValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'identifierValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'identifierValue = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _UninterpretedOption'identifierValue
+               (\ x__ y__ -> x__{_UninterpretedOption'identifierValue = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Word.Word64) =>
          Lens.Labels.HasLens' UninterpretedOption "positiveIntValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'positiveIntValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'positiveIntValue = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens
+               _UninterpretedOption'positiveIntValue
+               (\ x__ y__ -> x__{_UninterpretedOption'positiveIntValue = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Word.Word64) =>
          Lens.Labels.HasLens' UninterpretedOption "maybe'positiveIntValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'positiveIntValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'positiveIntValue = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _UninterpretedOption'positiveIntValue
+               (\ x__ y__ -> x__{_UninterpretedOption'positiveIntValue = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Int.Int64) =>
          Lens.Labels.HasLens' UninterpretedOption "negativeIntValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'negativeIntValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'negativeIntValue = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens
+               _UninterpretedOption'negativeIntValue
+               (\ x__ y__ -> x__{_UninterpretedOption'negativeIntValue = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Int.Int64) =>
          Lens.Labels.HasLens' UninterpretedOption "maybe'negativeIntValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'negativeIntValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'negativeIntValue = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _UninterpretedOption'negativeIntValue
+               (\ x__ y__ -> x__{_UninterpretedOption'negativeIntValue = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Double) =>
          Lens.Labels.HasLens' UninterpretedOption "doubleValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'doubleValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'doubleValue = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _UninterpretedOption'doubleValue
+               (\ x__ y__ -> x__{_UninterpretedOption'doubleValue = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Prelude.Double) =>
          Lens.Labels.HasLens' UninterpretedOption "maybe'doubleValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'doubleValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'doubleValue = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _UninterpretedOption'doubleValue
+               (\ x__ y__ -> x__{_UninterpretedOption'doubleValue = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.ByteString.ByteString) =>
          Lens.Labels.HasLens' UninterpretedOption "stringValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'stringValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'stringValue = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _UninterpretedOption'stringValue
+               (\ x__ y__ -> x__{_UninterpretedOption'stringValue = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.ByteString.ByteString) =>
          Lens.Labels.HasLens' UninterpretedOption "maybe'stringValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'stringValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'stringValue = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _UninterpretedOption'stringValue
+               (\ x__ y__ -> x__{_UninterpretedOption'stringValue = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' UninterpretedOption "aggregateValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'aggregateValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'aggregateValue = y__}))
-              (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+          = (Lens.Family2.Unchecked.lens _UninterpretedOption'aggregateValue
+               (\ x__ y__ -> x__{_UninterpretedOption'aggregateValue = y__}))
+              Prelude.. Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault
 instance a ~ (Prelude.Maybe Data.Text.Text) =>
          Lens.Labels.HasLens' UninterpretedOption "maybe'aggregateValue" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'aggregateValue
-                 (\ x__ y__ -> x__{_UninterpretedOption'aggregateValue = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens _UninterpretedOption'aggregateValue
+               (\ x__ y__ -> x__{_UninterpretedOption'aggregateValue = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message UninterpretedOption where
         messageName _
           = Data.Text.pack "google.protobuf.UninterpretedOption"
@@ -4846,22 +8884,244 @@ instance Data.ProtoLens.Message UninterpretedOption where
                                 _UninterpretedOption'stringValue = Prelude.Nothing,
                                 _UninterpretedOption'aggregateValue = Prelude.Nothing,
                                 _UninterpretedOption'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     UninterpretedOption ->
+                       Data.ProtoLens.Encoding.Bytes.Parser UninterpretedOption
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              (Lens.Family2.over
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "name"))
+                                 (\ !t -> Prelude.reverse t)
+                                 x))
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                18 -> do !y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                              Data.ProtoLens.Encoding.Bytes.getBytes
+                                                                (Prelude.fromIntegral len)
+                                                  Data.ProtoLens.Encoding.Bytes.runEither
+                                                    (Data.ProtoLens.Encoding.Bytes.runParser
+                                                       Data.ProtoLens.unfinishedParseMessage
+                                                       value)
+                                         loop
+                                           (Lens.Family2.over
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "name"))
+                                              (\ !t -> (:) y t)
+                                              x)
+                                26 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "identifierValue"))
+                                              y
+                                              x)
+                                32 -> do y <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "positiveIntValue"))
+                                              y
+                                              x)
+                                40 -> do y <- Prelude.fmap Prelude.fromIntegral
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "negativeIntValue"))
+                                              y
+                                              x)
+                                49 -> do y <- Prelude.fmap
+                                                Data.ProtoLens.Encoding.Bytes.wordToDouble
+                                                Data.ProtoLens.Encoding.Bytes.getFixed64
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "doubleValue"))
+                                              y
+                                              x)
+                                58 -> do y <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                 Data.ProtoLens.Encoding.Bytes.getBytes
+                                                   (Prelude.fromIntegral len)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "stringValue"))
+                                              y
+                                              x)
+                                66 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "aggregateValue"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               (Data.Monoid.mconcat
+                  (Prelude.map
+                     (\ _v ->
+                        (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude..
+                             (Data.ProtoLens.Encoding.Bytes.runBuilder) Prelude..
+                               Data.ProtoLens.unfinishedBuildMessage)
+                            _v)
+                     (Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "name"))
+                        _x)))
+                 Data.Monoid.<>
+                 (case
+                    Lens.Family2.view
+                      (Lens.Labels.lensOf'
+                         ((Lens.Labels.proxy#) ::
+                            (Lens.Labels.Proxy#) "maybe'identifierValue"))
+                      _x
+                    of
+                      (Prelude.Nothing) -> Data.Monoid.mempty
+                      Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 26)
+                                           Data.Monoid.<>
+                                           (((\ bs ->
+                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                   (Prelude.fromIntegral
+                                                      (Data.ByteString.length bs)))
+                                                  Data.Monoid.<>
+                                                  Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                              Prelude.. Data.Text.Encoding.encodeUtf8)
+                                             _v)
+                   Data.Monoid.<>
+                   (case
+                      Lens.Family2.view
+                        (Lens.Labels.lensOf'
+                           ((Lens.Labels.proxy#) ::
+                              (Lens.Labels.Proxy#) "maybe'positiveIntValue"))
+                        _x
+                      of
+                        (Prelude.Nothing) -> Data.Monoid.mempty
+                        Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 32)
+                                             Data.Monoid.<>
+                                             Data.ProtoLens.Encoding.Bytes.putVarInt _v)
+                     Data.Monoid.<>
+                     (case
+                        Lens.Family2.view
+                          (Lens.Labels.lensOf'
+                             ((Lens.Labels.proxy#) ::
+                                (Lens.Labels.Proxy#) "maybe'negativeIntValue"))
+                          _x
+                        of
+                          (Prelude.Nothing) -> Data.Monoid.mempty
+                          Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 40)
+                                               Data.Monoid.<>
+                                               ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                                  Prelude.fromIntegral)
+                                                 _v)
+                       Data.Monoid.<>
+                       (case
+                          Lens.Family2.view
+                            (Lens.Labels.lensOf'
+                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'doubleValue"))
+                            _x
+                          of
+                            (Prelude.Nothing) -> Data.Monoid.mempty
+                            Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 49)
+                                                 Data.Monoid.<>
+                                                 ((Data.ProtoLens.Encoding.Bytes.putFixed64)
+                                                    Prelude..
+                                                    Data.ProtoLens.Encoding.Bytes.doubleToWord)
+                                                   _v)
+                         Data.Monoid.<>
+                         (case
+                            Lens.Family2.view
+                              (Lens.Labels.lensOf'
+                                 ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "maybe'stringValue"))
+                              _x
+                            of
+                              (Prelude.Nothing) -> Data.Monoid.mempty
+                              Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 58)
+                                                   Data.Monoid.<>
+                                                   (\ bs ->
+                                                      (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                         (Prelude.fromIntegral
+                                                            (Data.ByteString.length bs)))
+                                                        Data.Monoid.<>
+                                                        Data.ProtoLens.Encoding.Bytes.putBytes bs)
+                                                     _v)
+                           Data.Monoid.<>
+                           (case
+                              Lens.Family2.view
+                                (Lens.Labels.lensOf'
+                                   ((Lens.Labels.proxy#) ::
+                                      (Lens.Labels.Proxy#) "maybe'aggregateValue"))
+                                _x
+                              of
+                                (Prelude.Nothing) -> Data.Monoid.mempty
+                                Prelude.Just _v -> (Data.ProtoLens.Encoding.Bytes.putVarInt 66)
+                                                     Data.Monoid.<>
+                                                     (((\ bs ->
+                                                          (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                             (Prelude.fromIntegral
+                                                                (Data.ByteString.length bs)))
+                                                            Data.Monoid.<>
+                                                            Data.ProtoLens.Encoding.Bytes.putBytes
+                                                              bs))
+                                                        Prelude.. Data.Text.Encoding.encodeUtf8)
+                                                       _v)
+                             Data.Monoid.<>
+                             Data.Monoid.mconcat
+                               (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                                  (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData UninterpretedOption where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq (_UninterpretedOption'_unknownFields x__)
-                (Control.DeepSeq.deepseq (_UninterpretedOption'name x__)
-                   (Control.DeepSeq.deepseq (_UninterpretedOption'identifierValue x__)
-                      (Control.DeepSeq.deepseq
-                         (_UninterpretedOption'positiveIntValue x__)
-                         (Control.DeepSeq.deepseq
-                            (_UninterpretedOption'negativeIntValue x__)
-                            (Control.DeepSeq.deepseq (_UninterpretedOption'doubleValue x__)
-                               (Control.DeepSeq.deepseq (_UninterpretedOption'stringValue x__)
-                                  (Control.DeepSeq.deepseq (_UninterpretedOption'aggregateValue x__)
-                                     (()))))))))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq (_UninterpretedOption'_unknownFields x__)
+                 (Control.DeepSeq.deepseq (_UninterpretedOption'name x__)
+                    (Control.DeepSeq.deepseq (_UninterpretedOption'identifierValue x__)
+                       (Control.DeepSeq.deepseq
+                          (_UninterpretedOption'positiveIntValue x__)
+                          (Control.DeepSeq.deepseq
+                             (_UninterpretedOption'negativeIntValue x__)
+                             (Control.DeepSeq.deepseq (_UninterpretedOption'doubleValue x__)
+                                (Control.DeepSeq.deepseq (_UninterpretedOption'stringValue x__)
+                                   (Control.DeepSeq.deepseq
+                                      (_UninterpretedOption'aggregateValue x__)
+                                      (())))))))))
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.namePart' @:: Lens' UninterpretedOption'NamePart Data.Text.Text@
@@ -4883,20 +9143,19 @@ instance a ~ (Data.Text.Text) =>
          Lens.Labels.HasLens' UninterpretedOption'NamePart "namePart" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens _UninterpretedOption'NamePart'namePart
-                 (\ x__ y__ -> x__{_UninterpretedOption'NamePart'namePart = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _UninterpretedOption'NamePart'namePart
+               (\ x__ y__ -> x__{_UninterpretedOption'NamePart'namePart = y__}))
+              Prelude.. Prelude.id
 instance a ~ (Prelude.Bool) =>
          Lens.Labels.HasLens' UninterpretedOption'NamePart "isExtension" a
          where
         lensOf' _
-          = (Prelude..)
-              (Lens.Family2.Unchecked.lens
-                 _UninterpretedOption'NamePart'isExtension
-                 (\ x__ y__ ->
-                    x__{_UninterpretedOption'NamePart'isExtension = y__}))
-              Prelude.id
+          = (Lens.Family2.Unchecked.lens
+               _UninterpretedOption'NamePart'isExtension
+               (\ x__ y__ ->
+                  x__{_UninterpretedOption'NamePart'isExtension = y__}))
+              Prelude.. Prelude.id
 instance Data.ProtoLens.Message UninterpretedOption'NamePart where
         messageName _
           = Data.Text.pack "google.protobuf.UninterpretedOption.NamePart"
@@ -4932,15 +9191,81 @@ instance Data.ProtoLens.Message UninterpretedOption'NamePart where
                                          _UninterpretedOption'NamePart'isExtension =
                                            Data.ProtoLens.fieldDefault,
                                          _UninterpretedOption'NamePart'_unknownFields = ([])}
-        unfinishedParseMessage = Prelude.return Data.ProtoLens.defMessage
-        unfinishedBuildMessage = Prelude.const Data.Monoid.mempty
+        unfinishedParseMessage
+          = let loop ::
+                     UninterpretedOption'NamePart ->
+                       Data.ProtoLens.Encoding.Bytes.Parser UninterpretedOption'NamePart
+                loop x
+                  = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
+                       if end then
+                         Prelude.return
+                           (Lens.Family2.over Data.ProtoLens.unknownFields
+                              (\ !t -> Prelude.reverse t)
+                              x)
+                         else
+                         do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                            case tag of
+                                10 -> do y <- do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                             Data.ProtoLens.Encoding.Bytes.getBytes
+                                                               (Prelude.fromIntegral len)
+                                                 Data.ProtoLens.Encoding.Bytes.runEither
+                                                   (case Data.Text.Encoding.decodeUtf8' value of
+                                                        Prelude.Left err -> Prelude.Left
+                                                                              (Prelude.show err)
+                                                        Prelude.Right r -> Prelude.Right r)
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "namePart"))
+                                              y
+                                              x)
+                                16 -> do y <- Prelude.fmap ((Prelude./=) 0)
+                                                Data.ProtoLens.Encoding.Bytes.getVarInt
+                                         loop
+                                           (Lens.Family2.set
+                                              (Lens.Labels.lensOf'
+                                                 ((Lens.Labels.proxy#) ::
+                                                    (Lens.Labels.Proxy#) "isExtension"))
+                                              y
+                                              x)
+                                wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValue wire
+                                           loop
+                                             (Lens.Family2.over Data.ProtoLens.unknownFields
+                                                (\ !t -> (:) y t)
+                                                x)
+              in loop Data.ProtoLens.defMessage
+        unfinishedBuildMessage
+          = (\ _x ->
+               ((Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                  (((\ bs ->
+                       (Data.ProtoLens.Encoding.Bytes.putVarInt
+                          (Prelude.fromIntegral (Data.ByteString.length bs)))
+                         Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                     Prelude.. Data.Text.Encoding.encodeUtf8)
+                    (Lens.Family2.view
+                       (Lens.Labels.lensOf'
+                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "namePart"))
+                       _x))
+                 Data.Monoid.<>
+                 ((Data.ProtoLens.Encoding.Bytes.putVarInt 16) Data.Monoid.<>
+                    ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                       (\ b -> if b then 1 else 0))
+                      (Lens.Family2.view
+                         (Lens.Labels.lensOf'
+                            ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "isExtension"))
+                         _x))
+                   Data.Monoid.<>
+                   Data.Monoid.mconcat
+                     (Prelude.map Data.ProtoLens.Encoding.Wire.buildTaggedValue
+                        (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
 instance Control.DeepSeq.NFData UninterpretedOption'NamePart where
         rnf
-          = \ x__ ->
-              Control.DeepSeq.deepseq
-                (_UninterpretedOption'NamePart'_unknownFields x__)
-                (Control.DeepSeq.deepseq
-                   (_UninterpretedOption'NamePart'namePart x__)
-                   (Control.DeepSeq.deepseq
-                      (_UninterpretedOption'NamePart'isExtension x__)
-                      (())))
+          = (\ x__ ->
+               Control.DeepSeq.deepseq
+                 (_UninterpretedOption'NamePart'_unknownFields x__)
+                 (Control.DeepSeq.deepseq
+                    (_UninterpretedOption'NamePart'namePart x__)
+                    (Control.DeepSeq.deepseq
+                       (_UninterpretedOption'NamePart'isExtension x__)
+                       (()))))

--- a/proto-lens/src/Proto/Google/Protobuf/Descriptor_Fields.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Descriptor_Fields.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE ScopedTypeVariables, DataKinds, TypeFamilies,
   UndecidableInstances, GeneralizedNewtypeDeriving,
   MultiParamTypeClasses, FlexibleContexts, FlexibleInstances,
-  PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds #-}
+  PatternSynonyms, MagicHash, NoImplicitPrelude, DataKinds,
+  BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports#-}
 {-# OPTIONS_GHC -fno-warn-duplicate-exports#-}
 module Proto.Google.Protobuf.Descriptor_Fields where
@@ -11,6 +12,8 @@ import qualified Data.Int
 import qualified Data.Monoid
 import qualified Data.Word
 import qualified Data.ProtoLens
+import qualified Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Encoding.Wire
 import qualified Data.ProtoLens.Message.Enum
 import qualified Data.ProtoLens.Service.Types
 import qualified Lens.Family2
@@ -19,6 +22,7 @@ import qualified Data.Text
 import qualified Data.Map
 import qualified Data.ByteString
 import qualified Data.ByteString.Char8
+import qualified Data.Text.Encoding
 import qualified Lens.Labels
 import qualified Text.Read
 


### PR DESCRIPTION
…ns-protoc.

Previously we were always using reflected encodings in proto-lens-protoc.
After recent changes, the generated encodings are good enough that we can
use them to decode DescriptorProto.  So, this change makes us use the generated
encodings (for better testing) when the flag is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/290)
<!-- Reviewable:end -->
