### PR TITLE
Lower the default size of the nested benchmark.

### DIFF
--- a/proto-lens-benchmarks/benchmarks/Nested.hs
+++ b/proto-lens-benchmarks/benchmarks/Nested.hs
@@ -19,7 +19,7 @@ import Proto.Nested
 import Proto.Nested_Fields
 
 defaultNumValues :: Int
-defaultNumValues = 10000
+defaultNumValues = 100
 
 intValue :: Int32
 intValue = 5


### PR DESCRIPTION
Lowering the default size from 10k to 100 elements.  Some benchmarks
that looked identical under the old one are 2x different under the new
one.  That indicates the size was causing the benchmark to obscure
some of the overhead.  And since we already have the packing benchmark
to measure the effects of repeated fields, I think it's better for this one to
isolate other effects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/291)
<!-- Reviewable:end -->
