### PR TITLE
Add a benchmark for fixed32-packed/unpacked (Word32).

### DIFF
--- a/proto-lens-benchmarks/benchmarks/Packing.hs
+++ b/proto-lens-benchmarks/benchmarks/Packing.hs
@@ -27,6 +27,10 @@ benchmaker size =
         (defMessage & num .~ replicate size 5 :: Int32Packed)
     , protoBenchmark "int32-unpacked"
         (defMessage & num .~ replicate size 5 :: Int32Unpacked)
+    , protoBenchmark "fixed32-packed"
+        (defMessage & num .~ replicate size 5 :: Fixed32Packed)
+    , protoBenchmark "fixed32-unpacked"
+        (defMessage & num .~ replicate size 5 :: Fixed32Unpacked)
     , protoBenchmark "float-packed"
         (defMessage & num .~ replicate size 5 :: FloatPacked)
     , protoBenchmark "float-unpacked"

--- a/proto-lens-benchmarks/benchmarks/packing.proto
+++ b/proto-lens-benchmarks/benchmarks/packing.proto
@@ -15,7 +15,7 @@ message Fixed32Unpacked {
 }
 
 message Fixed32Packed {
-  repeated fixed32 num = 1 [packed=false];
+  repeated fixed32 num = 1 [packed=true];
 }
 
 message FloatUnpacked {

--- a/proto-lens-benchmarks/benchmarks/packing.proto
+++ b/proto-lens-benchmarks/benchmarks/packing.proto
@@ -10,6 +10,14 @@ message Int32Packed {
   repeated int32 num = 1 [packed=true];
 }
 
+message Fixed32Unpacked {
+  repeated fixed32 num = 1 [packed=false];
+}
+
+message Fixed32Packed {
+  repeated fixed32 num = 1 [packed=false];
+}
+
 message FloatUnpacked {
   repeated float num = 1 [packed=false];
 }


### PR DESCRIPTION
When decoding/encoding floats, we read a fixed-length Word32
and then "cast" it to a `Float`.  This new benchmark helps separate
the cost of reading/writing that `Word32` from the cost of the
cast itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/301)
<!-- Reviewable:end -->
