### PR TITLE
Use a `satisfy` function to Improve some test error messages.

### DIFF
--- a/proto-lens-tests/tests/any_test.hs
+++ b/proto-lens-tests/tests/any_test.hs
@@ -16,6 +16,12 @@ import Data.ProtoLens.TestUtil
 import Proto.Any
 import Proto.Any_Fields
 
+isDifferentType, isDecodingError :: Either UnpackError a -> Bool
+isDifferentType (Left DifferentType{}) = True
+isDifferentType _ = False
+isDecodingError (Left DecodingError{}) = True
+isDecodingError _ = False
+
 main :: IO ()
 main = testMain
     [ testCase "pack/unpack" $ do
@@ -26,15 +32,14 @@ main = testMain
           -- Unpacking to the right type succeeds
           Right foo @=? unpack any1
           -- Unpacking to the wrong type fails
-          Left DifferentType{} <- return (unpack any1 :: Either UnpackError Bar)
+          satisfies isDifferentType (unpack any1 :: Either UnpackError Bar)
           -- Unpacking with the wrong package name fails
           let any2 = any1 & typeUrl .~ "type.googleapis.com/blah.Foo"
-          Left DifferentType{} <- return (unpack any2 :: Either UnpackError Foo)
+          satisfies isDifferentType (unpack any2 :: Either UnpackError Foo)
           -- Unpacking with invalid byte data fails
           -- Foo expects a string for field #2
           let any3 = any1 & value .~ toStrictByteString (tagged 2 (VarInt 42))
-          Left (DecodingError _) <- return (unpack any3 :: Either UnpackError Foo)
-          return ()
+          satisfies isDecodingError (unpack any3 :: Either UnpackError Foo)
     , testProperty "packWithPrefix/unpack" $ \(ArbitraryMessage (foo :: Foo)) -> do
           -- Generate a random prefix containing in particular URL separation
           -- characters.  Make sure that no matter the prefix, "unpack"


### PR DESCRIPTION
Previously some tests were relying on pattern match in do bindings;
when they failed, the error messages gave no information about
the problematic value.

I added a `satisfy` function (inspired by some other testing
frameworks) and used it in a few places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/292)
<!-- Reviewable:end -->
