### PR TITLE
Fix incorrect types in the packing benchmark.

### DIFF
--- a/proto-lens-benchmarks/benchmarks/Packing.hs
+++ b/proto-lens-benchmarks/benchmarks/Packing.hs
@@ -24,13 +24,13 @@ benchmaker size =
     -- (less likely for the legend to overlap results) if smaller results
     -- are first.
     [ protoBenchmark "int32-packed"
-        (defMessage & num .~ replicate size 5 ::Int32Unpacked)
+        (defMessage & num .~ replicate size 5 :: Int32Packed)
     , protoBenchmark "int32-unpacked"
-        (defMessage & num .~ replicate size 5 ::Int32Packed)
+        (defMessage & num .~ replicate size 5 :: Int32Unpacked)
     , protoBenchmark "float-packed"
         (defMessage & num .~ replicate size 5 :: FloatPacked)
     , protoBenchmark "float-unpacked"
-        (defMessage & num .~ replicate size 5 :: FloatPacked)
+        (defMessage & num .~ replicate size 5 :: FloatUnpacked)
     ]
 
 main :: IO ()


### PR DESCRIPTION
Typos in #277; the benchmark names and proto types didn't match up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/297)
<!-- Reviewable:end -->
