### PR TITLE
Store repeated fields as Vectors.

### DIFF
--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -4,6 +4,9 @@
 - Capitalize enum values, and capitalize names of enum sub-messages (#270).
 - Track changes to `proto-lens` using generated Haskell code to
   encode/decode proto messages more quickly.
+- Store repeated fields as `Vector`s, and expose the internal representation
+  via new `vector'*` lenses.  Use `Vector`s for more efficient
+  encoding/decoding.
 
 ## v0.4.0.1
 - Bump the dependency on `base` and `containers` to support `ghc-8.6.1`.

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -5,7 +5,7 @@
 - Track changes to `proto-lens` using generated Haskell code to
   encode/decode proto messages more quickly.
 - Store repeated fields as `Vector`s, and expose the internal representation
-  via new `vector'*` lenses.  Use `Vector`s for more efficient
+  via new `vec'*` lenses.  Use `Vector`s for more efficient
   encoding/decoding.
 
 ## v0.4.0.1

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -35,9 +35,6 @@ library:
     - Data.ProtoLens.Compiler.Definitions
     - Data.ProtoLens.Compiler.Generate
     - Data.ProtoLens.Compiler.Plugin
-  other-modules:
-    - Data.ProtoLens.Compiler.Generate.Encoding
-    - Data.ProtoLens.Compiler.Generate.FieldEncoding
 
 executables:
   proto-lens-protoc:

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Combinators.hs
@@ -202,6 +202,9 @@ infixl 1 <--
 stmt :: Exp -> Stmt
 stmt = Syntax.Qualifier ()
 
+letStmt :: [Decl] -> Stmt
+letStmt = Syntax.LetStmt () . Syntax.BDecls ()
+
 type FieldUpdate = Syntax.FieldUpdate ()
 
 fieldUpdate :: QName -> Exp -> FieldUpdate
@@ -350,6 +353,9 @@ tyForAll vars ctx t = Syntax.TyForall () (Just vars)
 
 tyBang :: Type -> Type
 tyBang = Syntax.TyBang () (Syntax.BangedTy ()) (Syntax.NoUnpackPragma ())
+
+tyWildCard :: Type
+tyWildCard = Syntax.TyWildCard () Nothing
 
 -- | Application of a Haskell type or expression to an argument.
 -- For example, to represent @f x y@, you can write

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -38,6 +38,7 @@ module Data.ProtoLens.Compiler.Definitions
     , definedFieldType
     , definedType
     , camelCase
+    , overloadedFieldName
     ) where
 
 import Control.Applicative (liftA2)
@@ -644,3 +645,6 @@ capitalize :: Text -> Text
 capitalize s
     | Just (c, s') <- uncons s = cons (toUpper c) s'
     | otherwise = s
+
+overloadedFieldName :: FieldInfo -> Symbol
+overloadedFieldName = overloadedName . fieldName

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -46,6 +46,10 @@ import Proto.Google.Protobuf.Descriptor_Fields
 import Data.ProtoLens.Compiler.Combinators
 import Data.ProtoLens.Compiler.Definitions
 import Data.ProtoLens.Compiler.Generate.Encoding
+import Data.ProtoLens.Compiler.Generate.Field
+    ( hsFieldType
+    , hsFieldVectorType
+    )
 
 -- Whether to import the "Runtime" modules or the originals;
 -- e.g., Data.ProtoLens.Runtime.Data.Map vs Data.Map.
@@ -97,12 +101,17 @@ generateModule modName imports modifyImport definitions importedEnv services
               [ "Prelude", "Data.Int", "Data.Monoid", "Data.Word"
               , "Data.ProtoLens"
               , "Data.ProtoLens.Encoding.Bytes"
+              , "Data.ProtoLens.Encoding.Growing"
+              , "Data.ProtoLens.Encoding.Parser.Unsafe"
               , "Data.ProtoLens.Encoding.Wire"
               , "Data.ProtoLens.Message.Enum"
               , "Data.ProtoLens.Service.Types"
               , "Lens.Family2", "Lens.Family2.Unchecked"
               , "Data.Text",  "Data.Map", "Data.ByteString", "Data.ByteString.Char8"
               , "Data.Text.Encoding"
+              , "Data.Vector"
+              , "Data.Vector.Generic"
+              , "Data.Vector.Unboxed"
               , "Lens.Labels", "Text.Read"
               ]
             ++ map importSimple imports
@@ -262,7 +271,7 @@ generateMessageDecls fieldModName env protoName info =
     -- haskell: data Foo'Bar = Foo'Bar'c !Prelude.Float
     --                       | Foo'Bar's !Sub
     [ uncommented $ dataDecl (oneofTypeName oneofInfo)
-      [ conDecl consName [hsFieldType env $ fieldDescriptor f]
+      [ conDecl consName [hsFieldType env f]
       | c <- oneofCases oneofInfo
       , let f = caseField c
       , let consName = caseConstructorName c
@@ -340,7 +349,7 @@ generatePrisms env oneofInfo =
                                 -- The oneof sum type name
                              @@ (tyCon . unQual $ oneofTypeName oneofInfo)
                                 -- The field contained in the sum
-                             @@ (hsFieldType env $ fieldDescriptor f)
+                             @@ (hsFieldType env f)
         -- Generate function definition
         -- Prism' is constructed with Constructor for building value
         -- and Deconstructor and wrapping in Just for getting value
@@ -672,8 +681,8 @@ plainRecordField env (PlainFieldInfo kind f) = case kind of
         -- type instance Field "foo" Foo = Map Bar Baz
     MapField entry ->
             let mapType = "Data.Map.Map"
-                            @@ hsFieldType env (fieldDescriptor $ keyField entry)
-                            @@ hsFieldType env (fieldDescriptor $ valueField entry)
+                            @@ hsFieldType env (keyField entry)
+                            @@ hsFieldType env (valueField entry)
             in recordField mapType
                   [LensInstance
                        { lensSymbol = baseName
@@ -683,23 +692,36 @@ plainRecordField env (PlainFieldInfo kind f) = case kind of
         -- data Foo = Foo { _Foo_bar :: [Bar] }
         -- type instance Field "bar" Foo = [Bar]
     RepeatedField {} ->
-            recordField listType
-                  [LensInstance
+            recordField vectorType
+                  [ LensInstance
                       { lensSymbol = baseName
                       , lensFieldType = listType
+                      , lensExp = vectorAccessor
+                      }
+                  , LensInstance
+                      { lensSymbol = "vector'" <> baseName
+                      , lensFieldType = vectorType
                       , lensExp = rawAccessor
-                      }]
+                      }
+                  ]
   where
     recordField = RecordField (haskellRecordFieldName $ fieldName f)
     baseName = overloadedName $ fieldName f
     fd = fieldDescriptor f
-    baseType = hsFieldType env fd
+    baseType = hsFieldType env f
     maybeType = "Prelude.Maybe" @@ baseType
     listType = tyList baseType
+    vectorType = hsFieldVectorType f @@ baseType
     rawAccessor = "Prelude.id"
     maybeAccessor = "Data.ProtoLens.maybeLens"
                           @@ hsFieldValueDefault env fd
 
+vectorAccessor :: Exp
+vectorAccessor = "Lens.Family2.Unchecked.lens" @@ getter @@ setter
+  where
+    getter = "Data.Vector.Generic.toList"
+    setter = lambda ["_", "y__"]
+                $ "Data.Vector.Generic.fromList" @@ "y__"
 
 oneofRecordField :: Env QName -> OneofInfo -> RecordField
 oneofRecordField env oneofInfo
@@ -746,39 +768,9 @@ oneofRecordField env oneofInfo
             | c <- oneofCases oneofInfo
             , let f = caseField c
             , let baseName = overloadedName $ fieldName f
-            , let baseType = hsFieldType env $ fieldDescriptor f
+            , let baseType = hsFieldType env f
             , let maybeName = "maybe'" <> baseName
             ]
-
-hsFieldType :: Env QName -> FieldDescriptorProto -> Type
-hsFieldType env fd = case fd ^. type' of
-    FieldDescriptorProto'TYPE_DOUBLE -> "Prelude.Double"
-    FieldDescriptorProto'TYPE_FLOAT -> "Prelude.Float"
-    FieldDescriptorProto'TYPE_INT64 -> "Data.Int.Int64"
-    FieldDescriptorProto'TYPE_UINT64 -> "Data.Word.Word64"
-    FieldDescriptorProto'TYPE_INT32 -> "Data.Int.Int32"
-    FieldDescriptorProto'TYPE_FIXED64 -> "Data.Word.Word64"
-    FieldDescriptorProto'TYPE_FIXED32 -> "Data.Word.Word32"
-    FieldDescriptorProto'TYPE_BOOL -> "Prelude.Bool"
-    FieldDescriptorProto'TYPE_STRING -> "Data.Text.Text"
-    FieldDescriptorProto'TYPE_GROUP
-        | Message m <- definedFieldType fd env -> tyCon $ messageName m
-        | otherwise -> error $ "expected TYPE_GROUP for type name"
-                              ++ unpack (fd ^. typeName)
-    FieldDescriptorProto'TYPE_MESSAGE
-        | Message m <- definedFieldType fd env -> tyCon $ messageName m
-        | otherwise -> error $ "expected TYPE_MESSAGE for type name"
-                              ++ unpack (fd ^. typeName)
-    FieldDescriptorProto'TYPE_BYTES -> "Data.ByteString.ByteString"
-    FieldDescriptorProto'TYPE_UINT32 -> "Data.Word.Word32"
-    FieldDescriptorProto'TYPE_ENUM
-        | Enum e <- definedFieldType fd env -> tyCon $ enumName e
-        | otherwise -> error $ "expected TYPE_ENUM for type name"
-                              ++ unpack (fd ^. typeName)
-    FieldDescriptorProto'TYPE_SFIXED32 -> "Data.Int.Int32"
-    FieldDescriptorProto'TYPE_SFIXED64 -> "Data.Int.Int64"
-    FieldDescriptorProto'TYPE_SINT32 -> "Data.Int.Int32"
-    FieldDescriptorProto'TYPE_SINT64 -> "Data.Int.Int64"
 
 hsFieldDefault :: Env QName -> PlainFieldInfo -> Exp
 hsFieldDefault env f = case plainFieldKind f of
@@ -786,7 +778,7 @@ hsFieldDefault env f = case plainFieldKind f of
     OptionalValueField -> hsFieldValueDefault env fd
     OptionalMaybeField -> "Prelude.Nothing"
     MapField {} -> "Data.Map.empty"
-    RepeatedField {} -> list []
+    RepeatedField {} -> "Data.Vector.Generic.empty"
   where
     fd = fieldDescriptor (plainFieldInfo f)
 
@@ -901,7 +893,7 @@ messageInstance env protoName m =
                   [ fieldUpdate (unQual $ messageUnknownFields m)
                         "[]"]
       ]
-    , [ match "parseMessage" [] $ generatedParser m ]
+    , [ match "parseMessage" [] $ generatedParser env m ]
     , [ match "buildMessage" [] $ generatedBuilder m ]
     ]
   where
@@ -950,7 +942,7 @@ fieldDescriptorExpr env n f =
         @@ (fieldTypeDescriptorExpr (fd ^. type')
                 @::@
                     ("Data.ProtoLens.FieldTypeDescriptor"
-                        @@ hsFieldType env fd))
+                        @@ hsFieldType env (plainFieldInfo f)))
         @@ fieldAccessorExpr f)
     -- TODO: why is this type sig needed?
     @::@

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -699,7 +699,7 @@ plainRecordField env (PlainFieldInfo kind f) = case kind of
                       , lensExp = vectorAccessor
                       }
                   , LensInstance
-                      { lensSymbol = "vector'" <> baseName
+                      { lensSymbol = "vec'" <> baseName
                       , lensFieldType = vectorType
                       , lensExp = rawAccessor
                       }

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Encoding.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Encoding.hs
@@ -108,8 +108,8 @@ finish m s = do' $
         ...
         {checkMissingFields}
         over unknownFields reverse
-            $ set (lensOf' proxy# :: Proxy# vector'a) frozen'a
-            $ set (lensOf' proxy# :: Proxy# vector'b) frozen'b
+            $ set (lensOf' proxy# :: Proxy# vec'a) frozen'a
+            $ set (lensOf' proxy# :: Proxy# vec'b) frozen'b
             ...
             $ {partialMessage}
     -}
@@ -514,7 +514,7 @@ lensOfOneofField =
     lensOfExp . ("maybe'" <>) . overloadedName . oneofFieldName
 
 lensOfVectorField :: FieldInfo -> Exp
-lensOfVectorField = lensOfExp . ("vector'" <>) . overloadedFieldName
+lensOfVectorField = lensOfExp . ("vec'" <>) . overloadedFieldName
 
 -- | Build a field along with its tag.
 buildTaggedField :: FieldInfo -> Exp -> Exp

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Encoding.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Encoding.hs
@@ -123,13 +123,14 @@ finish m s = do' $
     [ stmt $ checkMissingFields s
     , stmt $ "Prelude.return" @@
         (over' unknownFields' "Prelude.reverse"
-            @@(foldr (\(finfo, frozen) x' -> "Lens.Family2.set"
-                                            @@ lensOfVectorField finfo
-                                            @@ var (unQual frozen)
-                                            @@ x')
-                     (partialMessage s)
-                     (Map.elems $ Map.intersectionWith (,)
-                        repeatedInfos frozenNames)))
+            @@(foldr (@@)
+                (partialMessage s)
+                (Map.intersectionWith
+                    (\finfo frozen ->
+                        "Lens.Family2.set"
+                            @@ lensOfVectorField finfo
+                            @@ var (unQual frozen))
+                repeatedInfos frozenNames)))
             ]
 
   where

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Encoding.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Encoding.hs
@@ -18,7 +18,7 @@ import Lens.Family2 (view, (^.))
 
 import Data.ProtoLens.Compiler.Combinators
 import Data.ProtoLens.Compiler.Definitions
-import Data.ProtoLens.Compiler.Generate.FieldEncoding
+import Data.ProtoLens.Compiler.Generate.Field
 import Data.ProtoLens.Encoding.Wire (joinTypeAndTag)
 
 import Proto.Google.Protobuf.Descriptor_Fields
@@ -27,24 +27,30 @@ import Proto.Google.Protobuf.Descriptor_Fields
     , type'
     )
 
-generatedParser :: MessageInfo Name -> Exp
-generatedParser m =
-    {- let loop :: T -> Bool -> Bool -> ... -> Parser T
-           loop x required'a required'b ... = ...
-       in loop defMessage True True ...
+generatedParser :: Env QName -> MessageInfo Name -> Exp
+generatedParser env m =
+    {- let loop :: T -> Bool -> Bool -> ...
+                   -> MVector RealWorld Int32 -> MVector RealWorld Float -> ...
+                   -> Parser T
+           loop x required'a required'b ... mutable'a mutable'b ... = ...
+       in "package.T" <?> do
+            mutable'a <- unsafeLiftIO new
+            mutable'b <- unsafeLiftIO new
+            ...
+            loop defMessage True True ... mutable'a mutable'b ...
     -}
     let' [typeSig [loop] loopSig
          , funBind [match loop (fmap pVar $ loopArgs names) loopExpr]
          ]
         $ "Data.ProtoLens.Encoding.Bytes.<?>"
-           @@ continue (initialParseState names)
+           @@ do' (startStmts ++ [stmt $ continue startExp])
            @@ stringExp msgName
   where
     ty = tyCon (unQual $ messageName m)
     msgName = Text.unpack (messageDescriptor m ^. name)
     loopSig = foldr tyFun
         ("Data.ProtoLens.Encoding.Bytes.Parser" @@ ty)
-        (loopArgs $ parseStateTypes m)
+        (loopArgs $ parseStateTypes env m)
 
     names = parseStateNames m
     exprs = fmap (var . unQual) names
@@ -52,20 +58,17 @@ generatedParser m =
     end = "end"
     loop = "loop"
 
-    continue, finish :: ParseState Exp -> Exp
+    (startStmts, startExp) = startParse names
+
+    continue :: ParseState Exp -> Exp
     continue s = foldl (@@) loop (loopArgs s)
-    finish s = do'
-                [stmt $ checkMissingFields s
-                , stmt $ "Prelude.return" @@ (reverseRepeatedFields m
-                                        $ partialMessage s)
-                ]
 
     loopExpr
         {- Group:
             do
               tag <- getVarInt
               case tag of
-                {groupEndTag} -> return $ {reverseRepeatedFields} x
+                {groupEndTag} -> {finish}
                 ... -- Regular message fields
 
           TODO(#282): fail the parse if we find a group-end tag
@@ -74,14 +77,14 @@ generatedParser m =
         | Just g <- groupFieldNumber m = do'
             [ tag <-- getVarInt'
             , stmt $ case' tag $
-                (pLitInt (groupEndTag g) --> finish exprs)
+                (pLitInt (groupEndTag g) --> finish m exprs)
                     : parseTagCases continue exprs m
             ]
         {- Regular message type:
               do
                 end <- atEnd
                 if end
-                    then return $ {reverseRepeatedFields} x
+                    then {finish}
                     else do
                         tag <- getVarInt
                         case tag of ...
@@ -89,12 +92,50 @@ generatedParser m =
         | otherwise = do'
             [ end <-- "Data.ProtoLens.Encoding.Bytes.atEnd"
             , stmt $
-                if' end (finish exprs)
+                if' end (finish m exprs)
                     $ do'
                         [ tag <-- getVarInt'
                         , stmt $ case' tag $ parseTagCases continue exprs m
                         ]
             ]
+
+{- | A Parser expression that finalizes the message.
+
+do
+    frozen'a <- unsafeLiftIO $ unsafeFreeze mutable'a
+    frozen'b <- unsafeLiftIO $ unsafeFreeze mutable'b
+    ...
+    {checkMissingFields}
+    over unknownFields reverse
+        $ set vector'a frozen'a
+        $ set vector'b frozen'b
+        ...
+        $ {partialMessage}
+-}
+finish :: MessageInfo Name -> ParseState Exp -> Exp
+finish m s = do' $
+    [ pVar frozen <-- unsafeLiftIO' @@
+                    ("Data.ProtoLens.Encoding.Growing.unsafeFreeze"
+                        @@ mutable)
+    | (frozen, mutable) <- Map.elems $ Map.intersectionWith (,)
+                                frozenNames (repeatedFieldMVectors s)
+    ]
+    ++
+    [ stmt $ checkMissingFields s
+    , stmt $ "Prelude.return" @@
+        (over' unknownFields' "Prelude.reverse"
+            @@(foldr (\(finfo, frozen) x' -> "Lens.Family2.set"
+                                            @@ lensOfVectorField finfo
+                                            @@ var (unQual frozen) @@ x')
+                     (partialMessage s)
+                     (Map.elems $ Map.intersectionWith (,)
+                        repeatedInfos frozenNames)))
+            ]
+
+  where
+    repeatedInfos = repeatedFields m
+    frozenNames = (\f -> nameFromSymbol $ "frozen'" <> overloadedFieldName f)
+                    <$> repeatedInfos
 
 -- | The state of the parsing loop.  Each instance of @v@ corresponds
 -- to an argument of the loop function.
@@ -104,11 +145,13 @@ data ParseState v = ParseState
     , requiredFieldsUnset :: Map.Map FieldId v
         -- ^ The required fields of the message, each corresponding to
         -- a @Bool@ argument of the loop.
+    , repeatedFieldMVectors :: Map.Map FieldId v
     } deriving Functor
 
 -- | Returns a sequence all arguments of the loop function.
 loopArgs :: ParseState v -> [v]
 loopArgs s = partialMessage s : Map.elems (requiredFieldsUnset s)
+                                ++ Map.elems (repeatedFieldMVectors s)
 
 -- | The proto name of the field.
 newtype FieldId = FieldId Text.Text
@@ -124,26 +167,46 @@ parseStateNames m = ParseState
     , requiredFieldsUnset = Map.fromList
         [ (fieldId f, nameFromSymbol $ "required'" <> n)
         | f <- messageFields m
-        , let n = overloadedName (fieldName $ plainFieldInfo f)
+        , let info = plainFieldInfo f
+        , let n = overloadedFieldName info
         , RequiredField <- [plainFieldKind f]
         ]
+    , repeatedFieldMVectors =
+        (\f -> nameFromSymbol $ "mutable'" <> overloadedFieldName f)
+            <$> repeatedFields m
     }
 
--- | The intial values of the loop arguments.
-initialParseState :: ParseState a -> ParseState Exp
-initialParseState s = ParseState
-    { partialMessage = "Data.ProtoLens.defMessage"
-    , requiredFieldsUnset = const "Prelude.True"
-                                <$> requiredFieldsUnset s
-    }
+repeatedFields :: MessageInfo Name -> Map.Map FieldId FieldInfo
+repeatedFields m = Map.fromList
+    [ (fieldId f, plainFieldInfo f)
+    | f <- messageFields m
+    , RepeatedField{} <- [plainFieldKind f]
+    ]
+
+-- | Intialize the values of the loop arguments.
+startParse :: ParseState Name -> ([Stmt], ParseState Exp)
+startParse names =
+    ([ pVar n <-- unsafeLiftIO' @@ "Data.ProtoLens.Encoding.Growing.new"
+     | n <- Map.elems mvectorNames
+     ]
+    , ParseState
+        { partialMessage = "Data.ProtoLens.defMessage"
+        , requiredFieldsUnset = const "Prelude.True"
+                                    <$> requiredFieldsUnset names
+        , repeatedFieldMVectors = var . unQual <$> mvectorNames
+        }
+    )
+  where
+    mvectorNames = repeatedFieldMVectors names
 
 -- | The types of the loop arguments.
-parseStateTypes :: MessageInfo Name -> ParseState Type
-parseStateTypes m = ParseState
+parseStateTypes :: Env QName -> MessageInfo Name -> ParseState Type
+parseStateTypes env m = ParseState
     { partialMessage = tyCon (unQual $ messageName m)
     , requiredFieldsUnset = fmap (const "Prelude.Bool")
                             $ requiredFieldsUnset
                             $ parseStateNames m
+    , repeatedFieldMVectors = growingType env <$> repeatedFields m
     }
 
 -- | Transform the loop arguments by applying a given function
@@ -161,13 +224,20 @@ markRequiredField f s =
     s { requiredFieldsUnset = Map.insert f "Prelude.False"
                                 $ requiredFieldsUnset s }
 
-reverseRepeatedFields :: MessageInfo Name -> Exp -> Exp
-reverseRepeatedFields m = foldr (.) id $
-    (over' unknownFields' "Prelude.reverse" @@) :
-    [ (overField (plainFieldInfo f) "Prelude.reverse" @@)
-    | f <- messageFields m
-    , RepeatedField{} <- [plainFieldKind f]
-    ]
+-- | Append to the given repeated field.
+appendToRepeated :: FieldId -> Exp -> ParseState Exp -> (Stmt, ParseState Exp)
+appendToRepeated f x s =
+    ( v <-- unsafeLiftIO'
+                @@ ("Data.ProtoLens.Encoding.Growing.append"
+                        @@ (repeatedFieldMVectors s Map.! f)
+                        @@ x)
+    , s { repeatedFieldMVectors =
+                            Map.insert f (var $ unQual v)
+                                $ repeatedFieldMVectors s
+                        }
+    )
+  where
+    v = "v"
 
 -- | Returns an Exp of type @Parser ()@
 -- which fails if any of the missing fields aren't set.
@@ -251,15 +321,19 @@ parseFieldCase loop x f = case plainFieldKind f of
                . markRequiredField (fieldId f)
                $ x
         ]
-    unpackedCase = pLitInt (fieldTag info) --> do'
-        [ bangPat y <-- parseField info
-        , stmt . loop . updateParseState (overField info (cons @@ y))
-            $ x
-        ]
+    unpackedCase = pLitInt (fieldTag info) -->
+        let (appendStmt, x') = appendToRepeated (fieldId f) y x
+        in do'
+            [ bangPat y <-- parseField info
+            , appendStmt
+            , stmt . loop $ x'
+            ]
     packedCase = pLitInt (packedFieldTag info) --> do'
-        [ y <-- isolatedLengthy (parsePackedField info)
-        , stmt . loop . updateParseState (overField info ("Prelude.++" @@ y))
-            $ x
+        [ y <-- isolatedLengthy (parsePackedField info
+                                    @@ repeatedFieldMVectors x Map.! fieldId f)
+        , stmt $ loop x { repeatedFieldMVectors =
+                                Map.insert (fieldId f) (var $ unQual y)
+                                    $ repeatedFieldMVectors x }
         ]
     mapCase entryInfo = pLitInt (fieldTag info) --> do'
         [ bangPat (entry `patTypeSig` tyCon (unQual $ mapEntryTypeName entryInfo))
@@ -292,12 +366,12 @@ unknownFieldCase loop x = wire --> do'
 -- | An expression of type "b -> a -> a", corresponding to a Lens a b
 -- for this field.
 setField :: FieldInfo -> Exp
-setField f = "Lens.Family2.set" @@ lensOfExp (fieldLens f)
+setField f = "Lens.Family2.set" @@ lensOfField f
 
 -- | An expression of type "(b -> b) -> a -> a", corresponding to a
 -- Lens a b for this field.
 overField :: FieldInfo -> Exp -> Exp
-overField f = over' (lensOfExp (fieldLens f))
+overField f = over' (lensOfField f)
 
 -- | An expression of type "(b -> b) -> a -> a".
 --
@@ -311,7 +385,8 @@ over' f g = "Lens.Family2.over"
   where
     t = "t"
 
--- | A "Parser [a]" for a field that can be packed.
+-- | A "Growing v RealWorld a -> Parser (Growing v RealWorld a)"
+-- for a field that can be packed.
 parsePackedField :: FieldInfo -> Exp
 {- let ploop qs = do
                     packedEnd <- atEnd
@@ -319,15 +394,17 @@ parsePackedField :: FieldInfo -> Exp
                         then return qs
                         else do
                             !q <- {PARSE FIELD}
-                            ploop (q:qs)
-   in ploop []
+                            qs' <- append qs q
+                            ploop qs'
+   in ploop
 -}
 parsePackedField info = let' [funBind [match ploop [qs] ploopExp]]
-                       (ploop @@ emptyList)
+                            ploop
   where
     ploop = "ploop"
     q = "q"
     qs = "qs"
+    qs' = "qs'"
     packedEnd = "packedEnd"
     ploopExp = do'
         [ packedEnd <-- "Data.ProtoLens.Encoding.Bytes.atEnd"
@@ -336,7 +413,10 @@ parsePackedField info = let' [funBind [match ploop [qs] ploopExp]]
                 ("Prelude.return" @@ qs)
                 $ do'
                     [ bangPat q <-- parseField info
-                    , stmt $ ploop @@ (cons @@ q @@ qs)
+                    , qs' <-- unsafeLiftIO' @@
+                                ("Data.ProtoLens.Encoding.Growing.append"
+                                    @@ qs @@ q)
+                    , stmt $ ploop @@ qs'
                     ]
         ]
 
@@ -385,11 +465,11 @@ buildPlainField x f = case plainFieldKind f of
             @@ ("Prelude.map"
                     @@ lambda [v] (buildEntry entryInfo v)
                     @@ ("Data.Map.toList" @@ fieldValue))
-    RepeatedField Packed -> buildPackedField info fieldValue
-    RepeatedField _ -> "Data.Monoid.mconcat"
-                        @@ ("Prelude.map"
-                            @@ lambda [v] (buildTaggedField info v)
-                            @@ fieldValue)
+    RepeatedField Packed -> buildPackedField info vectorFieldValue
+    RepeatedField _ -> "Data.ProtoLens.Encoding.Bytes.foldMapBuilder"
+                            @@ lambda [v]
+                                    (buildTaggedField info v)
+                            @@ vectorFieldValue
   where
     info = plainFieldInfo f
     v = "_v"
@@ -398,6 +478,9 @@ buildPlainField x f = case plainFieldKind f of
                     @@ x
     maybeFieldValue = view'
                         @@ lensOfMaybeField info
+                        @@ x
+    vectorFieldValue = view'
+                        @@ lensOfVectorField info
                         @@ x
     {- Builds a value of the given map entry type
        from the given key/value pair kv.
@@ -416,18 +499,18 @@ buildPlainField x f = case plainFieldKind f of
                          @@ ("Data.ProtoLens.defMessage"
                                 @::@ tyCon (unQual $ mapEntryTypeName entry)))
 
-fieldLens :: FieldInfo -> Symbol
-fieldLens = overloadedName . fieldName
-
 lensOfField :: FieldInfo -> Exp
-lensOfField = lensOfExp . fieldLens
+lensOfField = lensOfExp . overloadedFieldName
 
 lensOfMaybeField :: FieldInfo -> Exp
-lensOfMaybeField = lensOfExp . ("maybe'" <>) . fieldLens
+lensOfMaybeField = lensOfExp . ("maybe'" <>) . overloadedFieldName
 
 lensOfOneofField :: OneofInfo -> Exp
 lensOfOneofField =
     lensOfExp . ("maybe'" <>) . overloadedName . oneofFieldName
+
+lensOfVectorField :: FieldInfo -> Exp
+lensOfVectorField = lensOfExp . ("vector'" <>) . overloadedFieldName
 
 -- | Build a field along with its tag.
 buildTaggedField :: FieldInfo -> Exp -> Exp
@@ -446,13 +529,14 @@ buildPackedField :: FieldInfo -> Exp -> Exp
             <> ... (runBuilder (mconcat (map {BUILD_ELT} p)))
 -}
 buildPackedField f x = let' [patBind p x]
-    $ if' ("Prelude.null" @@ p) mempty'
+    $ if' ("Data.Vector.Generic.null" @@ p) mempty'
     $ "Data.Monoid.<>"
-          @@ (putVarInt' @@ litInt (packedFieldTag f))
-          @@ (buildFieldType lengthy
+        @@ (putVarInt' @@ litInt (packedFieldTag f))
+        @@ (buildFieldType lengthy
                 @@ ("Data.ProtoLens.Encoding.Bytes.runBuilder"
-                    @@ ("Data.Monoid.mconcat"
-                        @@ ("Prelude.map" @@ buildField f @@ p))))
+                    @@ ("Data.ProtoLens.Encoding.Bytes.foldMapBuilder"
+                            @@ buildField f
+                            @@ p)))
   where
     p = "p"
 
@@ -493,13 +577,15 @@ lensOfExp sym = ("Lens.Labels.lensOf'"
                       ("Lens.Labels.Proxy#" @@ promoteSymbol sym)))
 
 -- | Some functions that are used in multiple places in the generated code.
-getVarInt', putVarInt', mempty', view', set', unknownFields' :: Exp
+getVarInt', putVarInt', mempty', view', set', unknownFields', unsafeLiftIO'
+    :: Exp
 getVarInt' = "Data.ProtoLens.Encoding.Bytes.getVarInt"
 putVarInt' = "Data.ProtoLens.Encoding.Bytes.putVarInt"
 mempty' = "Data.Monoid.mempty"
 view' = "Lens.Family2.view"
 set' = "Lens.Family2.set"
 unknownFields' = "Data.ProtoLens.unknownFields"
+unsafeLiftIO' = "Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO"
 
 -- | Returns an expression of type @Parser a@ for the given field.
 parseField :: FieldInfo -> Exp
@@ -515,3 +601,10 @@ buildField = buildFieldType . fieldInfoEncoding
 
 fieldInfoEncoding :: FieldInfo -> FieldEncoding
 fieldInfoEncoding = fieldEncoding . view type' . fieldDescriptor
+
+growingType :: Env QName -> FieldInfo -> Type
+growingType env f
+    = "Data.ProtoLens.Encoding.Growing.Growing"
+        @@ hsFieldVectorType f
+        @@ "Data.ProtoLens.Encoding.Growing.RealWorld"
+        @@ hsFieldType env f

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Field.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Field.hs
@@ -6,17 +6,68 @@
 --
 -- Upstream docs:
 -- <https://developers.google.com/protocol-buffers/docs/encoding#structure>
-module Data.ProtoLens.Compiler.Generate.FieldEncoding
-    ( FieldEncoding(..)
+module Data.ProtoLens.Compiler.Generate.Field
+    ( hsFieldType
+    , hsFieldVectorType
+    , FieldEncoding(..)
     , fieldEncoding
     , lengthy
     , groupEnd
     , isolatedLengthy
     ) where
 
+import Data.Text (unpack)
 import Data.Word (Word8)
 import Data.ProtoLens.Compiler.Combinators
+import Data.ProtoLens.Compiler.Definitions
+import Lens.Family2
 import Proto.Google.Protobuf.Descriptor (FieldDescriptorProto'Type(..))
+import Proto.Google.Protobuf.Descriptor_Fields (type', typeName)
+
+hsFieldType :: Env QName -> FieldInfo -> Type
+hsFieldType env f = let
+    fd = fieldDescriptor f
+    in case fd ^. type' of
+        FieldDescriptorProto'TYPE_DOUBLE -> "Prelude.Double"
+        FieldDescriptorProto'TYPE_FLOAT -> "Prelude.Float"
+        FieldDescriptorProto'TYPE_INT64 -> "Data.Int.Int64"
+        FieldDescriptorProto'TYPE_UINT64 -> "Data.Word.Word64"
+        FieldDescriptorProto'TYPE_INT32 -> "Data.Int.Int32"
+        FieldDescriptorProto'TYPE_FIXED64 -> "Data.Word.Word64"
+        FieldDescriptorProto'TYPE_FIXED32 -> "Data.Word.Word32"
+        FieldDescriptorProto'TYPE_BOOL -> "Prelude.Bool"
+        FieldDescriptorProto'TYPE_STRING -> "Data.Text.Text"
+        FieldDescriptorProto'TYPE_GROUP
+            | Message m <- definedFieldType fd env -> tyCon $ messageName m
+            | otherwise -> error $ "expected TYPE_GROUP for type name"
+                                ++ unpack (fd ^. typeName)
+        FieldDescriptorProto'TYPE_MESSAGE
+            | Message m <- definedFieldType fd env -> tyCon $ messageName m
+            | otherwise -> error $ "expected TYPE_MESSAGE for type name"
+                                ++ unpack (fd ^. typeName)
+        FieldDescriptorProto'TYPE_BYTES -> "Data.ByteString.ByteString"
+        FieldDescriptorProto'TYPE_UINT32 -> "Data.Word.Word32"
+        FieldDescriptorProto'TYPE_ENUM
+            | Enum e <- definedFieldType fd env -> tyCon $ enumName e
+            | otherwise -> error $ "expected TYPE_ENUM for type name"
+                                ++ unpack (fd ^. typeName)
+        FieldDescriptorProto'TYPE_SFIXED32 -> "Data.Int.Int32"
+        FieldDescriptorProto'TYPE_SFIXED64 -> "Data.Int.Int64"
+        FieldDescriptorProto'TYPE_SINT32 -> "Data.Int.Int32"
+        FieldDescriptorProto'TYPE_SINT64 -> "Data.Int.Int64"
+
+hsFieldVectorType :: FieldInfo -> Type
+hsFieldVectorType f = case fieldDescriptor f ^. type' of
+    FieldDescriptorProto'TYPE_MESSAGE -> boxed
+    -- TODO: store enums in unboxed fields.
+    FieldDescriptorProto'TYPE_ENUM -> boxed
+    FieldDescriptorProto'TYPE_GROUP -> boxed
+    FieldDescriptorProto'TYPE_STRING -> boxed
+    FieldDescriptorProto'TYPE_BYTES -> boxed
+    _ -> unboxed
+  where
+    boxed = "Data.Vector.Vector"
+    unboxed = "Data.Vector.Unboxed.Vector"
 
 -- | A representation for how to encode and decode a particular field type.
 data FieldEncoding = FieldEncoding

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Field.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Field.hs
@@ -18,11 +18,12 @@ module Data.ProtoLens.Compiler.Generate.Field
 
 import Data.Text (unpack)
 import Data.Word (Word8)
-import Data.ProtoLens.Compiler.Combinators
-import Data.ProtoLens.Compiler.Definitions
 import Lens.Family2
 import Proto.Google.Protobuf.Descriptor (FieldDescriptorProto'Type(..))
 import Proto.Google.Protobuf.Descriptor_Fields (type', typeName)
+
+import Data.ProtoLens.Compiler.Combinators
+import Data.ProtoLens.Compiler.Definitions
 
 hsFieldType :: Env QName -> FieldInfo -> Type
 hsFieldType env f = let

--- a/proto-lens-runtime/Changelog.md
+++ b/proto-lens-runtime/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog for `proto-lens-runtime`
 
+## Unreleased
+- Export more modules from proto-lens, to support generated encoding/decoding
+  and storing repeated fields as `Vector`s.
+
 ## v0.4.0.2
 - Bump the dependencies on `base` and `containers` to support `ghc-8.6.1.
 

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -25,6 +25,7 @@ library:
     - lens-labels == 0.3.*
     - proto-lens == 0.4.*
     - text == 1.2.*
+    - vector >= 0.11 && < 0.13
 
 
   reexported-modules:
@@ -38,6 +39,8 @@ library:
     - Data.Map as Data.ProtoLens.Runtime.Data.Map,
     - Data.ProtoLens as Data.ProtoLens.Runtime.Data.ProtoLens,
     - Data.ProtoLens.Encoding.Bytes as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Bytes,
+    - Data.ProtoLens.Encoding.Growing as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Growing,
+    - Data.ProtoLens.Encoding.Parser.Unsafe as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Parser.Unsafe,
     # TODO: try to avoid exposing the Wire module, or else merge it into the
     # Bytes module.
     - Data.ProtoLens.Encoding.Wire as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire,
@@ -45,6 +48,9 @@ library:
     - Data.ProtoLens.Message.Enum as Data.ProtoLens.Runtime.Data.ProtoLens.Message.Enum,
     - Data.Text as Data.ProtoLens.Runtime.Data.Text,
     - Data.Text.Encoding as Data.ProtoLens.Runtime.Data.Text.Encoding,
+    - Data.Vector as Data.ProtoLens.Runtime.Data.Vector,
+    - Data.Vector.Generic as Data.ProtoLens.Runtime.Data.Vector.Generic,
+    - Data.Vector.Unboxed as Data.ProtoLens.Runtime.Data.Vector.Unboxed,
     - Lens.Family2 as Data.ProtoLens.Runtime.Lens.Family2,
     - Lens.Family2.Unchecked as Data.ProtoLens.Runtime.Lens.Family2.Unchecked,
     - Lens.Labels as Data.ProtoLens.Runtime.Lens.Labels,

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -104,6 +104,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
+      - vector
     other-modules:
       - Proto.Repeated
       - Proto.Repeated_Fields

--- a/proto-lens-tests/tests/repeated_test.hs
+++ b/proto-lens-tests/tests/repeated_test.hs
@@ -86,10 +86,10 @@ main = testMain
         $ buildMessage (defFoo & a .~ [1,2] :: Foo)
             <> buildMessage (defFoo & a .~ [3,4] :: Foo)
     , testGroup "vector"
-        [ vectorTest @Bar "fixed64" arbitrary e vector'e
-        , vectorTest @Foo "int32" arbitrary a vector'a
-        , vectorTest @Foo "string" (T.pack <$> arbitrary) b vector'b
-        , vectorTest @Foo "message" arbitraryMessage c vector'c
+        [ vectorTest @Bar "fixed64" arbitrary e vec'e
+        , vectorTest @Foo "int32" arbitrary a vec'a
+        , vectorTest @Foo "string" (T.pack <$> arbitrary) b vec'b
+        , vectorTest @Foo "message" arbitraryMessage c vec'c
         ]
     , testGroup "roundtrip"
         [ runTypedTest (roundTripTest "foo" :: TypedTest Foo)

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -11,6 +11,9 @@
     by the generated code.
   - Simplify the API of `Data.ProtoLens.Encoding.Wire`, using a plain ADT
     rather than a GADT to represent unknown field values.
+- Add functionality for storing unknown fields as `Vector`s.  (See the
+  changelog of `proto-lens-protoc` for more details.)  Exposes the
+  `Growing` type for mutable vectors of growing capacity.
 - If fields have the wrong wire type, store them in `unknownFields` rather
   than failing the parse. (#125)
 - Export the new function `parseMessageDelimited`. (#61)

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -31,6 +31,7 @@ library:
   source-dirs: src
 
   other-modules:
+    - Data.ProtoLens.Encoding.Parser.Internal
     - Data.ProtoLens.TextFormat.Parser
   dependencies:
     - base >= 4.9 && < 4.13
@@ -41,8 +42,10 @@ library:
     - lens-labels == 0.3.*
     - parsec == 3.1.*
     - pretty == 1.1.*
+    - primitive == 0.6.*
     - text == 1.2.*
     - transformers >= 0.4 && < 0.6
+    - vector >= 0.11 && < 0.13
     - void == 0.7.*
 
 tests:

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -59,3 +59,14 @@ tests:
     - QuickCheck
     - test-framework
     - test-framework-quickcheck2
+
+  growing_test:
+    main: growing_test.hs
+    source-dirs: tests
+    dependencies:
+    - base
+    - vector
+    - proto-lens
+    - QuickCheck
+    - test-framework
+    - test-framework-quickcheck2

--- a/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
@@ -189,7 +189,10 @@ foldMapBuilder f = \v0 -> Internal.builder (loop v0)
         | V.null v = cont bs
         | otherwise = let
             !x = V.unsafeHead v
+            -- lts-8.24 (ghc-8.0) doesn't inline unsafeTail well.
+            -- We can remove the following bang when we bump the lower bound:
+            !xs = V.unsafeTail v
             in Internal.runBuilderWith
                         (f x)
-                        (loop (V.unsafeTail v) cont) bs
+                        (loop xs cont) bs
 {-# INLINE foldMapBuilder #-}

--- a/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
@@ -42,14 +42,17 @@ module Data.ProtoLens.Encoding.Bytes(
     atEnd,
     runEither,
     (<?>),
+    foldMapBuilder,
     ) where
 
 import Data.Bits
 import Data.ByteString (ByteString)
 import Data.ByteString.Lazy.Builder as Builder
+import qualified Data.ByteString.Builder.Internal as Internal
 import qualified Data.ByteString.Lazy as L
 import Data.Int (Int32, Int64)
 import Data.Monoid ((<>))
+import qualified Data.Vector.Generic as V
 import Data.Word (Word32, Word64)
 #if MIN_VERSION_base(4,11,0)
 import qualified GHC.Float as Float
@@ -169,3 +172,24 @@ wordToSignedInt64 n
 
 runEither :: Either String a -> Parser a
 runEither = either fail return
+
+-- | Loop over the elements of a vector and concatenate the resulting
+-- @Builder@s.
+--
+-- This function has been hand-tuned to perform better than a naive
+-- implementation using, e.g., Vector.foldr or a manual loop.
+foldMapBuilder :: V.Vector v a => (a -> Builder) -> v a -> Builder
+foldMapBuilder f = \v0 -> Internal.builder (loop v0)
+    -- Place v0 on the right-hand side so that GHC actually inlines
+    -- this function.
+  where
+    -- Fully-saturate the inner loop (rather than currying away `cont`
+    -- and `bs`) to avoid GHC creating an intermediate continuation.
+    loop v cont bs
+        | V.null v = cont bs
+        | otherwise = let
+            !x = V.unsafeHead v
+            in Internal.runBuilderWith
+                        (f x)
+                        (loop (V.unsafeTail v) cont) bs
+{-# INLINE foldMapBuilder #-}

--- a/proto-lens/src/Data/ProtoLens/Encoding/Growing.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Growing.hs
@@ -1,0 +1,59 @@
+-- | A mutable vector that grows in size.
+module Data.ProtoLens.Encoding.Growing (
+    Growing,
+    new,
+    append,
+    unsafeFreeze,
+    RealWorld,
+    ) where
+
+import Control.Monad.Primitive (PrimMonad, PrimState, RealWorld)
+
+import qualified Data.Vector.Generic as V
+import qualified Data.Vector.Generic.Mutable as MV
+
+-- | A mutable vector which can increase in capacity.
+data Growing v s a = Growing
+    {-# UNPACK #-} !Int
+        -- The number of elements in the mutable vector
+        -- that have already been set.
+    !(V.Mutable v s a)
+        -- TODOs for efficiency:
+        -- - Try unpacking this.  It's difficult as-is because
+        --   V.Mutable is a type function.
+        -- - MVectors support slicing, but we're not using that
+        --   functionality, so we're passing around an extra unnecessary
+        --   Int.
+
+-- | Create a new empty growing vector.
+new :: (PrimMonad m, V.Vector v a) => m (Growing v (PrimState m) a)
+new = Growing 0 <$> MV.new 0
+
+-- | Unsafely convert a growing vector to an immutable one without
+-- copying.  After this call, you may not use the growing vector
+-- nor any other growing vectors that were used to produce this one.
+unsafeFreeze
+    :: (PrimMonad m, V.Vector v a)
+    => Growing v (PrimState m) a -> m (v a)
+unsafeFreeze (Growing len m)
+    = V.unsafeFreeze (MV.take len m)
+
+-- | Returns a new growing vector with a new element at the end.
+-- Note that the return value may share storage with the input value.
+-- Furthermore, calling @append@ twice on the same input may result
+-- in two vectors that share the same storage.
+append
+    :: (PrimMonad m, V.Vector v a)
+    => Growing v (PrimState m) a
+    -> a
+    -> m (Growing v (PrimState m) a)
+append (Growing len v) x
+    | len < MV.length v = do
+        MV.unsafeWrite v len x
+        return $ Growing (len + 1) v
+    | otherwise = do
+        let len' = 2 * len + 1
+        v' <- MV.unsafeGrow v len'
+        MV.unsafeWrite v' len x
+        return $ Growing (len + 1) v'
+{-# INLINE append #-}

--- a/proto-lens/src/Data/ProtoLens/Encoding/Growing.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Growing.hs
@@ -1,4 +1,16 @@
 -- | A mutable vector that grows in size.
+--
+-- Example usage:
+--
+-- > import qualified Data.ProtoLens.Encoding.Growing as Growing
+-- > import qualified Data.Vector.Unboxed as V
+-- > test :: IO (V.Vector Int)
+-- > test = do
+-- >     v <- Growing.new
+-- >     v' <- Growing.append v 1
+-- >     v'' <- Growing.append v' 2
+-- >     v''' <- Growing.append v'' 3
+-- >     unsafeFreeze v'''
 module Data.ProtoLens.Encoding.Growing (
     Growing,
     new,
@@ -35,8 +47,7 @@ new = Growing 0 <$> MV.new 0
 unsafeFreeze
     :: (PrimMonad m, V.Vector v a)
     => Growing v (PrimState m) a -> m (v a)
-unsafeFreeze (Growing len m)
-    = V.unsafeFreeze (MV.take len m)
+unsafeFreeze (Growing len m) = V.unsafeFreeze (MV.take len m)
 
 -- | Returns a new growing vector with a new element at the end.
 -- Note that the return value may share storage with the input value.

--- a/proto-lens/src/Data/ProtoLens/Encoding/Parser/Internal.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Parser/Internal.hs
@@ -1,0 +1,40 @@
+-- | Definition of the parsing monad, plus internal
+-- unsafe functions.
+module Data.ProtoLens.Encoding.Parser.Internal
+    ( Parser(..)
+    , ParserResult(..)
+    ) where
+
+import Control.Monad (ap)
+import Control.Monad.Trans.Except
+import Data.Word (Word8)
+import Foreign.Ptr
+
+-- | A monad for parsing an input buffer.
+newtype Parser a = Parser
+    { unParser :: Ptr Word8 -- End position of the input
+               -> Ptr Word8 -- Current position in the input
+               -> ExceptT String IO (ParserResult a)
+    }
+
+data ParserResult a = ParserResult
+    { _newPos :: !(Ptr Word8) -- ^ New position in the input
+    , unParserResult :: a
+    }
+
+instance Functor ParserResult where
+    fmap f (ParserResult p x) = ParserResult p (f x)
+
+instance Functor Parser where
+    fmap f (Parser g) = Parser $ \end cur -> fmap f <$> g end cur
+
+instance Applicative Parser where
+    pure x = Parser $ \_ cur -> return $ ParserResult cur x
+    (<*>) = ap
+
+instance Monad Parser where
+    fail s = Parser $ \_ _ -> throwE s
+    return = pure
+    Parser f >>= g = Parser $ \end pos -> do
+        ParserResult pos' x <- f end pos
+        unParser (g x) end pos'

--- a/proto-lens/src/Data/ProtoLens/Encoding/Parser/Unsafe.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Parser/Unsafe.hs
@@ -1,0 +1,22 @@
+module Data.ProtoLens.Encoding.Parser.Unsafe
+    ( unsafeLiftIO ) where
+
+import Control.Monad.Trans.Class (lift)
+import Data.ProtoLens.Encoding.Parser.Internal
+
+-- | Runs an arbitrary @IO@ action inside a @Parser@.
+-- The generated code uses this function to construct vectors
+-- efficiently by incrementally building up mutable vectors.
+--
+-- NOTE: This is unsafe since @runParser@
+-- is a pure function, which lets us lift arbitrary IO into
+-- pure operations.
+-- However, here are some guarantees that we do get:
+--
+-- - For each individual call to 'runParser', the action
+--   wrapped by unsafeParserLiftIO will be called exactly once.
+-- - Different calls to 'unsafeLiftIO' within the same call to
+--   'runParser' will be sequenced according to their order in the Parser
+-- monad.
+unsafeLiftIO :: IO a -> Parser a
+unsafeLiftIO m = Parser $ \_ p -> ParserResult p <$> lift m

--- a/proto-lens/src/Data/ProtoLens/Encoding/Parser/Unsafe.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Parser/Unsafe.hs
@@ -14,9 +14,9 @@ import Data.ProtoLens.Encoding.Parser.Internal
 -- However, here are some guarantees that we do get:
 --
 -- - For each individual call to 'runParser', the action
---   wrapped by unsafeParserLiftIO will be called exactly once.
+--   wrapped by 'unsafeLiftIO' will be called exactly once.
 -- - Different calls to 'unsafeLiftIO' within the same call to
 --   'runParser' will be sequenced according to their order in the Parser
--- monad.
+--   monad.
 unsafeLiftIO :: IO a -> Parser a
 unsafeLiftIO m = Parser $ \_ p -> ParserResult p <$> lift m

--- a/proto-lens/src/Data/ProtoLens/Message.hs
+++ b/proto-lens/src/Data/ProtoLens/Message.hs
@@ -108,6 +108,7 @@ class Message msg where
 allFields :: Message msg => [FieldDescriptor msg]
 allFields = Map.elems fieldsByTag
 
+-- TODO: represent FieldSet as a Vector too.
 type FieldSet = [TaggedValue]
 
 -- | A description of a specific field of a protocol buffer.
@@ -191,7 +192,6 @@ instance FieldDefault B.ByteString where
 
 instance FieldDefault T.Text where
     fieldDefault = T.empty
-
 
 -- | How a given repeated field is transmitted on the wire format.
 data Packing = Packed | Unpacked

--- a/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -18,6 +18,8 @@ import qualified Data.Monoid
 import qualified Data.Word
 import qualified Data.ProtoLens
 import qualified Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Encoding.Parser.Unsafe
 import qualified Data.ProtoLens.Encoding.Wire
 import qualified Data.ProtoLens.Message.Enum
 import qualified Data.ProtoLens.Service.Types
@@ -28,6 +30,9 @@ import qualified Data.Map
 import qualified Data.ByteString
 import qualified Data.ByteString.Char8
 import qualified Data.Text.Encoding
+import qualified Data.Vector
+import qualified Data.Vector.Generic
+import qualified Data.Vector.Unboxed
 import qualified Lens.Labels
 import qualified Text.Read
 import qualified Proto.Google.Protobuf.Descriptor
@@ -35,19 +40,24 @@ import qualified Proto.Google.Protobuf.Descriptor
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.fileToGenerate' @:: Lens' CodeGeneratorRequest [Data.Text.Text]@
+    * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.vector'fileToGenerate' @:: Lens' CodeGeneratorRequest (Data.Vector.Vector Data.Text.Text)@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.parameter' @:: Lens' CodeGeneratorRequest Data.Text.Text@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.maybe'parameter' @:: Lens' CodeGeneratorRequest (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.protoFile' @:: Lens' CodeGeneratorRequest
   [Proto.Google.Protobuf.Descriptor.FileDescriptorProto]@
+    * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.vector'protoFile' @:: Lens' CodeGeneratorRequest
+  (Data.Vector.Vector
+     Proto.Google.Protobuf.Descriptor.FileDescriptorProto)@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.compilerVersion' @:: Lens' CodeGeneratorRequest Version@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.maybe'compilerVersion' @:: Lens' CodeGeneratorRequest (Prelude.Maybe Version)@
  -}
 data CodeGeneratorRequest = CodeGeneratorRequest{_CodeGeneratorRequest'fileToGenerate
-                                                 :: ![Data.Text.Text],
+                                                 :: !(Data.Vector.Vector Data.Text.Text),
                                                  _CodeGeneratorRequest'parameter ::
                                                  !(Prelude.Maybe Data.Text.Text),
                                                  _CodeGeneratorRequest'protoFile ::
-                                                 ![Proto.Google.Protobuf.Descriptor.FileDescriptorProto],
+                                                 !(Data.Vector.Vector
+                                                     Proto.Google.Protobuf.Descriptor.FileDescriptorProto),
                                                  _CodeGeneratorRequest'compilerVersion ::
                                                  !(Prelude.Maybe Version),
                                                  _CodeGeneratorRequest'_unknownFields ::
@@ -60,6 +70,15 @@ instance Prelude.Show CodeGeneratorRequest where
                  (Prelude.showChar '}' __s))
 instance a ~ ([Data.Text.Text]) =>
          Lens.Labels.HasLens' CodeGeneratorRequest "fileToGenerate" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'fileToGenerate
+               (\ x__ y__ -> x__{_CodeGeneratorRequest'fileToGenerate = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector Data.Text.Text) =>
+         Lens.Labels.HasLens' CodeGeneratorRequest "vector'fileToGenerate" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'fileToGenerate
@@ -82,6 +101,17 @@ instance a ~ (Prelude.Maybe Data.Text.Text) =>
 instance a ~
            ([Proto.Google.Protobuf.Descriptor.FileDescriptorProto]) =>
          Lens.Labels.HasLens' CodeGeneratorRequest "protoFile" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'protoFile
+               (\ x__ y__ -> x__{_CodeGeneratorRequest'protoFile = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~
+           (Data.Vector.Vector
+              Proto.Google.Protobuf.Descriptor.FileDescriptorProto) =>
+         Lens.Labels.HasLens' CodeGeneratorRequest "vector'protoFile" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'protoFile
@@ -151,19 +181,33 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
           = Lens.Family2.Unchecked.lens _CodeGeneratorRequest'_unknownFields
               (\ x__ y__ -> x__{_CodeGeneratorRequest'_unknownFields = y__})
         defMessage
-          = CodeGeneratorRequest{_CodeGeneratorRequest'fileToGenerate = [],
+          = CodeGeneratorRequest{_CodeGeneratorRequest'fileToGenerate =
+                                   Data.Vector.Generic.empty,
                                  _CodeGeneratorRequest'parameter = Prelude.Nothing,
-                                 _CodeGeneratorRequest'protoFile = [],
+                                 _CodeGeneratorRequest'protoFile = Data.Vector.Generic.empty,
                                  _CodeGeneratorRequest'compilerVersion = Prelude.Nothing,
                                  _CodeGeneratorRequest'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      CodeGeneratorRequest ->
-                       Data.ProtoLens.Encoding.Bytes.Parser CodeGeneratorRequest
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         Data.Text.Text
+                         ->
+                         Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                           Data.ProtoLens.Encoding.Growing.RealWorld
+                           Proto.Google.Protobuf.Descriptor.FileDescriptorProto
+                           -> Data.ProtoLens.Encoding.Bytes.Parser CodeGeneratorRequest
+                loop x mutable'fileToGenerate mutable'protoFile
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'fileToGenerate <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                       (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                          mutable'fileToGenerate)
+                            frozen'protoFile <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                     mutable'protoFile)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -171,16 +215,16 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "fileToGenerate"))
-                                    (\ !t -> Prelude.reverse t)
-                                    (Lens.Family2.over
+                                          (Lens.Labels.Proxy#) "vector'fileToGenerate"))
+                                    frozen'fileToGenerate
+                                    (Lens.Family2.set
                                        (Lens.Labels.lensOf'
                                           ((Lens.Labels.proxy#) ::
-                                             (Lens.Labels.Proxy#) "protoFile"))
-                                       (\ !t -> Prelude.reverse t)
+                                             (Lens.Labels.Proxy#) "vector'protoFile"))
+                                       frozen'protoFile
                                        x)))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -195,13 +239,11 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                                                           Prelude.Right r -> Prelude.Right r))
                                                  Data.ProtoLens.Encoding.Bytes.<?>
                                                  "file_to_generate"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "fileToGenerate"))
-                                              (\ !t -> (:) y t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'fileToGenerate
+                                                   y)
+                                         loop x v mutable'protoFile
                                 18 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                               Data.ProtoLens.Encoding.Bytes.getBytes
                                                                 (Prelude.fromIntegral len)
@@ -218,24 +260,22 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                                                     (Lens.Labels.Proxy#) "parameter"))
                                               y
                                               x)
-                                122 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                                Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                  (Prelude.fromIntegral len)
-                                                    Data.ProtoLens.Encoding.Bytes.runEither
-                                                      (Data.ProtoLens.decodeMessage value))
+                                           mutable'fileToGenerate
+                                           mutable'protoFile
+                                122 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                    Data.ProtoLens.Encoding.Bytes.isolate
+                                                      (Prelude.fromIntegral len)
+                                                      Data.ProtoLens.parseMessage)
                                                   Data.ProtoLens.Encoding.Bytes.<?> "proto_file"
-                                          loop
-                                            (Lens.Family2.over
-                                               (Lens.Labels.lensOf'
-                                                  ((Lens.Labels.proxy#) ::
-                                                     (Lens.Labels.Proxy#) "protoFile"))
-                                               (\ !t -> (:) y t)
-                                               x)
-                                26 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                              Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                (Prelude.fromIntegral len)
-                                                  Data.ProtoLens.Encoding.Bytes.runEither
-                                                    (Data.ProtoLens.decodeMessage value))
+                                          v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                 (Data.ProtoLens.Encoding.Growing.append
+                                                    mutable'protoFile
+                                                    y)
+                                          loop x mutable'fileToGenerate v
+                                26 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                  Data.ProtoLens.Encoding.Bytes.isolate
+                                                    (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.parseMessage)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "compiler_version"
                                          loop
                                            (Lens.Family2.set
@@ -244,31 +284,42 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                                                     (Lens.Labels.Proxy#) "compilerVersion"))
                                               y
                                               x)
+                                           mutable'fileToGenerate
+                                           mutable'protoFile
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'fileToGenerate
+                                             mutable'protoFile
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "CodeGeneratorRequest"
+              (do mutable'fileToGenerate <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                              Data.ProtoLens.Encoding.Growing.new
+                  mutable'protoFile <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                         Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'fileToGenerate
+                    mutable'protoFile)
+                Data.ProtoLens.Encoding.Bytes.<?> "CodeGeneratorRequest"
         buildMessage
           = (\ _x ->
-               (Data.Monoid.mconcat
-                  (Prelude.map
-                     (\ _v ->
-                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.Text.Encoding.encodeUtf8)
-                            _v)
-                     (Lens.Family2.view
-                        (Lens.Labels.lensOf'
-                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "fileToGenerate"))
-                        _x)))
+               (Data.Vector.Generic.foldr
+                  (\ _v as ->
+                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                        (((\ bs ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                (Prelude.fromIntegral (Data.ByteString.length bs)))
+                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                           Prelude.. Data.Text.Encoding.encodeUtf8)
+                          _v)
+                       Data.Monoid.<> as)
+                  Data.Monoid.mempty
+                  (Lens.Family2.view
+                     (Lens.Labels.lensOf'
+                        ((Lens.Labels.proxy#) ::
+                           (Lens.Labels.Proxy#) "vector'fileToGenerate"))
+                     _x))
                  Data.Monoid.<>
                  (case
                     Lens.Family2.view
@@ -288,20 +339,21 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                                               Prelude.. Data.Text.Encoding.encodeUtf8)
                                              _v)
                    Data.Monoid.<>
-                   (Data.Monoid.mconcat
-                      (Prelude.map
-                         (\ _v ->
-                            (Data.ProtoLens.Encoding.Bytes.putVarInt 122) Data.Monoid.<>
-                              (((\ bs ->
-                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                 Prelude.. Data.ProtoLens.encodeMessage)
-                                _v)
-                         (Lens.Family2.view
-                            (Lens.Labels.lensOf'
-                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "protoFile"))
-                            _x)))
+                   (Data.Vector.Generic.foldr
+                      (\ _v as ->
+                         ((Data.ProtoLens.Encoding.Bytes.putVarInt 122) Data.Monoid.<>
+                            (((\ bs ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                               Prelude.. Data.ProtoLens.encodeMessage)
+                              _v)
+                           Data.Monoid.<> as)
+                      Data.Monoid.mempty
+                      (Lens.Family2.view
+                         (Lens.Labels.lensOf'
+                            ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'protoFile"))
+                         _x))
                      Data.Monoid.<>
                      (case
                         Lens.Family2.view
@@ -339,11 +391,13 @@ instance Control.DeepSeq.NFData CodeGeneratorRequest where
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.error' @:: Lens' CodeGeneratorResponse Data.Text.Text@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.maybe'error' @:: Lens' CodeGeneratorResponse (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.file' @:: Lens' CodeGeneratorResponse [CodeGeneratorResponse'File]@
+    * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.vector'file' @:: Lens' CodeGeneratorResponse
+  (Data.Vector.Vector CodeGeneratorResponse'File)@
  -}
 data CodeGeneratorResponse = CodeGeneratorResponse{_CodeGeneratorResponse'error
                                                    :: !(Prelude.Maybe Data.Text.Text),
                                                    _CodeGeneratorResponse'file ::
-                                                   ![CodeGeneratorResponse'File],
+                                                   !(Data.Vector.Vector CodeGeneratorResponse'File),
                                                    _CodeGeneratorResponse'_unknownFields ::
                                                    !Data.ProtoLens.FieldSet}
                                deriving (Prelude.Eq, Prelude.Ord)
@@ -368,6 +422,15 @@ instance a ~ (Prelude.Maybe Data.Text.Text) =>
               Prelude.. Prelude.id
 instance a ~ ([CodeGeneratorResponse'File]) =>
          Lens.Labels.HasLens' CodeGeneratorResponse "file" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'file
+               (\ x__ y__ -> x__{_CodeGeneratorResponse'file = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector CodeGeneratorResponse'File) =>
+         Lens.Labels.HasLens' CodeGeneratorResponse "vector'file" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'file
@@ -403,16 +466,22 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
         defMessage
           = CodeGeneratorResponse{_CodeGeneratorResponse'error =
                                     Prelude.Nothing,
-                                  _CodeGeneratorResponse'file = [],
+                                  _CodeGeneratorResponse'file = Data.Vector.Generic.empty,
                                   _CodeGeneratorResponse'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      CodeGeneratorResponse ->
-                       Data.ProtoLens.Encoding.Bytes.Parser CodeGeneratorResponse
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         CodeGeneratorResponse'File
+                         -> Data.ProtoLens.Encoding.Bytes.Parser CodeGeneratorResponse
+                loop x mutable'file
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'file <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                             (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                mutable'file)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -420,10 +489,10 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "file"))
-                                    (\ !t -> Prelude.reverse t)
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file"))
+                                    frozen'file
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -444,28 +513,29 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
                                                     (Lens.Labels.Proxy#) "error"))
                                               y
                                               x)
-                                122 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                                Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                  (Prelude.fromIntegral len)
-                                                    Data.ProtoLens.Encoding.Bytes.runEither
-                                                      (Data.ProtoLens.decodeMessage value))
+                                           mutable'file
+                                122 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                    Data.ProtoLens.Encoding.Bytes.isolate
+                                                      (Prelude.fromIntegral len)
+                                                      Data.ProtoLens.parseMessage)
                                                   Data.ProtoLens.Encoding.Bytes.<?> "file"
-                                          loop
-                                            (Lens.Family2.over
-                                               (Lens.Labels.lensOf'
-                                                  ((Lens.Labels.proxy#) ::
-                                                     (Lens.Labels.Proxy#) "file"))
-                                               (\ !t -> (:) y t)
-                                               x)
+                                          v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                 (Data.ProtoLens.Encoding.Growing.append
+                                                    mutable'file
+                                                    y)
+                                          loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'file
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "CodeGeneratorResponse"
+              (do mutable'file <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                    Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'file)
+                Data.ProtoLens.Encoding.Bytes.<?> "CodeGeneratorResponse"
         buildMessage
           = (\ _x ->
                (case
@@ -485,20 +555,21 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
                                             Prelude.. Data.Text.Encoding.encodeUtf8)
                                            _v)
                  Data.Monoid.<>
-                 (Data.Monoid.mconcat
-                    (Prelude.map
-                       (\ _v ->
-                          (Data.ProtoLens.Encoding.Bytes.putVarInt 122) Data.Monoid.<>
-                            (((\ bs ->
-                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                               Prelude.. Data.ProtoLens.encodeMessage)
-                              _v)
-                       (Lens.Family2.view
-                          (Lens.Labels.lensOf'
-                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "file"))
-                          _x)))
+                 (Data.Vector.Generic.foldr
+                    (\ _v as ->
+                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 122) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude.. Data.ProtoLens.encodeMessage)
+                            _v)
+                         Data.Monoid.<> as)
+                    Data.Monoid.mempty
+                    (Lens.Family2.view
+                       (Lens.Labels.lensOf'
+                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file"))
+                       _x))
                    Data.Monoid.<>
                    Data.ProtoLens.Encoding.Wire.buildFieldSet
                      (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -699,8 +770,8 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
                                                 (\ !t -> (:) y t)
                                                 x)
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "File"
+              (do loop Data.ProtoLens.defMessage)
+                Data.ProtoLens.Encoding.Bytes.<?> "File"
         buildMessage
           = (\ _x ->
                (case
@@ -967,8 +1038,8 @@ instance Data.ProtoLens.Message Version where
                                                 (\ !t -> (:) y t)
                                                 x)
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "Version"
+              (do loop Data.ProtoLens.defMessage)
+                Data.ProtoLens.Encoding.Bytes.<?> "Version"
         buildMessage
           = (\ _x ->
                (case

--- a/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -40,12 +40,12 @@ import qualified Proto.Google.Protobuf.Descriptor
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.fileToGenerate' @:: Lens' CodeGeneratorRequest [Data.Text.Text]@
-    * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.vector'fileToGenerate' @:: Lens' CodeGeneratorRequest (Data.Vector.Vector Data.Text.Text)@
+    * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.vec'fileToGenerate' @:: Lens' CodeGeneratorRequest (Data.Vector.Vector Data.Text.Text)@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.parameter' @:: Lens' CodeGeneratorRequest Data.Text.Text@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.maybe'parameter' @:: Lens' CodeGeneratorRequest (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.protoFile' @:: Lens' CodeGeneratorRequest
   [Proto.Google.Protobuf.Descriptor.FileDescriptorProto]@
-    * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.vector'protoFile' @:: Lens' CodeGeneratorRequest
+    * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.vec'protoFile' @:: Lens' CodeGeneratorRequest
   (Data.Vector.Vector
      Proto.Google.Protobuf.Descriptor.FileDescriptorProto)@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.compilerVersion' @:: Lens' CodeGeneratorRequest Version@
@@ -78,7 +78,7 @@ instance a ~ ([Data.Text.Text]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector Data.Text.Text) =>
-         Lens.Labels.HasLens' CodeGeneratorRequest "vector'fileToGenerate" a
+         Lens.Labels.HasLens' CodeGeneratorRequest "vec'fileToGenerate" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'fileToGenerate
@@ -111,7 +111,7 @@ instance a ~
 instance a ~
            (Data.Vector.Vector
               Proto.Google.Protobuf.Descriptor.FileDescriptorProto) =>
-         Lens.Labels.HasLens' CodeGeneratorRequest "vector'protoFile" a
+         Lens.Labels.HasLens' CodeGeneratorRequest "vec'protoFile" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _CodeGeneratorRequest'protoFile
@@ -218,12 +218,12 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'fileToGenerate"))
+                                          (Lens.Labels.Proxy#) "vec'fileToGenerate"))
                                     frozen'fileToGenerate
                                     (Lens.Family2.set
                                        (Lens.Labels.lensOf'
                                           ((Lens.Labels.proxy#) ::
-                                             (Lens.Labels.Proxy#) "vector'protoFile"))
+                                             (Lens.Labels.Proxy#) "vec'protoFile"))
                                        frozen'protoFile
                                        x)))
                          else
@@ -304,21 +304,19 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                 Data.ProtoLens.Encoding.Bytes.<?> "CodeGeneratorRequest"
         buildMessage
           = (\ _x ->
-               (Data.Vector.Generic.foldr
-                  (\ _v as ->
-                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
-                        (((\ bs ->
-                             (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                (Prelude.fromIntegral (Data.ByteString.length bs)))
-                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                           Prelude.. Data.Text.Encoding.encodeUtf8)
-                          _v)
-                       Data.Monoid.<> as)
-                  Data.Monoid.mempty
+               (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                  (\ _v ->
+                     (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                       (((\ bs ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt
+                               (Prelude.fromIntegral (Data.ByteString.length bs)))
+                              Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                          Prelude.. Data.Text.Encoding.encodeUtf8)
+                         _v)
                   (Lens.Family2.view
                      (Lens.Labels.lensOf'
                         ((Lens.Labels.proxy#) ::
-                           (Lens.Labels.Proxy#) "vector'fileToGenerate"))
+                           (Lens.Labels.Proxy#) "vec'fileToGenerate"))
                      _x))
                  Data.Monoid.<>
                  (case
@@ -339,20 +337,18 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
                                               Prelude.. Data.Text.Encoding.encodeUtf8)
                                              _v)
                    Data.Monoid.<>
-                   (Data.Vector.Generic.foldr
-                      (\ _v as ->
-                         ((Data.ProtoLens.Encoding.Bytes.putVarInt 122) Data.Monoid.<>
-                            (((\ bs ->
-                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                               Prelude.. Data.ProtoLens.encodeMessage)
-                              _v)
-                           Data.Monoid.<> as)
-                      Data.Monoid.mempty
+                   (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                      (\ _v ->
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt 122) Data.Monoid.<>
+                           (((\ bs ->
+                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                   (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                  Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                              Prelude.. Data.ProtoLens.encodeMessage)
+                             _v)
                       (Lens.Family2.view
                          (Lens.Labels.lensOf'
-                            ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'protoFile"))
+                            ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'protoFile"))
                          _x))
                      Data.Monoid.<>
                      (case
@@ -391,7 +387,7 @@ instance Control.DeepSeq.NFData CodeGeneratorRequest where
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.error' @:: Lens' CodeGeneratorResponse Data.Text.Text@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.maybe'error' @:: Lens' CodeGeneratorResponse (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.file' @:: Lens' CodeGeneratorResponse [CodeGeneratorResponse'File]@
-    * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.vector'file' @:: Lens' CodeGeneratorResponse
+    * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.vec'file' @:: Lens' CodeGeneratorResponse
   (Data.Vector.Vector CodeGeneratorResponse'File)@
  -}
 data CodeGeneratorResponse = CodeGeneratorResponse{_CodeGeneratorResponse'error
@@ -430,7 +426,7 @@ instance a ~ ([CodeGeneratorResponse'File]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector CodeGeneratorResponse'File) =>
-         Lens.Labels.HasLens' CodeGeneratorResponse "vector'file" a
+         Lens.Labels.HasLens' CodeGeneratorResponse "vec'file" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _CodeGeneratorResponse'file
@@ -491,7 +487,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
                                  (\ !t -> Prelude.reverse t)
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file"))
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'file"))
                                     frozen'file
                                     x))
                          else
@@ -555,20 +551,18 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
                                             Prelude.. Data.Text.Encoding.encodeUtf8)
                                            _v)
                  Data.Monoid.<>
-                 (Data.Vector.Generic.foldr
-                    (\ _v as ->
-                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 122) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                         Data.Monoid.<> as)
-                    Data.Monoid.mempty
+                 (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                    (\ _v ->
+                       (Data.ProtoLens.Encoding.Bytes.putVarInt 122) Data.Monoid.<>
+                         (((\ bs ->
+                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                            Prelude.. Data.ProtoLens.encodeMessage)
+                           _v)
                     (Lens.Family2.view
                        (Lens.Labels.lensOf'
-                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file"))
+                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'file"))
                        _x))
                    Data.Monoid.<>
                    Data.ProtoLens.Encoding.Wire.buildFieldSet

--- a/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin_Fields.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin_Fields.hs
@@ -13,6 +13,8 @@ import qualified Data.Monoid
 import qualified Data.Word
 import qualified Data.ProtoLens
 import qualified Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Encoding.Parser.Unsafe
 import qualified Data.ProtoLens.Encoding.Wire
 import qualified Data.ProtoLens.Message.Enum
 import qualified Data.ProtoLens.Service.Types
@@ -23,6 +25,9 @@ import qualified Data.Map
 import qualified Data.ByteString
 import qualified Data.ByteString.Char8
 import qualified Data.Text.Encoding
+import qualified Data.Vector
+import qualified Data.Vector.Generic
+import qualified Data.Vector.Unboxed
 import qualified Lens.Labels
 import qualified Text.Read
 import qualified Proto.Google.Protobuf.Descriptor
@@ -192,3 +197,26 @@ suffix ::
 suffix
   = Lens.Labels.lensOf'
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "suffix")
+vector'file ::
+            forall f s a .
+              (Prelude.Functor f, Lens.Labels.HasLens' s "vector'file" a) =>
+              Lens.Family2.LensLike' f s a
+vector'file
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file")
+vector'fileToGenerate ::
+                      forall f s a .
+                        (Prelude.Functor f,
+                         Lens.Labels.HasLens' s "vector'fileToGenerate" a) =>
+                        Lens.Family2.LensLike' f s a
+vector'fileToGenerate
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "vector'fileToGenerate")
+vector'protoFile ::
+                 forall f s a .
+                   (Prelude.Functor f, Lens.Labels.HasLens' s "vector'protoFile" a) =>
+                   Lens.Family2.LensLike' f s a
+vector'protoFile
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'protoFile")

--- a/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin_Fields.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Compiler/Plugin_Fields.hs
@@ -197,26 +197,25 @@ suffix ::
 suffix
   = Lens.Labels.lensOf'
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "suffix")
-vector'file ::
-            forall f s a .
-              (Prelude.Functor f, Lens.Labels.HasLens' s "vector'file" a) =>
-              Lens.Family2.LensLike' f s a
-vector'file
+vec'file ::
+         forall f s a .
+           (Prelude.Functor f, Lens.Labels.HasLens' s "vec'file" a) =>
+           Lens.Family2.LensLike' f s a
+vec'file
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file")
-vector'fileToGenerate ::
-                      forall f s a .
-                        (Prelude.Functor f,
-                         Lens.Labels.HasLens' s "vector'fileToGenerate" a) =>
-                        Lens.Family2.LensLike' f s a
-vector'fileToGenerate
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'file")
+vec'fileToGenerate ::
+                   forall f s a .
+                     (Prelude.Functor f,
+                      Lens.Labels.HasLens' s "vec'fileToGenerate" a) =>
+                     Lens.Family2.LensLike' f s a
+vec'fileToGenerate
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) ::
-         (Lens.Labels.Proxy#) "vector'fileToGenerate")
-vector'protoFile ::
-                 forall f s a .
-                   (Prelude.Functor f, Lens.Labels.HasLens' s "vector'protoFile" a) =>
-                   Lens.Family2.LensLike' f s a
-vector'protoFile
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'fileToGenerate")
+vec'protoFile ::
+              forall f s a .
+                (Prelude.Functor f, Lens.Labels.HasLens' s "vec'protoFile" a) =>
+                Lens.Family2.LensLike' f s a
+vec'protoFile
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'protoFile")
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'protoFile")

--- a/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
@@ -34,6 +34,8 @@ import qualified Data.Monoid
 import qualified Data.Word
 import qualified Data.ProtoLens
 import qualified Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Encoding.Parser.Unsafe
 import qualified Data.ProtoLens.Encoding.Wire
 import qualified Data.ProtoLens.Message.Enum
 import qualified Data.ProtoLens.Service.Types
@@ -44,6 +46,9 @@ import qualified Data.Map
 import qualified Data.ByteString
 import qualified Data.ByteString.Char8
 import qualified Data.Text.Encoding
+import qualified Data.Vector
+import qualified Data.Vector.Generic
+import qualified Data.Vector.Unboxed
 import qualified Lens.Labels
 import qualified Text.Read
 
@@ -52,29 +57,45 @@ import qualified Text.Read
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' DescriptorProto Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'name' @:: Lens' DescriptorProto (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.field' @:: Lens' DescriptorProto [FieldDescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'field' @:: Lens' DescriptorProto (Data.Vector.Vector FieldDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.extension' @:: Lens' DescriptorProto [FieldDescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'extension' @:: Lens' DescriptorProto (Data.Vector.Vector FieldDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.nestedType' @:: Lens' DescriptorProto [DescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'nestedType' @:: Lens' DescriptorProto (Data.Vector.Vector DescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.enumType' @:: Lens' DescriptorProto [EnumDescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'enumType' @:: Lens' DescriptorProto (Data.Vector.Vector EnumDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.extensionRange' @:: Lens' DescriptorProto [DescriptorProto'ExtensionRange]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'extensionRange' @:: Lens' DescriptorProto
+  (Data.Vector.Vector DescriptorProto'ExtensionRange)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.oneofDecl' @:: Lens' DescriptorProto [OneofDescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'oneofDecl' @:: Lens' DescriptorProto (Data.Vector.Vector OneofDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.options' @:: Lens' DescriptorProto MessageOptions@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'options' @:: Lens' DescriptorProto (Prelude.Maybe MessageOptions)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.reservedRange' @:: Lens' DescriptorProto [DescriptorProto'ReservedRange]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'reservedRange' @:: Lens' DescriptorProto
+  (Data.Vector.Vector DescriptorProto'ReservedRange)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.reservedName' @:: Lens' DescriptorProto [Data.Text.Text]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'reservedName' @:: Lens' DescriptorProto (Data.Vector.Vector Data.Text.Text)@
  -}
 data DescriptorProto = DescriptorProto{_DescriptorProto'name ::
                                        !(Prelude.Maybe Data.Text.Text),
-                                       _DescriptorProto'field :: ![FieldDescriptorProto],
-                                       _DescriptorProto'extension :: ![FieldDescriptorProto],
-                                       _DescriptorProto'nestedType :: ![DescriptorProto],
-                                       _DescriptorProto'enumType :: ![EnumDescriptorProto],
+                                       _DescriptorProto'field ::
+                                       !(Data.Vector.Vector FieldDescriptorProto),
+                                       _DescriptorProto'extension ::
+                                       !(Data.Vector.Vector FieldDescriptorProto),
+                                       _DescriptorProto'nestedType ::
+                                       !(Data.Vector.Vector DescriptorProto),
+                                       _DescriptorProto'enumType ::
+                                       !(Data.Vector.Vector EnumDescriptorProto),
                                        _DescriptorProto'extensionRange ::
-                                       ![DescriptorProto'ExtensionRange],
-                                       _DescriptorProto'oneofDecl :: ![OneofDescriptorProto],
+                                       !(Data.Vector.Vector DescriptorProto'ExtensionRange),
+                                       _DescriptorProto'oneofDecl ::
+                                       !(Data.Vector.Vector OneofDescriptorProto),
                                        _DescriptorProto'options :: !(Prelude.Maybe MessageOptions),
                                        _DescriptorProto'reservedRange ::
-                                       ![DescriptorProto'ReservedRange],
-                                       _DescriptorProto'reservedName :: ![Data.Text.Text],
+                                       !(Data.Vector.Vector DescriptorProto'ReservedRange),
+                                       _DescriptorProto'reservedName ::
+                                       !(Data.Vector.Vector Data.Text.Text),
                                        _DescriptorProto'_unknownFields :: !Data.ProtoLens.FieldSet}
                          deriving (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show DescriptorProto where
@@ -102,9 +123,27 @@ instance a ~ ([FieldDescriptorProto]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'field
                (\ x__ y__ -> x__{_DescriptorProto'field = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector FieldDescriptorProto) =>
+         Lens.Labels.HasLens' DescriptorProto "vector'field" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'field
+               (\ x__ y__ -> x__{_DescriptorProto'field = y__}))
               Prelude.. Prelude.id
 instance a ~ ([FieldDescriptorProto]) =>
          Lens.Labels.HasLens' DescriptorProto "extension" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'extension
+               (\ x__ y__ -> x__{_DescriptorProto'extension = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector FieldDescriptorProto) =>
+         Lens.Labels.HasLens' DescriptorProto "vector'extension" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'extension
@@ -116,9 +155,27 @@ instance a ~ ([DescriptorProto]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'nestedType
                (\ x__ y__ -> x__{_DescriptorProto'nestedType = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector DescriptorProto) =>
+         Lens.Labels.HasLens' DescriptorProto "vector'nestedType" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'nestedType
+               (\ x__ y__ -> x__{_DescriptorProto'nestedType = y__}))
               Prelude.. Prelude.id
 instance a ~ ([EnumDescriptorProto]) =>
          Lens.Labels.HasLens' DescriptorProto "enumType" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'enumType
+               (\ x__ y__ -> x__{_DescriptorProto'enumType = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector EnumDescriptorProto) =>
+         Lens.Labels.HasLens' DescriptorProto "vector'enumType" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'enumType
@@ -130,9 +187,27 @@ instance a ~ ([DescriptorProto'ExtensionRange]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'extensionRange
                (\ x__ y__ -> x__{_DescriptorProto'extensionRange = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector DescriptorProto'ExtensionRange) =>
+         Lens.Labels.HasLens' DescriptorProto "vector'extensionRange" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'extensionRange
+               (\ x__ y__ -> x__{_DescriptorProto'extensionRange = y__}))
               Prelude.. Prelude.id
 instance a ~ ([OneofDescriptorProto]) =>
          Lens.Labels.HasLens' DescriptorProto "oneofDecl" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'oneofDecl
+               (\ x__ y__ -> x__{_DescriptorProto'oneofDecl = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector OneofDescriptorProto) =>
+         Lens.Labels.HasLens' DescriptorProto "vector'oneofDecl" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'oneofDecl
@@ -158,9 +233,27 @@ instance a ~ ([DescriptorProto'ReservedRange]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'reservedRange
                (\ x__ y__ -> x__{_DescriptorProto'reservedRange = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector DescriptorProto'ReservedRange) =>
+         Lens.Labels.HasLens' DescriptorProto "vector'reservedRange" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'reservedRange
+               (\ x__ y__ -> x__{_DescriptorProto'reservedRange = y__}))
               Prelude.. Prelude.id
 instance a ~ ([Data.Text.Text]) =>
          Lens.Labels.HasLens' DescriptorProto "reservedName" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _DescriptorProto'reservedName
+               (\ x__ y__ -> x__{_DescriptorProto'reservedName = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector Data.Text.Text) =>
+         Lens.Labels.HasLens' DescriptorProto "vector'reservedName" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'reservedName
@@ -266,22 +359,81 @@ instance Data.ProtoLens.Message DescriptorProto where
               (\ x__ y__ -> x__{_DescriptorProto'_unknownFields = y__})
         defMessage
           = DescriptorProto{_DescriptorProto'name = Prelude.Nothing,
-                            _DescriptorProto'field = [], _DescriptorProto'extension = [],
-                            _DescriptorProto'nestedType = [], _DescriptorProto'enumType = [],
-                            _DescriptorProto'extensionRange = [],
-                            _DescriptorProto'oneofDecl = [],
+                            _DescriptorProto'field = Data.Vector.Generic.empty,
+                            _DescriptorProto'extension = Data.Vector.Generic.empty,
+                            _DescriptorProto'nestedType = Data.Vector.Generic.empty,
+                            _DescriptorProto'enumType = Data.Vector.Generic.empty,
+                            _DescriptorProto'extensionRange = Data.Vector.Generic.empty,
+                            _DescriptorProto'oneofDecl = Data.Vector.Generic.empty,
                             _DescriptorProto'options = Prelude.Nothing,
-                            _DescriptorProto'reservedRange = [],
-                            _DescriptorProto'reservedName = [],
+                            _DescriptorProto'reservedRange = Data.Vector.Generic.empty,
+                            _DescriptorProto'reservedName = Data.Vector.Generic.empty,
                             _DescriptorProto'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      DescriptorProto ->
-                       Data.ProtoLens.Encoding.Bytes.Parser DescriptorProto
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         EnumDescriptorProto
+                         ->
+                         Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                           Data.ProtoLens.Encoding.Growing.RealWorld
+                           FieldDescriptorProto
+                           ->
+                           Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                             Data.ProtoLens.Encoding.Growing.RealWorld
+                             DescriptorProto'ExtensionRange
+                             ->
+                             Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                               Data.ProtoLens.Encoding.Growing.RealWorld
+                               FieldDescriptorProto
+                               ->
+                               Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                                 Data.ProtoLens.Encoding.Growing.RealWorld
+                                 DescriptorProto
+                                 ->
+                                 Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                                   Data.ProtoLens.Encoding.Growing.RealWorld
+                                   OneofDescriptorProto
+                                   ->
+                                   Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                                     Data.ProtoLens.Encoding.Growing.RealWorld
+                                     Data.Text.Text
+                                     ->
+                                     Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                                       Data.ProtoLens.Encoding.Growing.RealWorld
+                                       DescriptorProto'ReservedRange
+                                       -> Data.ProtoLens.Encoding.Bytes.Parser DescriptorProto
+                loop x mutable'enumType mutable'extension mutable'extensionRange
+                  mutable'field mutable'nestedType mutable'oneofDecl
+                  mutable'reservedName mutable'reservedRange
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'enumType <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                 (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                    mutable'enumType)
+                            frozen'extension <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                     mutable'extension)
+                            frozen'extensionRange <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                       (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                          mutable'extensionRange)
+                            frozen'field <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                              (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                 mutable'field)
+                            frozen'nestedType <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                      mutable'nestedType)
+                            frozen'oneofDecl <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                     mutable'oneofDecl)
+                            frozen'reservedName <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                     (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                        mutable'reservedName)
+                            frozen'reservedRange <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                      (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                         mutable'reservedRange)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -289,45 +441,48 @@ instance Data.ProtoLens.Message DescriptorProto where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "field"))
-                                    (\ !t -> Prelude.reverse t)
-                                    (Lens.Family2.over
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "vector'enumType"))
+                                    frozen'enumType
+                                    (Lens.Family2.set
                                        (Lens.Labels.lensOf'
                                           ((Lens.Labels.proxy#) ::
-                                             (Lens.Labels.Proxy#) "extension"))
-                                       (\ !t -> Prelude.reverse t)
-                                       (Lens.Family2.over
+                                             (Lens.Labels.Proxy#) "vector'extension"))
+                                       frozen'extension
+                                       (Lens.Family2.set
                                           (Lens.Labels.lensOf'
                                              ((Lens.Labels.proxy#) ::
-                                                (Lens.Labels.Proxy#) "nestedType"))
-                                          (\ !t -> Prelude.reverse t)
-                                          (Lens.Family2.over
+                                                (Lens.Labels.Proxy#) "vector'extensionRange"))
+                                          frozen'extensionRange
+                                          (Lens.Family2.set
                                              (Lens.Labels.lensOf'
                                                 ((Lens.Labels.proxy#) ::
-                                                   (Lens.Labels.Proxy#) "enumType"))
-                                             (\ !t -> Prelude.reverse t)
-                                             (Lens.Family2.over
+                                                   (Lens.Labels.Proxy#) "vector'field"))
+                                             frozen'field
+                                             (Lens.Family2.set
                                                 (Lens.Labels.lensOf'
                                                    ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "extensionRange"))
-                                                (\ !t -> Prelude.reverse t)
-                                                (Lens.Family2.over
+                                                      (Lens.Labels.Proxy#) "vector'nestedType"))
+                                                frozen'nestedType
+                                                (Lens.Family2.set
                                                    (Lens.Labels.lensOf'
                                                       ((Lens.Labels.proxy#) ::
-                                                         (Lens.Labels.Proxy#) "oneofDecl"))
-                                                   (\ !t -> Prelude.reverse t)
-                                                   (Lens.Family2.over
+                                                         (Lens.Labels.Proxy#) "vector'oneofDecl"))
+                                                   frozen'oneofDecl
+                                                   (Lens.Family2.set
                                                       (Lens.Labels.lensOf'
                                                          ((Lens.Labels.proxy#) ::
-                                                            (Lens.Labels.Proxy#) "reservedRange"))
-                                                      (\ !t -> Prelude.reverse t)
-                                                      (Lens.Family2.over
+                                                            (Lens.Labels.Proxy#)
+                                                              "vector'reservedName"))
+                                                      frozen'reservedName
+                                                      (Lens.Family2.set
                                                          (Lens.Labels.lensOf'
                                                             ((Lens.Labels.proxy#) ::
-                                                               (Lens.Labels.Proxy#) "reservedName"))
-                                                         (\ !t -> Prelude.reverse t)
+                                                               (Lens.Labels.Proxy#)
+                                                                 "vector'reservedRange"))
+                                                         frozen'reservedRange
                                                          x)))))))))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -348,89 +503,110 @@ instance Data.ProtoLens.Message DescriptorProto where
                                                     (Lens.Labels.Proxy#) "name"))
                                               y
                                               x)
-                                18 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                           mutable'enumType
+                                           mutable'extension
+                                           mutable'extensionRange
+                                           mutable'field
+                                           mutable'nestedType
+                                           mutable'oneofDecl
+                                           mutable'reservedName
+                                           mutable'reservedRange
+                                18 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "field"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "field"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                50 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'field
+                                                   y)
+                                         loop x mutable'enumType mutable'extension
+                                           mutable'extensionRange
+                                           v
+                                           mutable'nestedType
+                                           mutable'oneofDecl
+                                           mutable'reservedName
+                                           mutable'reservedRange
+                                50 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "extension"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "extension"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                26 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'extension
+                                                   y)
+                                         loop x mutable'enumType v mutable'extensionRange
+                                           mutable'field
+                                           mutable'nestedType
+                                           mutable'oneofDecl
+                                           mutable'reservedName
+                                           mutable'reservedRange
+                                26 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "nested_type"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "nestedType"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                34 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'nestedType
+                                                   y)
+                                         loop x mutable'enumType mutable'extension
+                                           mutable'extensionRange
+                                           mutable'field
+                                           v
+                                           mutable'oneofDecl
+                                           mutable'reservedName
+                                           mutable'reservedRange
+                                34 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "enum_type"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "enumType"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                42 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'enumType
+                                                   y)
+                                         loop x v mutable'extension mutable'extensionRange
+                                           mutable'field
+                                           mutable'nestedType
+                                           mutable'oneofDecl
+                                           mutable'reservedName
+                                           mutable'reservedRange
+                                42 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "extension_range"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "extensionRange"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                66 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'extensionRange
+                                                   y)
+                                         loop x mutable'enumType mutable'extension v mutable'field
+                                           mutable'nestedType
+                                           mutable'oneofDecl
+                                           mutable'reservedName
+                                           mutable'reservedRange
+                                66 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "oneof_decl"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "oneofDecl"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                58 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                              Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                (Prelude.fromIntegral len)
-                                                  Data.ProtoLens.Encoding.Bytes.runEither
-                                                    (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'oneofDecl
+                                                   y)
+                                         loop x mutable'enumType mutable'extension
+                                           mutable'extensionRange
+                                           mutable'field
+                                           mutable'nestedType
+                                           v
+                                           mutable'reservedName
+                                           mutable'reservedRange
+                                58 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                  Data.ProtoLens.Encoding.Bytes.isolate
+                                                    (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.parseMessage)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "options"
                                          loop
                                            (Lens.Family2.set
@@ -439,19 +615,30 @@ instance Data.ProtoLens.Message DescriptorProto where
                                                     (Lens.Labels.Proxy#) "options"))
                                               y
                                               x)
-                                74 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                           mutable'enumType
+                                           mutable'extension
+                                           mutable'extensionRange
+                                           mutable'field
+                                           mutable'nestedType
+                                           mutable'oneofDecl
+                                           mutable'reservedName
+                                           mutable'reservedRange
+                                74 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "reserved_range"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "reservedRange"))
-                                              (\ !t -> (:) y t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'reservedRange
+                                                   y)
+                                         loop x mutable'enumType mutable'extension
+                                           mutable'extensionRange
+                                           mutable'field
+                                           mutable'nestedType
+                                           mutable'oneofDecl
+                                           mutable'reservedName
+                                           v
                                 82 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                                Data.ProtoLens.Encoding.Bytes.getBytes
                                                                  (Prelude.fromIntegral len)
@@ -461,22 +648,56 @@ instance Data.ProtoLens.Message DescriptorProto where
                                                                                 (Prelude.show err)
                                                           Prelude.Right r -> Prelude.Right r))
                                                  Data.ProtoLens.Encoding.Bytes.<?> "reserved_name"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "reservedName"))
-                                              (\ !t -> (:) y t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'reservedName
+                                                   y)
+                                         loop x mutable'enumType mutable'extension
+                                           mutable'extensionRange
+                                           mutable'field
+                                           mutable'nestedType
+                                           mutable'oneofDecl
+                                           v
+                                           mutable'reservedRange
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'enumType
+                                             mutable'extension
+                                             mutable'extensionRange
+                                             mutable'field
+                                             mutable'nestedType
+                                             mutable'oneofDecl
+                                             mutable'reservedName
+                                             mutable'reservedRange
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "DescriptorProto"
+              (do mutable'enumType <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                        Data.ProtoLens.Encoding.Growing.new
+                  mutable'extension <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                         Data.ProtoLens.Encoding.Growing.new
+                  mutable'extensionRange <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                              Data.ProtoLens.Encoding.Growing.new
+                  mutable'field <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                     Data.ProtoLens.Encoding.Growing.new
+                  mutable'nestedType <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                          Data.ProtoLens.Encoding.Growing.new
+                  mutable'oneofDecl <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                         Data.ProtoLens.Encoding.Growing.new
+                  mutable'reservedName <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                            Data.ProtoLens.Encoding.Growing.new
+                  mutable'reservedRange <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                             Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'enumType mutable'extension
+                    mutable'extensionRange
+                    mutable'field
+                    mutable'nestedType
+                    mutable'oneofDecl
+                    mutable'reservedName
+                    mutable'reservedRange)
+                Data.ProtoLens.Encoding.Bytes.<?> "DescriptorProto"
         buildMessage
           = (\ _x ->
                (case
@@ -496,70 +717,90 @@ instance Data.ProtoLens.Message DescriptorProto where
                                             Prelude.. Data.Text.Encoding.encodeUtf8)
                                            _v)
                  Data.Monoid.<>
-                 (Data.Monoid.mconcat
-                    (Prelude.map
-                       (\ _v ->
-                          (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                 (Data.Vector.Generic.foldr
+                    (\ _v as ->
+                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude.. Data.ProtoLens.encodeMessage)
+                            _v)
+                         Data.Monoid.<> as)
+                    Data.Monoid.mempty
+                    (Lens.Family2.view
+                       (Lens.Labels.lensOf'
+                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'field"))
+                       _x))
+                   Data.Monoid.<>
+                   (Data.Vector.Generic.foldr
+                      (\ _v as ->
+                         ((Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
                             (((\ bs ->
                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
                                     (Prelude.fromIntegral (Data.ByteString.length bs)))
                                    Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
                                Prelude.. Data.ProtoLens.encodeMessage)
                               _v)
-                       (Lens.Family2.view
-                          (Lens.Labels.lensOf'
-                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "field"))
-                          _x)))
-                   Data.Monoid.<>
-                   (Data.Monoid.mconcat
-                      (Prelude.map
-                         (\ _v ->
-                            (Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
+                           Data.Monoid.<> as)
+                      Data.Monoid.mempty
+                      (Lens.Family2.view
+                         (Lens.Labels.lensOf'
+                            ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'extension"))
+                         _x))
+                     Data.Monoid.<>
+                     (Data.Vector.Generic.foldr
+                        (\ _v as ->
+                           ((Data.ProtoLens.Encoding.Bytes.putVarInt 26) Data.Monoid.<>
                               (((\ bs ->
                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
                                       (Prelude.fromIntegral (Data.ByteString.length bs)))
                                      Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
                                  Prelude.. Data.ProtoLens.encodeMessage)
                                 _v)
-                         (Lens.Family2.view
-                            (Lens.Labels.lensOf'
-                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "extension"))
-                            _x)))
-                     Data.Monoid.<>
-                     (Data.Monoid.mconcat
-                        (Prelude.map
-                           (\ _v ->
-                              (Data.ProtoLens.Encoding.Bytes.putVarInt 26) Data.Monoid.<>
+                             Data.Monoid.<> as)
+                        Data.Monoid.mempty
+                        (Lens.Family2.view
+                           (Lens.Labels.lensOf'
+                              ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'nestedType"))
+                           _x))
+                       Data.Monoid.<>
+                       (Data.Vector.Generic.foldr
+                          (\ _v as ->
+                             ((Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
                                 (((\ bs ->
                                      (Data.ProtoLens.Encoding.Bytes.putVarInt
                                         (Prelude.fromIntegral (Data.ByteString.length bs)))
                                        Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
                                    Prelude.. Data.ProtoLens.encodeMessage)
                                   _v)
-                           (Lens.Family2.view
-                              (Lens.Labels.lensOf'
-                                 ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "nestedType"))
-                              _x)))
-                       Data.Monoid.<>
-                       (Data.Monoid.mconcat
-                          (Prelude.map
-                             (\ _v ->
-                                (Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
+                               Data.Monoid.<> as)
+                          Data.Monoid.mempty
+                          (Lens.Family2.view
+                             (Lens.Labels.lensOf'
+                                ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'enumType"))
+                             _x))
+                         Data.Monoid.<>
+                         (Data.Vector.Generic.foldr
+                            (\ _v as ->
+                               ((Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
                                   (((\ bs ->
                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
                                          Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
                                      Prelude.. Data.ProtoLens.encodeMessage)
                                     _v)
-                             (Lens.Family2.view
-                                (Lens.Labels.lensOf'
-                                   ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "enumType"))
-                                _x)))
-                         Data.Monoid.<>
-                         (Data.Monoid.mconcat
-                            (Prelude.map
-                               (\ _v ->
-                                  (Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
+                                 Data.Monoid.<> as)
+                            Data.Monoid.mempty
+                            (Lens.Family2.view
+                               (Lens.Labels.lensOf'
+                                  ((Lens.Labels.proxy#) ::
+                                     (Lens.Labels.Proxy#) "vector'extensionRange"))
+                               _x))
+                           Data.Monoid.<>
+                           (Data.Vector.Generic.foldr
+                              (\ _v as ->
+                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt 66) Data.Monoid.<>
                                     (((\ bs ->
                                          (Data.ProtoLens.Encoding.Bytes.putVarInt
                                             (Prelude.fromIntegral (Data.ByteString.length bs)))
@@ -567,27 +808,13 @@ instance Data.ProtoLens.Message DescriptorProto where
                                            Data.ProtoLens.Encoding.Bytes.putBytes bs))
                                        Prelude.. Data.ProtoLens.encodeMessage)
                                       _v)
-                               (Lens.Family2.view
-                                  (Lens.Labels.lensOf'
-                                     ((Lens.Labels.proxy#) ::
-                                        (Lens.Labels.Proxy#) "extensionRange"))
-                                  _x)))
-                           Data.Monoid.<>
-                           (Data.Monoid.mconcat
-                              (Prelude.map
-                                 (\ _v ->
-                                    (Data.ProtoLens.Encoding.Bytes.putVarInt 66) Data.Monoid.<>
-                                      (((\ bs ->
-                                           (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                              (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                             Data.Monoid.<>
-                                             Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                         Prelude.. Data.ProtoLens.encodeMessage)
-                                        _v)
-                                 (Lens.Family2.view
-                                    (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "oneofDecl"))
-                                    _x)))
+                                   Data.Monoid.<> as)
+                              Data.Monoid.mempty
+                              (Lens.Family2.view
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "vector'oneofDecl"))
+                                 _x))
                              Data.Monoid.<>
                              (case
                                 Lens.Family2.view
@@ -608,42 +835,42 @@ instance Data.ProtoLens.Message DescriptorProto where
                                                           Prelude.. Data.ProtoLens.encodeMessage)
                                                          _v)
                                Data.Monoid.<>
-                               (Data.Monoid.mconcat
-                                  (Prelude.map
-                                     (\ _v ->
-                                        (Data.ProtoLens.Encoding.Bytes.putVarInt 74) Data.Monoid.<>
+                               (Data.Vector.Generic.foldr
+                                  (\ _v as ->
+                                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 74) Data.Monoid.<>
+                                        (((\ bs ->
+                                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                               Data.Monoid.<>
+                                               Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                           Prelude.. Data.ProtoLens.encodeMessage)
+                                          _v)
+                                       Data.Monoid.<> as)
+                                  Data.Monoid.mempty
+                                  (Lens.Family2.view
+                                     (Lens.Labels.lensOf'
+                                        ((Lens.Labels.proxy#) ::
+                                           (Lens.Labels.Proxy#) "vector'reservedRange"))
+                                     _x))
+                                 Data.Monoid.<>
+                                 (Data.Vector.Generic.foldr
+                                    (\ _v as ->
+                                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 82) Data.Monoid.<>
                                           (((\ bs ->
                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
                                                   (Prelude.fromIntegral
                                                      (Data.ByteString.length bs)))
                                                  Data.Monoid.<>
                                                  Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                             Prelude.. Data.ProtoLens.encodeMessage)
+                                             Prelude.. Data.Text.Encoding.encodeUtf8)
                                             _v)
-                                     (Lens.Family2.view
-                                        (Lens.Labels.lensOf'
-                                           ((Lens.Labels.proxy#) ::
-                                              (Lens.Labels.Proxy#) "reservedRange"))
-                                        _x)))
-                                 Data.Monoid.<>
-                                 (Data.Monoid.mconcat
-                                    (Prelude.map
-                                       (\ _v ->
-                                          (Data.ProtoLens.Encoding.Bytes.putVarInt 82)
-                                            Data.Monoid.<>
-                                            (((\ bs ->
-                                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                                    (Prelude.fromIntegral
-                                                       (Data.ByteString.length bs)))
-                                                   Data.Monoid.<>
-                                                   Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                               Prelude.. Data.Text.Encoding.encodeUtf8)
-                                              _v)
-                                       (Lens.Family2.view
-                                          (Lens.Labels.lensOf'
-                                             ((Lens.Labels.proxy#) ::
-                                                (Lens.Labels.Proxy#) "reservedName"))
-                                          _x)))
+                                         Data.Monoid.<> as)
+                                    Data.Monoid.mempty
+                                    (Lens.Family2.view
+                                       (Lens.Labels.lensOf'
+                                          ((Lens.Labels.proxy#) ::
+                                             (Lens.Labels.Proxy#) "vector'reservedName"))
+                                       _x))
                                    Data.Monoid.<>
                                    Data.ProtoLens.Encoding.Wire.buildFieldSet
                                      (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -826,11 +1053,10 @@ instance Data.ProtoLens.Message DescriptorProto'ExtensionRange
                                                     (Lens.Labels.Proxy#) "end"))
                                               y
                                               x)
-                                26 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                              Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                (Prelude.fromIntegral len)
-                                                  Data.ProtoLens.Encoding.Bytes.runEither
-                                                    (Data.ProtoLens.decodeMessage value))
+                                26 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                  Data.ProtoLens.Encoding.Bytes.isolate
+                                                    (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.parseMessage)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "options"
                                          loop
                                            (Lens.Family2.set
@@ -846,8 +1072,8 @@ instance Data.ProtoLens.Message DescriptorProto'ExtensionRange
                                                 (\ !t -> (:) y t)
                                                 x)
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "ExtensionRange"
+              (do loop Data.ProtoLens.defMessage)
+                Data.ProtoLens.Encoding.Bytes.<?> "ExtensionRange"
         buildMessage
           = (\ _x ->
                (case
@@ -1037,8 +1263,8 @@ instance Data.ProtoLens.Message DescriptorProto'ReservedRange where
                                                 (\ !t -> (:) y t)
                                                 x)
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "ReservedRange"
+              (do loop Data.ProtoLens.defMessage)
+                Data.ProtoLens.Encoding.Bytes.<?> "ReservedRange"
         buildMessage
           = (\ _x ->
                (case
@@ -1082,21 +1308,27 @@ instance Control.DeepSeq.NFData DescriptorProto'ReservedRange where
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' EnumDescriptorProto Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'name' @:: Lens' EnumDescriptorProto (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.value' @:: Lens' EnumDescriptorProto [EnumValueDescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'value' @:: Lens' EnumDescriptorProto
+  (Data.Vector.Vector EnumValueDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.options' @:: Lens' EnumDescriptorProto EnumOptions@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'options' @:: Lens' EnumDescriptorProto (Prelude.Maybe EnumOptions)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.reservedRange' @:: Lens' EnumDescriptorProto [EnumDescriptorProto'EnumReservedRange]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'reservedRange' @:: Lens' EnumDescriptorProto
+  (Data.Vector.Vector EnumDescriptorProto'EnumReservedRange)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.reservedName' @:: Lens' EnumDescriptorProto [Data.Text.Text]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'reservedName' @:: Lens' EnumDescriptorProto (Data.Vector.Vector Data.Text.Text)@
  -}
 data EnumDescriptorProto = EnumDescriptorProto{_EnumDescriptorProto'name
                                                :: !(Prelude.Maybe Data.Text.Text),
                                                _EnumDescriptorProto'value ::
-                                               ![EnumValueDescriptorProto],
+                                               !(Data.Vector.Vector EnumValueDescriptorProto),
                                                _EnumDescriptorProto'options ::
                                                !(Prelude.Maybe EnumOptions),
                                                _EnumDescriptorProto'reservedRange ::
-                                               ![EnumDescriptorProto'EnumReservedRange],
+                                               !(Data.Vector.Vector
+                                                   EnumDescriptorProto'EnumReservedRange),
                                                _EnumDescriptorProto'reservedName ::
-                                               ![Data.Text.Text],
+                                               !(Data.Vector.Vector Data.Text.Text),
                                                _EnumDescriptorProto'_unknownFields ::
                                                !Data.ProtoLens.FieldSet}
                              deriving (Prelude.Eq, Prelude.Ord)
@@ -1125,6 +1357,15 @@ instance a ~ ([EnumValueDescriptorProto]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'value
                (\ x__ y__ -> x__{_EnumDescriptorProto'value = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector EnumValueDescriptorProto) =>
+         Lens.Labels.HasLens' EnumDescriptorProto "vector'value" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'value
+               (\ x__ y__ -> x__{_EnumDescriptorProto'value = y__}))
               Prelude.. Prelude.id
 instance a ~ (EnumOptions) =>
          Lens.Labels.HasLens' EnumDescriptorProto "options" a
@@ -1146,9 +1387,28 @@ instance a ~ ([EnumDescriptorProto'EnumReservedRange]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'reservedRange
                (\ x__ y__ -> x__{_EnumDescriptorProto'reservedRange = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~
+           (Data.Vector.Vector EnumDescriptorProto'EnumReservedRange) =>
+         Lens.Labels.HasLens' EnumDescriptorProto "vector'reservedRange" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'reservedRange
+               (\ x__ y__ -> x__{_EnumDescriptorProto'reservedRange = y__}))
               Prelude.. Prelude.id
 instance a ~ ([Data.Text.Text]) =>
          Lens.Labels.HasLens' EnumDescriptorProto "reservedName" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'reservedName
+               (\ x__ y__ -> x__{_EnumDescriptorProto'reservedName = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector Data.Text.Text) =>
+         Lens.Labels.HasLens' EnumDescriptorProto "vector'reservedName" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'reservedName
@@ -1211,19 +1471,39 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
               (\ x__ y__ -> x__{_EnumDescriptorProto'_unknownFields = y__})
         defMessage
           = EnumDescriptorProto{_EnumDescriptorProto'name = Prelude.Nothing,
-                                _EnumDescriptorProto'value = [],
+                                _EnumDescriptorProto'value = Data.Vector.Generic.empty,
                                 _EnumDescriptorProto'options = Prelude.Nothing,
-                                _EnumDescriptorProto'reservedRange = [],
-                                _EnumDescriptorProto'reservedName = [],
+                                _EnumDescriptorProto'reservedRange = Data.Vector.Generic.empty,
+                                _EnumDescriptorProto'reservedName = Data.Vector.Generic.empty,
                                 _EnumDescriptorProto'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      EnumDescriptorProto ->
-                       Data.ProtoLens.Encoding.Bytes.Parser EnumDescriptorProto
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         Data.Text.Text
+                         ->
+                         Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                           Data.ProtoLens.Encoding.Growing.RealWorld
+                           EnumDescriptorProto'EnumReservedRange
+                           ->
+                           Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                             Data.ProtoLens.Encoding.Growing.RealWorld
+                             EnumValueDescriptorProto
+                             -> Data.ProtoLens.Encoding.Bytes.Parser EnumDescriptorProto
+                loop x mutable'reservedName mutable'reservedRange mutable'value
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'reservedName <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                     (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                        mutable'reservedName)
+                            frozen'reservedRange <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                      (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                         mutable'reservedRange)
+                            frozen'value <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                              (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                 mutable'value)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -1231,20 +1511,21 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "value"))
-                                    (\ !t -> Prelude.reverse t)
-                                    (Lens.Family2.over
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "vector'reservedName"))
+                                    frozen'reservedName
+                                    (Lens.Family2.set
                                        (Lens.Labels.lensOf'
                                           ((Lens.Labels.proxy#) ::
-                                             (Lens.Labels.Proxy#) "reservedRange"))
-                                       (\ !t -> Prelude.reverse t)
-                                       (Lens.Family2.over
+                                             (Lens.Labels.Proxy#) "vector'reservedRange"))
+                                       frozen'reservedRange
+                                       (Lens.Family2.set
                                           (Lens.Labels.lensOf'
                                              ((Lens.Labels.proxy#) ::
-                                                (Lens.Labels.Proxy#) "reservedName"))
-                                          (\ !t -> Prelude.reverse t)
+                                                (Lens.Labels.Proxy#) "vector'value"))
+                                          frozen'value
                                           x))))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -1265,24 +1546,23 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                                                     (Lens.Labels.Proxy#) "name"))
                                               y
                                               x)
-                                18 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                           mutable'reservedName
+                                           mutable'reservedRange
+                                           mutable'value
+                                18 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "value"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "value"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                26 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                              Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                (Prelude.fromIntegral len)
-                                                  Data.ProtoLens.Encoding.Bytes.runEither
-                                                    (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'value
+                                                   y)
+                                         loop x mutable'reservedName mutable'reservedRange v
+                                26 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                  Data.ProtoLens.Encoding.Bytes.isolate
+                                                    (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.parseMessage)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "options"
                                          loop
                                            (Lens.Family2.set
@@ -1291,19 +1571,19 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                                                     (Lens.Labels.Proxy#) "options"))
                                               y
                                               x)
-                                34 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                           mutable'reservedName
+                                           mutable'reservedRange
+                                           mutable'value
+                                34 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "reserved_range"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "reservedRange"))
-                                              (\ !t -> (:) y t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'reservedRange
+                                                   y)
+                                         loop x mutable'reservedName v mutable'value
                                 42 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                                Data.ProtoLens.Encoding.Bytes.getBytes
                                                                  (Prelude.fromIntegral len)
@@ -1313,22 +1593,31 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                                                                                 (Prelude.show err)
                                                           Prelude.Right r -> Prelude.Right r))
                                                  Data.ProtoLens.Encoding.Bytes.<?> "reserved_name"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "reservedName"))
-                                              (\ !t -> (:) y t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'reservedName
+                                                   y)
+                                         loop x v mutable'reservedRange mutable'value
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'reservedName
+                                             mutable'reservedRange
+                                             mutable'value
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "EnumDescriptorProto"
+              (do mutable'reservedName <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                            Data.ProtoLens.Encoding.Growing.new
+                  mutable'reservedRange <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                             Data.ProtoLens.Encoding.Growing.new
+                  mutable'value <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                     Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'reservedName
+                    mutable'reservedRange
+                    mutable'value)
+                Data.ProtoLens.Encoding.Bytes.<?> "EnumDescriptorProto"
         buildMessage
           = (\ _x ->
                (case
@@ -1348,20 +1637,21 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                                             Prelude.. Data.Text.Encoding.encodeUtf8)
                                            _v)
                  Data.Monoid.<>
-                 (Data.Monoid.mconcat
-                    (Prelude.map
-                       (\ _v ->
-                          (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
-                            (((\ bs ->
-                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                               Prelude.. Data.ProtoLens.encodeMessage)
-                              _v)
-                       (Lens.Family2.view
-                          (Lens.Labels.lensOf'
-                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "value"))
-                          _x)))
+                 (Data.Vector.Generic.foldr
+                    (\ _v as ->
+                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude.. Data.ProtoLens.encodeMessage)
+                            _v)
+                         Data.Monoid.<> as)
+                    Data.Monoid.mempty
+                    (Lens.Family2.view
+                       (Lens.Labels.lensOf'
+                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'value"))
+                       _x))
                    Data.Monoid.<>
                    (case
                       Lens.Family2.view
@@ -1381,35 +1671,39 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                                                 Prelude.. Data.ProtoLens.encodeMessage)
                                                _v)
                      Data.Monoid.<>
-                     (Data.Monoid.mconcat
-                        (Prelude.map
-                           (\ _v ->
-                              (Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
+                     (Data.Vector.Generic.foldr
+                        (\ _v as ->
+                           ((Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
+                              (((\ bs ->
+                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                 Prelude.. Data.ProtoLens.encodeMessage)
+                                _v)
+                             Data.Monoid.<> as)
+                        Data.Monoid.mempty
+                        (Lens.Family2.view
+                           (Lens.Labels.lensOf'
+                              ((Lens.Labels.proxy#) ::
+                                 (Lens.Labels.Proxy#) "vector'reservedRange"))
+                           _x))
+                       Data.Monoid.<>
+                       (Data.Vector.Generic.foldr
+                          (\ _v as ->
+                             ((Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
                                 (((\ bs ->
                                      (Data.ProtoLens.Encoding.Bytes.putVarInt
                                         (Prelude.fromIntegral (Data.ByteString.length bs)))
                                        Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                   Prelude.. Data.ProtoLens.encodeMessage)
+                                   Prelude.. Data.Text.Encoding.encodeUtf8)
                                   _v)
-                           (Lens.Family2.view
-                              (Lens.Labels.lensOf'
-                                 ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "reservedRange"))
-                              _x)))
-                       Data.Monoid.<>
-                       (Data.Monoid.mconcat
-                          (Prelude.map
-                             (\ _v ->
-                                (Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
-                                  (((\ bs ->
-                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                          (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                         Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                     Prelude.. Data.Text.Encoding.encodeUtf8)
-                                    _v)
-                             (Lens.Family2.view
-                                (Lens.Labels.lensOf'
-                                   ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "reservedName"))
-                                _x)))
+                               Data.Monoid.<> as)
+                          Data.Monoid.mempty
+                          (Lens.Family2.view
+                             (Lens.Labels.lensOf'
+                                ((Lens.Labels.proxy#) ::
+                                   (Lens.Labels.Proxy#) "vector'reservedName"))
+                             _x))
                          Data.Monoid.<>
                          Data.ProtoLens.Encoding.Wire.buildFieldSet
                            (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -1580,8 +1874,8 @@ instance Data.ProtoLens.Message
                                                 (\ !t -> (:) y t)
                                                 x)
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "EnumReservedRange"
+              (do loop Data.ProtoLens.defMessage)
+                Data.ProtoLens.Encoding.Bytes.<?> "EnumReservedRange"
         buildMessage
           = (\ _x ->
                (case
@@ -1631,11 +1925,13 @@ instance Control.DeepSeq.NFData
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' EnumOptions Prelude.Bool@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'deprecated' @:: Lens' EnumOptions (Prelude.Maybe Prelude.Bool)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' EnumOptions [UninterpretedOption]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' EnumOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data EnumOptions = EnumOptions{_EnumOptions'allowAlias ::
                                !(Prelude.Maybe Prelude.Bool),
                                _EnumOptions'deprecated :: !(Prelude.Maybe Prelude.Bool),
-                               _EnumOptions'uninterpretedOption :: ![UninterpretedOption],
+                               _EnumOptions'uninterpretedOption ::
+                               !(Data.Vector.Vector UninterpretedOption),
                                _EnumOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
                      deriving (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show EnumOptions where
@@ -1673,6 +1969,15 @@ instance a ~ (Prelude.Maybe Prelude.Bool) =>
               Prelude.. Prelude.id
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' EnumOptions "uninterpretedOption" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _EnumOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_EnumOptions'uninterpretedOption = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector UninterpretedOption) =>
+         Lens.Labels.HasLens' EnumOptions "vector'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _EnumOptions'uninterpretedOption
@@ -1717,15 +2022,22 @@ instance Data.ProtoLens.Message EnumOptions where
         defMessage
           = EnumOptions{_EnumOptions'allowAlias = Prelude.Nothing,
                         _EnumOptions'deprecated = Prelude.Nothing,
-                        _EnumOptions'uninterpretedOption = [],
+                        _EnumOptions'uninterpretedOption = Data.Vector.Generic.empty,
                         _EnumOptions'_unknownFields = ([])}
         parseMessage
           = let loop ::
-                     EnumOptions -> Data.ProtoLens.Encoding.Bytes.Parser EnumOptions
-                loop x
+                     EnumOptions ->
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         UninterpretedOption
+                         -> Data.ProtoLens.Encoding.Bytes.Parser EnumOptions
+                loop x mutable'uninterpretedOption
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                            (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                               mutable'uninterpretedOption)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -1733,11 +2045,11 @@ instance Data.ProtoLens.Message EnumOptions where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                    (\ !t -> Prelude.reverse t)
+                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                    frozen'uninterpretedOption
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -1752,6 +2064,7 @@ instance Data.ProtoLens.Message EnumOptions where
                                                     (Lens.Labels.Proxy#) "allowAlias"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 24 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "deprecated"
@@ -1762,29 +2075,30 @@ instance Data.ProtoLens.Message EnumOptions where
                                                     (Lens.Labels.Proxy#) "deprecated"))
                                               y
                                               x)
-                                7994 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                                 Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                   (Prelude.fromIntegral len)
-                                                     Data.ProtoLens.Encoding.Bytes.runEither
-                                                       (Data.ProtoLens.decodeMessage value))
+                                           mutable'uninterpretedOption
+                                7994 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.isolate
+                                                       (Prelude.fromIntegral len)
+                                                       Data.ProtoLens.parseMessage)
                                                    Data.ProtoLens.Encoding.Bytes.<?>
                                                    "uninterpreted_option"
-                                           loop
-                                             (Lens.Family2.over
-                                                (Lens.Labels.lensOf'
-                                                   ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                                (\ !t -> (:) y t)
-                                                x)
+                                           v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.append
+                                                     mutable'uninterpretedOption
+                                                     y)
+                                           loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'uninterpretedOption
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "EnumOptions"
+              (do mutable'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'uninterpretedOption)
+                Data.ProtoLens.Encoding.Bytes.<?> "EnumOptions"
         buildMessage
           = (\ _x ->
                (case
@@ -1813,21 +2127,22 @@ instance Data.ProtoLens.Message EnumOptions where
                                               (\ b -> if b then 1 else 0))
                                              _v)
                    Data.Monoid.<>
-                   (Data.Monoid.mconcat
-                      (Prelude.map
-                         (\ _v ->
-                            (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                              (((\ bs ->
-                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                 Prelude.. Data.ProtoLens.encodeMessage)
-                                _v)
-                         (Lens.Family2.view
-                            (Lens.Labels.lensOf'
-                               ((Lens.Labels.proxy#) ::
-                                  (Lens.Labels.Proxy#) "uninterpretedOption"))
-                            _x)))
+                   (Data.Vector.Generic.foldr
+                      (\ _v as ->
+                         ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                            (((\ bs ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                               Prelude.. Data.ProtoLens.encodeMessage)
+                              _v)
+                           Data.Monoid.<> as)
+                      Data.Monoid.mempty
+                      (Lens.Family2.view
+                         (Lens.Labels.lensOf'
+                            ((Lens.Labels.proxy#) ::
+                               (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                         _x))
                      Data.Monoid.<>
                      Data.ProtoLens.Encoding.Wire.buildFieldSet
                        (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -1992,11 +2307,10 @@ instance Data.ProtoLens.Message EnumValueDescriptorProto where
                                                     (Lens.Labels.Proxy#) "number"))
                                               y
                                               x)
-                                26 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                              Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                (Prelude.fromIntegral len)
-                                                  Data.ProtoLens.Encoding.Bytes.runEither
-                                                    (Data.ProtoLens.decodeMessage value))
+                                26 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                  Data.ProtoLens.Encoding.Bytes.isolate
+                                                    (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.parseMessage)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "options"
                                          loop
                                            (Lens.Family2.set
@@ -2012,8 +2326,8 @@ instance Data.ProtoLens.Message EnumValueDescriptorProto where
                                                 (\ !t -> (:) y t)
                                                 x)
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "EnumValueDescriptorProto"
+              (do loop Data.ProtoLens.defMessage)
+                Data.ProtoLens.Encoding.Bytes.<?> "EnumValueDescriptorProto"
         buildMessage
           = (\ _x ->
                (case
@@ -2080,11 +2394,12 @@ instance Control.DeepSeq.NFData EnumValueDescriptorProto where
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' EnumValueOptions Prelude.Bool@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'deprecated' @:: Lens' EnumValueOptions (Prelude.Maybe Prelude.Bool)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' EnumValueOptions [UninterpretedOption]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' EnumValueOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data EnumValueOptions = EnumValueOptions{_EnumValueOptions'deprecated
                                          :: !(Prelude.Maybe Prelude.Bool),
                                          _EnumValueOptions'uninterpretedOption ::
-                                         ![UninterpretedOption],
+                                         !(Data.Vector.Vector UninterpretedOption),
                                          _EnumValueOptions'_unknownFields ::
                                          !Data.ProtoLens.FieldSet}
                           deriving (Prelude.Eq, Prelude.Ord)
@@ -2109,6 +2424,17 @@ instance a ~ (Prelude.Maybe Prelude.Bool) =>
               Prelude.. Prelude.id
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' EnumValueOptions "uninterpretedOption" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens
+               _EnumValueOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_EnumValueOptions'uninterpretedOption = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector UninterpretedOption) =>
+         Lens.Labels.HasLens' EnumValueOptions "vector'uninterpretedOption"
+           a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens
@@ -2144,16 +2470,22 @@ instance Data.ProtoLens.Message EnumValueOptions where
               (\ x__ y__ -> x__{_EnumValueOptions'_unknownFields = y__})
         defMessage
           = EnumValueOptions{_EnumValueOptions'deprecated = Prelude.Nothing,
-                             _EnumValueOptions'uninterpretedOption = [],
+                             _EnumValueOptions'uninterpretedOption = Data.Vector.Generic.empty,
                              _EnumValueOptions'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      EnumValueOptions ->
-                       Data.ProtoLens.Encoding.Bytes.Parser EnumValueOptions
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         UninterpretedOption
+                         -> Data.ProtoLens.Encoding.Bytes.Parser EnumValueOptions
+                loop x mutable'uninterpretedOption
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                            (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                               mutable'uninterpretedOption)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -2161,11 +2493,11 @@ instance Data.ProtoLens.Message EnumValueOptions where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                    (\ !t -> Prelude.reverse t)
+                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                    frozen'uninterpretedOption
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -2180,29 +2512,30 @@ instance Data.ProtoLens.Message EnumValueOptions where
                                                    (Lens.Labels.Proxy#) "deprecated"))
                                              y
                                              x)
-                                7994 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                                 Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                   (Prelude.fromIntegral len)
-                                                     Data.ProtoLens.Encoding.Bytes.runEither
-                                                       (Data.ProtoLens.decodeMessage value))
+                                          mutable'uninterpretedOption
+                                7994 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.isolate
+                                                       (Prelude.fromIntegral len)
+                                                       Data.ProtoLens.parseMessage)
                                                    Data.ProtoLens.Encoding.Bytes.<?>
                                                    "uninterpreted_option"
-                                           loop
-                                             (Lens.Family2.over
-                                                (Lens.Labels.lensOf'
-                                                   ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                                (\ !t -> (:) y t)
-                                                x)
+                                           v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.append
+                                                     mutable'uninterpretedOption
+                                                     y)
+                                           loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'uninterpretedOption
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "EnumValueOptions"
+              (do mutable'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'uninterpretedOption)
+                Data.ProtoLens.Encoding.Bytes.<?> "EnumValueOptions"
         buildMessage
           = (\ _x ->
                (case
@@ -2218,21 +2551,22 @@ instance Data.ProtoLens.Message EnumValueOptions where
                                             (\ b -> if b then 1 else 0))
                                            _v)
                  Data.Monoid.<>
-                 (Data.Monoid.mconcat
-                    (Prelude.map
-                       (\ _v ->
-                          (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                            (((\ bs ->
-                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                               Prelude.. Data.ProtoLens.encodeMessage)
-                              _v)
-                       (Lens.Family2.view
-                          (Lens.Labels.lensOf'
-                             ((Lens.Labels.proxy#) ::
-                                (Lens.Labels.Proxy#) "uninterpretedOption"))
-                          _x)))
+                 (Data.Vector.Generic.foldr
+                    (\ _v as ->
+                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude.. Data.ProtoLens.encodeMessage)
+                            _v)
+                         Data.Monoid.<> as)
+                    Data.Monoid.mempty
+                    (Lens.Family2.view
+                       (Lens.Labels.lensOf'
+                          ((Lens.Labels.proxy#) ::
+                             (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                       _x))
                    Data.Monoid.<>
                    Data.ProtoLens.Encoding.Wire.buildFieldSet
                      (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -2247,9 +2581,11 @@ instance Control.DeepSeq.NFData EnumValueOptions where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' ExtensionRangeOptions [UninterpretedOption]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' ExtensionRangeOptions
+  (Data.Vector.Vector UninterpretedOption)@
  -}
 data ExtensionRangeOptions = ExtensionRangeOptions{_ExtensionRangeOptions'uninterpretedOption
-                                                   :: ![UninterpretedOption],
+                                                   :: !(Data.Vector.Vector UninterpretedOption),
                                                    _ExtensionRangeOptions'_unknownFields ::
                                                    !Data.ProtoLens.FieldSet}
                                deriving (Prelude.Eq, Prelude.Ord)
@@ -2260,6 +2596,19 @@ instance Prelude.Show ExtensionRangeOptions where
                  (Prelude.showChar '}' __s))
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' ExtensionRangeOptions "uninterpretedOption" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens
+               _ExtensionRangeOptions'uninterpretedOption
+               (\ x__ y__ ->
+                  x__{_ExtensionRangeOptions'uninterpretedOption = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector UninterpretedOption) =>
+         Lens.Labels.HasLens' ExtensionRangeOptions
+           "vector'uninterpretedOption"
+           a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens
@@ -2288,16 +2637,22 @@ instance Data.ProtoLens.Message ExtensionRangeOptions where
               (\ x__ y__ -> x__{_ExtensionRangeOptions'_unknownFields = y__})
         defMessage
           = ExtensionRangeOptions{_ExtensionRangeOptions'uninterpretedOption
-                                    = [],
+                                    = Data.Vector.Generic.empty,
                                   _ExtensionRangeOptions'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      ExtensionRangeOptions ->
-                       Data.ProtoLens.Encoding.Bytes.Parser ExtensionRangeOptions
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         UninterpretedOption
+                         -> Data.ProtoLens.Encoding.Bytes.Parser ExtensionRangeOptions
+                loop x mutable'uninterpretedOption
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                            (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                               mutable'uninterpretedOption)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -2305,55 +2660,56 @@ instance Data.ProtoLens.Message ExtensionRangeOptions where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                    (\ !t -> Prelude.reverse t)
+                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                    frozen'uninterpretedOption
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
                             case tag of
-                                7994 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                                 Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                   (Prelude.fromIntegral len)
-                                                     Data.ProtoLens.Encoding.Bytes.runEither
-                                                       (Data.ProtoLens.decodeMessage value))
+                                7994 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.isolate
+                                                       (Prelude.fromIntegral len)
+                                                       Data.ProtoLens.parseMessage)
                                                    Data.ProtoLens.Encoding.Bytes.<?>
                                                    "uninterpreted_option"
-                                           loop
-                                             (Lens.Family2.over
-                                                (Lens.Labels.lensOf'
-                                                   ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                                (\ !t -> (:) y t)
-                                                x)
+                                           v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.append
+                                                     mutable'uninterpretedOption
+                                                     y)
+                                           loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'uninterpretedOption
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "ExtensionRangeOptions"
+              (do mutable'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'uninterpretedOption)
+                Data.ProtoLens.Encoding.Bytes.<?> "ExtensionRangeOptions"
         buildMessage
           = (\ _x ->
-               (Data.Monoid.mconcat
-                  (Prelude.map
-                     (\ _v ->
-                        (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                     (Lens.Family2.view
-                        (Lens.Labels.lensOf'
-                           ((Lens.Labels.proxy#) ::
-                              (Lens.Labels.Proxy#) "uninterpretedOption"))
-                        _x)))
+               (Data.Vector.Generic.foldr
+                  (\ _v as ->
+                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                        (((\ bs ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                (Prelude.fromIntegral (Data.ByteString.length bs)))
+                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                           Prelude.. Data.ProtoLens.encodeMessage)
+                          _v)
+                       Data.Monoid.<> as)
+                  Data.Monoid.mempty
+                  (Lens.Family2.view
+                     (Lens.Labels.lensOf'
+                        ((Lens.Labels.proxy#) ::
+                           (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                     _x))
                  Data.Monoid.<>
                  Data.ProtoLens.Encoding.Wire.buildFieldSet
                    (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -2811,11 +3167,10 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                                                     (Lens.Labels.Proxy#) "jsonName"))
                                               y
                                               x)
-                                66 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                              Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                (Prelude.fromIntegral len)
-                                                  Data.ProtoLens.Encoding.Bytes.runEither
-                                                    (Data.ProtoLens.decodeMessage value))
+                                66 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                  Data.ProtoLens.Encoding.Bytes.isolate
+                                                    (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.parseMessage)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "options"
                                          loop
                                            (Lens.Family2.set
@@ -2831,8 +3186,8 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                                                 (\ !t -> (:) y t)
                                                 x)
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "FieldDescriptorProto"
+              (do loop Data.ProtoLens.defMessage)
+                Data.ProtoLens.Encoding.Bytes.<?> "FieldDescriptorProto"
         buildMessage
           = (\ _x ->
                (case
@@ -3308,6 +3663,7 @@ instance Control.DeepSeq.NFData FieldDescriptorProto'Type where
     * 'Proto.Google.Protobuf.Descriptor_Fields.weak' @:: Lens' FieldOptions Prelude.Bool@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'weak' @:: Lens' FieldOptions (Prelude.Maybe Prelude.Bool)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' FieldOptions [UninterpretedOption]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' FieldOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data FieldOptions = FieldOptions{_FieldOptions'ctype ::
                                  !(Prelude.Maybe FieldOptions'CType),
@@ -3316,7 +3672,8 @@ data FieldOptions = FieldOptions{_FieldOptions'ctype ::
                                  _FieldOptions'lazy :: !(Prelude.Maybe Prelude.Bool),
                                  _FieldOptions'deprecated :: !(Prelude.Maybe Prelude.Bool),
                                  _FieldOptions'weak :: !(Prelude.Maybe Prelude.Bool),
-                                 _FieldOptions'uninterpretedOption :: ![UninterpretedOption],
+                                 _FieldOptions'uninterpretedOption ::
+                                 !(Data.Vector.Vector UninterpretedOption),
                                  _FieldOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
                       deriving (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show FieldOptions where
@@ -3414,6 +3771,15 @@ instance a ~ ([UninterpretedOption]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FieldOptions'uninterpretedOption
                (\ x__ y__ -> x__{_FieldOptions'uninterpretedOption = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector UninterpretedOption) =>
+         Lens.Labels.HasLens' FieldOptions "vector'uninterpretedOption" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _FieldOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_FieldOptions'uninterpretedOption = y__}))
               Prelude.. Prelude.id
 instance Data.ProtoLens.Message FieldOptions where
         messageName _ = Data.Text.pack "google.protobuf.FieldOptions"
@@ -3494,15 +3860,22 @@ instance Data.ProtoLens.Message FieldOptions where
                          _FieldOptions'lazy = Prelude.Nothing,
                          _FieldOptions'deprecated = Prelude.Nothing,
                          _FieldOptions'weak = Prelude.Nothing,
-                         _FieldOptions'uninterpretedOption = [],
+                         _FieldOptions'uninterpretedOption = Data.Vector.Generic.empty,
                          _FieldOptions'_unknownFields = ([])}
         parseMessage
           = let loop ::
-                     FieldOptions -> Data.ProtoLens.Encoding.Bytes.Parser FieldOptions
-                loop x
+                     FieldOptions ->
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         UninterpretedOption
+                         -> Data.ProtoLens.Encoding.Bytes.Parser FieldOptions
+                loop x mutable'uninterpretedOption
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                            (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                               mutable'uninterpretedOption)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -3510,11 +3883,11 @@ instance Data.ProtoLens.Message FieldOptions where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                    (\ !t -> Prelude.reverse t)
+                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                    frozen'uninterpretedOption
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -3530,6 +3903,7 @@ instance Data.ProtoLens.Message FieldOptions where
                                                    (Lens.Labels.Proxy#) "ctype"))
                                              y
                                              x)
+                                          mutable'uninterpretedOption
                                 16 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "packed"
@@ -3540,6 +3914,7 @@ instance Data.ProtoLens.Message FieldOptions where
                                                     (Lens.Labels.Proxy#) "packed"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 48 -> do y <- (Prelude.fmap Prelude.toEnum
                                                  (Prelude.fmap Prelude.fromIntegral
                                                     Data.ProtoLens.Encoding.Bytes.getVarInt))
@@ -3551,6 +3926,7 @@ instance Data.ProtoLens.Message FieldOptions where
                                                     (Lens.Labels.Proxy#) "jstype"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 40 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "lazy"
@@ -3561,6 +3937,7 @@ instance Data.ProtoLens.Message FieldOptions where
                                                     (Lens.Labels.Proxy#) "lazy"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 24 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "deprecated"
@@ -3571,6 +3948,7 @@ instance Data.ProtoLens.Message FieldOptions where
                                                     (Lens.Labels.Proxy#) "deprecated"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 80 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "weak"
@@ -3581,29 +3959,30 @@ instance Data.ProtoLens.Message FieldOptions where
                                                     (Lens.Labels.Proxy#) "weak"))
                                               y
                                               x)
-                                7994 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                                 Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                   (Prelude.fromIntegral len)
-                                                     Data.ProtoLens.Encoding.Bytes.runEither
-                                                       (Data.ProtoLens.decodeMessage value))
+                                           mutable'uninterpretedOption
+                                7994 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.isolate
+                                                       (Prelude.fromIntegral len)
+                                                       Data.ProtoLens.parseMessage)
                                                    Data.ProtoLens.Encoding.Bytes.<?>
                                                    "uninterpreted_option"
-                                           loop
-                                             (Lens.Family2.over
-                                                (Lens.Labels.lensOf'
-                                                   ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                                (\ !t -> (:) y t)
-                                                x)
+                                           v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.append
+                                                     mutable'uninterpretedOption
+                                                     y)
+                                           loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'uninterpretedOption
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "FieldOptions"
+              (do mutable'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'uninterpretedOption)
+                Data.ProtoLens.Encoding.Bytes.<?> "FieldOptions"
         buildMessage
           = (\ _x ->
                (case
@@ -3686,22 +4065,23 @@ instance Data.ProtoLens.Message FieldOptions where
                                                       Prelude.. (\ b -> if b then 1 else 0))
                                                      _v)
                            Data.Monoid.<>
-                           (Data.Monoid.mconcat
-                              (Prelude.map
-                                 (\ _v ->
-                                    (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                                      (((\ bs ->
-                                           (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                              (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                             Data.Monoid.<>
-                                             Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                         Prelude.. Data.ProtoLens.encodeMessage)
-                                        _v)
-                                 (Lens.Family2.view
-                                    (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                    _x)))
+                           (Data.Vector.Generic.foldr
+                              (\ _v as ->
+                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                                    (((\ bs ->
+                                         (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                            (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                           Data.Monoid.<>
+                                           Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                       Prelude.. Data.ProtoLens.encodeMessage)
+                                      _v)
+                                   Data.Monoid.<> as)
+                              Data.Monoid.mempty
+                              (Lens.Family2.view
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                 _x))
                              Data.Monoid.<>
                              Data.ProtoLens.Encoding.Wire.buildFieldSet
                                (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -3825,12 +4205,22 @@ instance Control.DeepSeq.NFData FieldOptions'JSType where
     * 'Proto.Google.Protobuf.Descriptor_Fields.package' @:: Lens' FileDescriptorProto Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'package' @:: Lens' FileDescriptorProto (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.dependency' @:: Lens' FileDescriptorProto [Data.Text.Text]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'dependency' @:: Lens' FileDescriptorProto (Data.Vector.Vector Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.publicDependency' @:: Lens' FileDescriptorProto [Data.Int.Int32]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'publicDependency' @:: Lens' FileDescriptorProto
+  (Data.Vector.Unboxed.Vector Data.Int.Int32)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.weakDependency' @:: Lens' FileDescriptorProto [Data.Int.Int32]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'weakDependency' @:: Lens' FileDescriptorProto
+  (Data.Vector.Unboxed.Vector Data.Int.Int32)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.messageType' @:: Lens' FileDescriptorProto [DescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'messageType' @:: Lens' FileDescriptorProto (Data.Vector.Vector DescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.enumType' @:: Lens' FileDescriptorProto [EnumDescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'enumType' @:: Lens' FileDescriptorProto (Data.Vector.Vector EnumDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.service' @:: Lens' FileDescriptorProto [ServiceDescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'service' @:: Lens' FileDescriptorProto
+  (Data.Vector.Vector ServiceDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.extension' @:: Lens' FileDescriptorProto [FieldDescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'extension' @:: Lens' FileDescriptorProto (Data.Vector.Vector FieldDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.options' @:: Lens' FileDescriptorProto FileOptions@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'options' @:: Lens' FileDescriptorProto (Prelude.Maybe FileOptions)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.sourceCodeInfo' @:: Lens' FileDescriptorProto SourceCodeInfo@
@@ -3842,19 +4232,20 @@ data FileDescriptorProto = FileDescriptorProto{_FileDescriptorProto'name
                                                :: !(Prelude.Maybe Data.Text.Text),
                                                _FileDescriptorProto'package ::
                                                !(Prelude.Maybe Data.Text.Text),
-                                               _FileDescriptorProto'dependency :: ![Data.Text.Text],
+                                               _FileDescriptorProto'dependency ::
+                                               !(Data.Vector.Vector Data.Text.Text),
                                                _FileDescriptorProto'publicDependency ::
-                                               ![Data.Int.Int32],
+                                               !(Data.Vector.Unboxed.Vector Data.Int.Int32),
                                                _FileDescriptorProto'weakDependency ::
-                                               ![Data.Int.Int32],
+                                               !(Data.Vector.Unboxed.Vector Data.Int.Int32),
                                                _FileDescriptorProto'messageType ::
-                                               ![DescriptorProto],
+                                               !(Data.Vector.Vector DescriptorProto),
                                                _FileDescriptorProto'enumType ::
-                                               ![EnumDescriptorProto],
+                                               !(Data.Vector.Vector EnumDescriptorProto),
                                                _FileDescriptorProto'service ::
-                                               ![ServiceDescriptorProto],
+                                               !(Data.Vector.Vector ServiceDescriptorProto),
                                                _FileDescriptorProto'extension ::
-                                               ![FieldDescriptorProto],
+                                               !(Data.Vector.Vector FieldDescriptorProto),
                                                _FileDescriptorProto'options ::
                                                !(Prelude.Maybe FileOptions),
                                                _FileDescriptorProto'sourceCodeInfo ::
@@ -3903,9 +4294,29 @@ instance a ~ ([Data.Text.Text]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'dependency
                (\ x__ y__ -> x__{_FileDescriptorProto'dependency = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector Data.Text.Text) =>
+         Lens.Labels.HasLens' FileDescriptorProto "vector'dependency" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'dependency
+               (\ x__ y__ -> x__{_FileDescriptorProto'dependency = y__}))
               Prelude.. Prelude.id
 instance a ~ ([Data.Int.Int32]) =>
          Lens.Labels.HasLens' FileDescriptorProto "publicDependency" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens
+               _FileDescriptorProto'publicDependency
+               (\ x__ y__ -> x__{_FileDescriptorProto'publicDependency = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Unboxed.Vector Data.Int.Int32) =>
+         Lens.Labels.HasLens' FileDescriptorProto "vector'publicDependency"
+           a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens
@@ -3918,9 +4329,27 @@ instance a ~ ([Data.Int.Int32]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'weakDependency
                (\ x__ y__ -> x__{_FileDescriptorProto'weakDependency = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Unboxed.Vector Data.Int.Int32) =>
+         Lens.Labels.HasLens' FileDescriptorProto "vector'weakDependency" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'weakDependency
+               (\ x__ y__ -> x__{_FileDescriptorProto'weakDependency = y__}))
               Prelude.. Prelude.id
 instance a ~ ([DescriptorProto]) =>
          Lens.Labels.HasLens' FileDescriptorProto "messageType" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'messageType
+               (\ x__ y__ -> x__{_FileDescriptorProto'messageType = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector DescriptorProto) =>
+         Lens.Labels.HasLens' FileDescriptorProto "vector'messageType" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'messageType
@@ -3932,6 +4361,15 @@ instance a ~ ([EnumDescriptorProto]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'enumType
                (\ x__ y__ -> x__{_FileDescriptorProto'enumType = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector EnumDescriptorProto) =>
+         Lens.Labels.HasLens' FileDescriptorProto "vector'enumType" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'enumType
+               (\ x__ y__ -> x__{_FileDescriptorProto'enumType = y__}))
               Prelude.. Prelude.id
 instance a ~ ([ServiceDescriptorProto]) =>
          Lens.Labels.HasLens' FileDescriptorProto "service" a
@@ -3939,9 +4377,27 @@ instance a ~ ([ServiceDescriptorProto]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'service
                (\ x__ y__ -> x__{_FileDescriptorProto'service = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector ServiceDescriptorProto) =>
+         Lens.Labels.HasLens' FileDescriptorProto "vector'service" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'service
+               (\ x__ y__ -> x__{_FileDescriptorProto'service = y__}))
               Prelude.. Prelude.id
 instance a ~ ([FieldDescriptorProto]) =>
          Lens.Labels.HasLens' FileDescriptorProto "extension" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _FileDescriptorProto'extension
+               (\ x__ y__ -> x__{_FileDescriptorProto'extension = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector FieldDescriptorProto) =>
+         Lens.Labels.HasLens' FileDescriptorProto "vector'extension" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'extension
@@ -4110,13 +4566,13 @@ instance Data.ProtoLens.Message FileDescriptorProto where
         defMessage
           = FileDescriptorProto{_FileDescriptorProto'name = Prelude.Nothing,
                                 _FileDescriptorProto'package = Prelude.Nothing,
-                                _FileDescriptorProto'dependency = [],
-                                _FileDescriptorProto'publicDependency = [],
-                                _FileDescriptorProto'weakDependency = [],
-                                _FileDescriptorProto'messageType = [],
-                                _FileDescriptorProto'enumType = [],
-                                _FileDescriptorProto'service = [],
-                                _FileDescriptorProto'extension = [],
+                                _FileDescriptorProto'dependency = Data.Vector.Generic.empty,
+                                _FileDescriptorProto'publicDependency = Data.Vector.Generic.empty,
+                                _FileDescriptorProto'weakDependency = Data.Vector.Generic.empty,
+                                _FileDescriptorProto'messageType = Data.Vector.Generic.empty,
+                                _FileDescriptorProto'enumType = Data.Vector.Generic.empty,
+                                _FileDescriptorProto'service = Data.Vector.Generic.empty,
+                                _FileDescriptorProto'extension = Data.Vector.Generic.empty,
                                 _FileDescriptorProto'options = Prelude.Nothing,
                                 _FileDescriptorProto'sourceCodeInfo = Prelude.Nothing,
                                 _FileDescriptorProto'syntax = Prelude.Nothing,
@@ -4124,11 +4580,62 @@ instance Data.ProtoLens.Message FileDescriptorProto where
         parseMessage
           = let loop ::
                      FileDescriptorProto ->
-                       Data.ProtoLens.Encoding.Bytes.Parser FileDescriptorProto
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         Data.Text.Text
+                         ->
+                         Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                           Data.ProtoLens.Encoding.Growing.RealWorld
+                           EnumDescriptorProto
+                           ->
+                           Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                             Data.ProtoLens.Encoding.Growing.RealWorld
+                             FieldDescriptorProto
+                             ->
+                             Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                               Data.ProtoLens.Encoding.Growing.RealWorld
+                               DescriptorProto
+                               ->
+                               Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Unboxed.Vector
+                                 Data.ProtoLens.Encoding.Growing.RealWorld
+                                 Data.Int.Int32
+                                 ->
+                                 Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                                   Data.ProtoLens.Encoding.Growing.RealWorld
+                                   ServiceDescriptorProto
+                                   ->
+                                   Data.ProtoLens.Encoding.Growing.Growing
+                                     Data.Vector.Unboxed.Vector
+                                     Data.ProtoLens.Encoding.Growing.RealWorld
+                                     Data.Int.Int32
+                                     -> Data.ProtoLens.Encoding.Bytes.Parser FileDescriptorProto
+                loop x mutable'dependency mutable'enumType mutable'extension
+                  mutable'messageType mutable'publicDependency mutable'service
+                  mutable'weakDependency
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'dependency <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                      mutable'dependency)
+                            frozen'enumType <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                 (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                    mutable'enumType)
+                            frozen'extension <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                     mutable'extension)
+                            frozen'messageType <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                    (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                       mutable'messageType)
+                            frozen'publicDependency <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                         (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                            mutable'publicDependency)
+                            frozen'service <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                   mutable'service)
+                            frozen'weakDependency <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                       (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                          mutable'weakDependency)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -4136,40 +4643,43 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "dependency"))
-                                    (\ !t -> Prelude.reverse t)
-                                    (Lens.Family2.over
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "vector'dependency"))
+                                    frozen'dependency
+                                    (Lens.Family2.set
                                        (Lens.Labels.lensOf'
                                           ((Lens.Labels.proxy#) ::
-                                             (Lens.Labels.Proxy#) "publicDependency"))
-                                       (\ !t -> Prelude.reverse t)
-                                       (Lens.Family2.over
+                                             (Lens.Labels.Proxy#) "vector'enumType"))
+                                       frozen'enumType
+                                       (Lens.Family2.set
                                           (Lens.Labels.lensOf'
                                              ((Lens.Labels.proxy#) ::
-                                                (Lens.Labels.Proxy#) "weakDependency"))
-                                          (\ !t -> Prelude.reverse t)
-                                          (Lens.Family2.over
+                                                (Lens.Labels.Proxy#) "vector'extension"))
+                                          frozen'extension
+                                          (Lens.Family2.set
                                              (Lens.Labels.lensOf'
                                                 ((Lens.Labels.proxy#) ::
-                                                   (Lens.Labels.Proxy#) "messageType"))
-                                             (\ !t -> Prelude.reverse t)
-                                             (Lens.Family2.over
+                                                   (Lens.Labels.Proxy#) "vector'messageType"))
+                                             frozen'messageType
+                                             (Lens.Family2.set
                                                 (Lens.Labels.lensOf'
                                                    ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "enumType"))
-                                                (\ !t -> Prelude.reverse t)
-                                                (Lens.Family2.over
+                                                      (Lens.Labels.Proxy#)
+                                                        "vector'publicDependency"))
+                                                frozen'publicDependency
+                                                (Lens.Family2.set
                                                    (Lens.Labels.lensOf'
                                                       ((Lens.Labels.proxy#) ::
-                                                         (Lens.Labels.Proxy#) "service"))
-                                                   (\ !t -> Prelude.reverse t)
-                                                   (Lens.Family2.over
+                                                         (Lens.Labels.Proxy#) "vector'service"))
+                                                   frozen'service
+                                                   (Lens.Family2.set
                                                       (Lens.Labels.lensOf'
                                                          ((Lens.Labels.proxy#) ::
-                                                            (Lens.Labels.Proxy#) "extension"))
-                                                      (\ !t -> Prelude.reverse t)
+                                                            (Lens.Labels.Proxy#)
+                                                              "vector'weakDependency"))
+                                                      frozen'weakDependency
                                                       x))))))))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -4190,6 +4700,13 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                                     (Lens.Labels.Proxy#) "name"))
                                               y
                                               x)
+                                           mutable'dependency
+                                           mutable'enumType
+                                           mutable'extension
+                                           mutable'messageType
+                                           mutable'publicDependency
+                                           mutable'service
+                                           mutable'weakDependency
                                 18 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                               Data.ProtoLens.Encoding.Bytes.getBytes
                                                                 (Prelude.fromIntegral len)
@@ -4206,6 +4723,13 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                                     (Lens.Labels.Proxy#) "package"))
                                               y
                                               x)
+                                           mutable'dependency
+                                           mutable'enumType
+                                           mutable'extension
+                                           mutable'messageType
+                                           mutable'publicDependency
+                                           mutable'service
+                                           mutable'weakDependency
                                 26 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                                Data.ProtoLens.Encoding.Bytes.getBytes
                                                                  (Prelude.fromIntegral len)
@@ -4215,139 +4739,154 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                                                                 (Prelude.show err)
                                                           Prelude.Right r -> Prelude.Right r))
                                                  Data.ProtoLens.Encoding.Bytes.<?> "dependency"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "dependency"))
-                                              (\ !t -> (:) y t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'dependency
+                                                   y)
+                                         loop x v mutable'enumType mutable'extension
+                                           mutable'messageType
+                                           mutable'publicDependency
+                                           mutable'service
+                                           mutable'weakDependency
                                 80 -> do !y <- (Prelude.fmap Prelude.fromIntegral
                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                  Data.ProtoLens.Encoding.Bytes.<?>
                                                  "public_dependency"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "publicDependency"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                82 -> do bytes <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                     Data.ProtoLens.Encoding.Bytes.getBytes
-                                                       (Prelude.fromIntegral len)
-                                         y <- Data.ProtoLens.Encoding.Bytes.runEither
-                                                (Data.ProtoLens.Encoding.Bytes.runParser
-                                                   (let ploop qs
-                                                          = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
-                                                               if packedEnd then Prelude.return qs
-                                                                 else
-                                                                 do !q <- (Prelude.fmap
-                                                                             Prelude.fromIntegral
-                                                                             Data.ProtoLens.Encoding.Bytes.getVarInt)
-                                                                            Data.ProtoLens.Encoding.Bytes.<?>
-                                                                            "public_dependency"
-                                                                    ploop ((:) q qs)
-                                                      in ploop [])
-                                                   bytes)
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "publicDependency"))
-                                              (\ !t -> (y) Prelude.++ t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'publicDependency
+                                                   y)
+                                         loop x mutable'dependency mutable'enumType
+                                           mutable'extension
+                                           mutable'messageType
+                                           v
+                                           mutable'service
+                                           mutable'weakDependency
+                                82 -> do y <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                 Data.ProtoLens.Encoding.Bytes.isolate
+                                                   (Prelude.fromIntegral len)
+                                                   ((let ploop qs
+                                                           = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                                if packedEnd then Prelude.return qs
+                                                                  else
+                                                                  do !q <- (Prelude.fmap
+                                                                              Prelude.fromIntegral
+                                                                              Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                                                             Data.ProtoLens.Encoding.Bytes.<?>
+                                                                             "public_dependency"
+                                                                     qs' <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                                              (Data.ProtoLens.Encoding.Growing.append
+                                                                                 qs
+                                                                                 q)
+                                                                     ploop qs'
+                                                       in ploop)
+                                                      mutable'publicDependency)
+                                         loop x mutable'dependency mutable'enumType
+                                           mutable'extension
+                                           mutable'messageType
+                                           y
+                                           mutable'service
+                                           mutable'weakDependency
                                 88 -> do !y <- (Prelude.fmap Prelude.fromIntegral
                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "weak_dependency"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "weakDependency"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                90 -> do bytes <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                     Data.ProtoLens.Encoding.Bytes.getBytes
-                                                       (Prelude.fromIntegral len)
-                                         y <- Data.ProtoLens.Encoding.Bytes.runEither
-                                                (Data.ProtoLens.Encoding.Bytes.runParser
-                                                   (let ploop qs
-                                                          = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
-                                                               if packedEnd then Prelude.return qs
-                                                                 else
-                                                                 do !q <- (Prelude.fmap
-                                                                             Prelude.fromIntegral
-                                                                             Data.ProtoLens.Encoding.Bytes.getVarInt)
-                                                                            Data.ProtoLens.Encoding.Bytes.<?>
-                                                                            "weak_dependency"
-                                                                    ploop ((:) q qs)
-                                                      in ploop [])
-                                                   bytes)
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "weakDependency"))
-                                              (\ !t -> (y) Prelude.++ t)
-                                              x)
-                                34 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'weakDependency
+                                                   y)
+                                         loop x mutable'dependency mutable'enumType
+                                           mutable'extension
+                                           mutable'messageType
+                                           mutable'publicDependency
+                                           mutable'service
+                                           v
+                                90 -> do y <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                 Data.ProtoLens.Encoding.Bytes.isolate
+                                                   (Prelude.fromIntegral len)
+                                                   ((let ploop qs
+                                                           = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                                if packedEnd then Prelude.return qs
+                                                                  else
+                                                                  do !q <- (Prelude.fmap
+                                                                              Prelude.fromIntegral
+                                                                              Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                                                             Data.ProtoLens.Encoding.Bytes.<?>
+                                                                             "weak_dependency"
+                                                                     qs' <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                                              (Data.ProtoLens.Encoding.Growing.append
+                                                                                 qs
+                                                                                 q)
+                                                                     ploop qs'
+                                                       in ploop)
+                                                      mutable'weakDependency)
+                                         loop x mutable'dependency mutable'enumType
+                                           mutable'extension
+                                           mutable'messageType
+                                           mutable'publicDependency
+                                           mutable'service
+                                           y
+                                34 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "message_type"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "messageType"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                42 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'messageType
+                                                   y)
+                                         loop x mutable'dependency mutable'enumType
+                                           mutable'extension
+                                           v
+                                           mutable'publicDependency
+                                           mutable'service
+                                           mutable'weakDependency
+                                42 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "enum_type"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "enumType"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                50 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'enumType
+                                                   y)
+                                         loop x mutable'dependency v mutable'extension
+                                           mutable'messageType
+                                           mutable'publicDependency
+                                           mutable'service
+                                           mutable'weakDependency
+                                50 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "service"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "service"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                58 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'service
+                                                   y)
+                                         loop x mutable'dependency mutable'enumType
+                                           mutable'extension
+                                           mutable'messageType
+                                           mutable'publicDependency
+                                           v
+                                           mutable'weakDependency
+                                58 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "extension"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "extension"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                66 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                              Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                (Prelude.fromIntegral len)
-                                                  Data.ProtoLens.Encoding.Bytes.runEither
-                                                    (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'extension
+                                                   y)
+                                         loop x mutable'dependency mutable'enumType v
+                                           mutable'messageType
+                                           mutable'publicDependency
+                                           mutable'service
+                                           mutable'weakDependency
+                                66 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                  Data.ProtoLens.Encoding.Bytes.isolate
+                                                    (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.parseMessage)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "options"
                                          loop
                                            (Lens.Family2.set
@@ -4356,11 +4895,17 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                                     (Lens.Labels.Proxy#) "options"))
                                               y
                                               x)
-                                74 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                              Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                (Prelude.fromIntegral len)
-                                                  Data.ProtoLens.Encoding.Bytes.runEither
-                                                    (Data.ProtoLens.decodeMessage value))
+                                           mutable'dependency
+                                           mutable'enumType
+                                           mutable'extension
+                                           mutable'messageType
+                                           mutable'publicDependency
+                                           mutable'service
+                                           mutable'weakDependency
+                                74 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                  Data.ProtoLens.Encoding.Bytes.isolate
+                                                    (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.parseMessage)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "source_code_info"
                                          loop
                                            (Lens.Family2.set
@@ -4369,6 +4914,13 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                                     (Lens.Labels.Proxy#) "sourceCodeInfo"))
                                               y
                                               x)
+                                           mutable'dependency
+                                           mutable'enumType
+                                           mutable'extension
+                                           mutable'messageType
+                                           mutable'publicDependency
+                                           mutable'service
+                                           mutable'weakDependency
                                 98 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                               Data.ProtoLens.Encoding.Bytes.getBytes
                                                                 (Prelude.fromIntegral len)
@@ -4385,15 +4937,48 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                                     (Lens.Labels.Proxy#) "syntax"))
                                               y
                                               x)
+                                           mutable'dependency
+                                           mutable'enumType
+                                           mutable'extension
+                                           mutable'messageType
+                                           mutable'publicDependency
+                                           mutable'service
+                                           mutable'weakDependency
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'dependency
+                                             mutable'enumType
+                                             mutable'extension
+                                             mutable'messageType
+                                             mutable'publicDependency
+                                             mutable'service
+                                             mutable'weakDependency
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "FileDescriptorProto"
+              (do mutable'dependency <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                          Data.ProtoLens.Encoding.Growing.new
+                  mutable'enumType <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                        Data.ProtoLens.Encoding.Growing.new
+                  mutable'extension <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                         Data.ProtoLens.Encoding.Growing.new
+                  mutable'messageType <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                           Data.ProtoLens.Encoding.Growing.new
+                  mutable'publicDependency <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                Data.ProtoLens.Encoding.Growing.new
+                  mutable'service <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                       Data.ProtoLens.Encoding.Growing.new
+                  mutable'weakDependency <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                              Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'dependency mutable'enumType
+                    mutable'extension
+                    mutable'messageType
+                    mutable'publicDependency
+                    mutable'service
+                    mutable'weakDependency)
+                Data.ProtoLens.Encoding.Bytes.<?> "FileDescriptorProto"
         buildMessage
           = (\ _x ->
                (case
@@ -4431,49 +5016,70 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                               Prelude.. Data.Text.Encoding.encodeUtf8)
                                              _v)
                    Data.Monoid.<>
-                   (Data.Monoid.mconcat
-                      (Prelude.map
-                         (\ _v ->
-                            (Data.ProtoLens.Encoding.Bytes.putVarInt 26) Data.Monoid.<>
-                              (((\ bs ->
-                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                 Prelude.. Data.Text.Encoding.encodeUtf8)
-                                _v)
-                         (Lens.Family2.view
-                            (Lens.Labels.lensOf'
-                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "dependency"))
-                            _x)))
+                   (Data.Vector.Generic.foldr
+                      (\ _v as ->
+                         ((Data.ProtoLens.Encoding.Bytes.putVarInt 26) Data.Monoid.<>
+                            (((\ bs ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                               Prelude.. Data.Text.Encoding.encodeUtf8)
+                              _v)
+                           Data.Monoid.<> as)
+                      Data.Monoid.mempty
+                      (Lens.Family2.view
+                         (Lens.Labels.lensOf'
+                            ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'dependency"))
+                         _x))
                      Data.Monoid.<>
-                     (Data.Monoid.mconcat
-                        (Prelude.map
-                           (\ _v ->
-                              (Data.ProtoLens.Encoding.Bytes.putVarInt 80) Data.Monoid.<>
+                     (Data.Vector.Generic.foldr
+                        (\ _v as ->
+                           ((Data.ProtoLens.Encoding.Bytes.putVarInt 80) Data.Monoid.<>
+                              ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                 Prelude.fromIntegral)
+                                _v)
+                             Data.Monoid.<> as)
+                        Data.Monoid.mempty
+                        (Lens.Family2.view
+                           (Lens.Labels.lensOf'
+                              ((Lens.Labels.proxy#) ::
+                                 (Lens.Labels.Proxy#) "vector'publicDependency"))
+                           _x))
+                       Data.Monoid.<>
+                       (Data.Vector.Generic.foldr
+                          (\ _v as ->
+                             ((Data.ProtoLens.Encoding.Bytes.putVarInt 88) Data.Monoid.<>
                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
                                    Prelude.fromIntegral)
                                   _v)
-                           (Lens.Family2.view
-                              (Lens.Labels.lensOf'
-                                 ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "publicDependency"))
-                              _x)))
-                       Data.Monoid.<>
-                       (Data.Monoid.mconcat
-                          (Prelude.map
-                             (\ _v ->
-                                (Data.ProtoLens.Encoding.Bytes.putVarInt 88) Data.Monoid.<>
-                                  ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
-                                     Prelude.fromIntegral)
-                                    _v)
-                             (Lens.Family2.view
-                                (Lens.Labels.lensOf'
-                                   ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "weakDependency"))
-                                _x)))
+                               Data.Monoid.<> as)
+                          Data.Monoid.mempty
+                          (Lens.Family2.view
+                             (Lens.Labels.lensOf'
+                                ((Lens.Labels.proxy#) ::
+                                   (Lens.Labels.Proxy#) "vector'weakDependency"))
+                             _x))
                          Data.Monoid.<>
-                         (Data.Monoid.mconcat
-                            (Prelude.map
-                               (\ _v ->
-                                  (Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
+                         (Data.Vector.Generic.foldr
+                            (\ _v as ->
+                               ((Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
+                                  (((\ bs ->
+                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                          (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                         Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                     Prelude.. Data.ProtoLens.encodeMessage)
+                                    _v)
+                                 Data.Monoid.<> as)
+                            Data.Monoid.mempty
+                            (Lens.Family2.view
+                               (Lens.Labels.lensOf'
+                                  ((Lens.Labels.proxy#) ::
+                                     (Lens.Labels.Proxy#) "vector'messageType"))
+                               _x))
+                           Data.Monoid.<>
+                           (Data.Vector.Generic.foldr
+                              (\ _v as ->
+                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
                                     (((\ bs ->
                                          (Data.ProtoLens.Encoding.Bytes.putVarInt
                                             (Prelude.fromIntegral (Data.ByteString.length bs)))
@@ -4481,15 +5087,17 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                            Data.ProtoLens.Encoding.Bytes.putBytes bs))
                                        Prelude.. Data.ProtoLens.encodeMessage)
                                       _v)
-                               (Lens.Family2.view
-                                  (Lens.Labels.lensOf'
-                                     ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "messageType"))
-                                  _x)))
-                           Data.Monoid.<>
-                           (Data.Monoid.mconcat
-                              (Prelude.map
-                                 (\ _v ->
-                                    (Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
+                                   Data.Monoid.<> as)
+                              Data.Monoid.mempty
+                              (Lens.Family2.view
+                                 (Lens.Labels.lensOf'
+                                    ((Lens.Labels.proxy#) ::
+                                       (Lens.Labels.Proxy#) "vector'enumType"))
+                                 _x))
+                             Data.Monoid.<>
+                             (Data.Vector.Generic.foldr
+                                (\ _v as ->
+                                   ((Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
                                       (((\ bs ->
                                            (Data.ProtoLens.Encoding.Bytes.putVarInt
                                               (Prelude.fromIntegral (Data.ByteString.length bs)))
@@ -4497,15 +5105,17 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                              Data.ProtoLens.Encoding.Bytes.putBytes bs))
                                          Prelude.. Data.ProtoLens.encodeMessage)
                                         _v)
-                                 (Lens.Family2.view
-                                    (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "enumType"))
-                                    _x)))
-                             Data.Monoid.<>
-                             (Data.Monoid.mconcat
-                                (Prelude.map
-                                   (\ _v ->
-                                      (Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
+                                     Data.Monoid.<> as)
+                                Data.Monoid.mempty
+                                (Lens.Family2.view
+                                   (Lens.Labels.lensOf'
+                                      ((Lens.Labels.proxy#) ::
+                                         (Lens.Labels.Proxy#) "vector'service"))
+                                   _x))
+                               Data.Monoid.<>
+                               (Data.Vector.Generic.foldr
+                                  (\ _v as ->
+                                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 58) Data.Monoid.<>
                                         (((\ bs ->
                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
@@ -4513,28 +5123,13 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
                                            Prelude.. Data.ProtoLens.encodeMessage)
                                           _v)
-                                   (Lens.Family2.view
-                                      (Lens.Labels.lensOf'
-                                         ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "service"))
-                                      _x)))
-                               Data.Monoid.<>
-                               (Data.Monoid.mconcat
-                                  (Prelude.map
-                                     (\ _v ->
-                                        (Data.ProtoLens.Encoding.Bytes.putVarInt 58) Data.Monoid.<>
-                                          (((\ bs ->
-                                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                                  (Prelude.fromIntegral
-                                                     (Data.ByteString.length bs)))
-                                                 Data.Monoid.<>
-                                                 Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                             Prelude.. Data.ProtoLens.encodeMessage)
-                                            _v)
-                                     (Lens.Family2.view
-                                        (Lens.Labels.lensOf'
-                                           ((Lens.Labels.proxy#) ::
-                                              (Lens.Labels.Proxy#) "extension"))
-                                        _x)))
+                                       Data.Monoid.<> as)
+                                  Data.Monoid.mempty
+                                  (Lens.Family2.view
+                                     (Lens.Labels.lensOf'
+                                        ((Lens.Labels.proxy#) ::
+                                           (Lens.Labels.Proxy#) "vector'extension"))
+                                     _x))
                                  Data.Monoid.<>
                                  (case
                                     Lens.Family2.view
@@ -4629,9 +5224,10 @@ instance Control.DeepSeq.NFData FileDescriptorProto where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.file' @:: Lens' FileDescriptorSet [FileDescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'file' @:: Lens' FileDescriptorSet (Data.Vector.Vector FileDescriptorProto)@
  -}
 data FileDescriptorSet = FileDescriptorSet{_FileDescriptorSet'file
-                                           :: ![FileDescriptorProto],
+                                           :: !(Data.Vector.Vector FileDescriptorProto),
                                            _FileDescriptorSet'_unknownFields ::
                                            !Data.ProtoLens.FieldSet}
                            deriving (Prelude.Eq, Prelude.Ord)
@@ -4642,6 +5238,15 @@ instance Prelude.Show FileDescriptorSet where
                  (Prelude.showChar '}' __s))
 instance a ~ ([FileDescriptorProto]) =>
          Lens.Labels.HasLens' FileDescriptorSet "file" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _FileDescriptorSet'file
+               (\ x__ y__ -> x__{_FileDescriptorSet'file = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector FileDescriptorProto) =>
+         Lens.Labels.HasLens' FileDescriptorSet "vector'file" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorSet'file
@@ -4664,16 +5269,23 @@ instance Data.ProtoLens.Message FileDescriptorSet where
           = Lens.Family2.Unchecked.lens _FileDescriptorSet'_unknownFields
               (\ x__ y__ -> x__{_FileDescriptorSet'_unknownFields = y__})
         defMessage
-          = FileDescriptorSet{_FileDescriptorSet'file = [],
+          = FileDescriptorSet{_FileDescriptorSet'file =
+                                Data.Vector.Generic.empty,
                               _FileDescriptorSet'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      FileDescriptorSet ->
-                       Data.ProtoLens.Encoding.Bytes.Parser FileDescriptorSet
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         FileDescriptorProto
+                         -> Data.ProtoLens.Encoding.Bytes.Parser FileDescriptorSet
+                loop x mutable'file
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'file <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                             (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                mutable'file)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -4681,52 +5293,52 @@ instance Data.ProtoLens.Message FileDescriptorSet where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "file"))
-                                    (\ !t -> Prelude.reverse t)
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file"))
+                                    frozen'file
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
                             case tag of
-                                10 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                10 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "file"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "file"))
-                                              (\ !t -> (:) y t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append mutable'file
+                                                   y)
+                                         loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'file
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "FileDescriptorSet"
+              (do mutable'file <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                    Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'file)
+                Data.ProtoLens.Encoding.Bytes.<?> "FileDescriptorSet"
         buildMessage
           = (\ _x ->
-               (Data.Monoid.mconcat
-                  (Prelude.map
-                     (\ _v ->
-                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                     (Lens.Family2.view
-                        (Lens.Labels.lensOf'
-                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "file"))
-                        _x)))
+               (Data.Vector.Generic.foldr
+                  (\ _v as ->
+                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                        (((\ bs ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                (Prelude.fromIntegral (Data.ByteString.length bs)))
+                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                           Prelude.. Data.ProtoLens.encodeMessage)
+                          _v)
+                       Data.Monoid.<> as)
+                  Data.Monoid.mempty
+                  (Lens.Family2.view
+                     (Lens.Labels.lensOf'
+                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file"))
+                     _x))
                  Data.Monoid.<>
                  Data.ProtoLens.Encoding.Wire.buildFieldSet
                    (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -4778,6 +5390,7 @@ instance Control.DeepSeq.NFData FileDescriptorSet where
     * 'Proto.Google.Protobuf.Descriptor_Fields.rubyPackage' @:: Lens' FileOptions Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'rubyPackage' @:: Lens' FileOptions (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' FileOptions [UninterpretedOption]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' FileOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data FileOptions = FileOptions{_FileOptions'javaPackage ::
                                !(Prelude.Maybe Data.Text.Text),
@@ -4803,7 +5416,8 @@ data FileOptions = FileOptions{_FileOptions'javaPackage ::
                                _FileOptions'phpMetadataNamespace ::
                                !(Prelude.Maybe Data.Text.Text),
                                _FileOptions'rubyPackage :: !(Prelude.Maybe Data.Text.Text),
-                               _FileOptions'uninterpretedOption :: ![UninterpretedOption],
+                               _FileOptions'uninterpretedOption ::
+                               !(Data.Vector.Vector UninterpretedOption),
                                _FileOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
                      deriving (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show FileOptions where
@@ -5100,6 +5714,15 @@ instance a ~ ([UninterpretedOption]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileOptions'uninterpretedOption
                (\ x__ y__ -> x__{_FileOptions'uninterpretedOption = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector UninterpretedOption) =>
+         Lens.Labels.HasLens' FileOptions "vector'uninterpretedOption" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _FileOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_FileOptions'uninterpretedOption = y__}))
               Prelude.. Prelude.id
 instance Data.ProtoLens.Message FileOptions where
         messageName _ = Data.Text.pack "google.protobuf.FileOptions"
@@ -5339,15 +5962,22 @@ instance Data.ProtoLens.Message FileOptions where
                         _FileOptions'phpNamespace = Prelude.Nothing,
                         _FileOptions'phpMetadataNamespace = Prelude.Nothing,
                         _FileOptions'rubyPackage = Prelude.Nothing,
-                        _FileOptions'uninterpretedOption = [],
+                        _FileOptions'uninterpretedOption = Data.Vector.Generic.empty,
                         _FileOptions'_unknownFields = ([])}
         parseMessage
           = let loop ::
-                     FileOptions -> Data.ProtoLens.Encoding.Bytes.Parser FileOptions
-                loop x
+                     FileOptions ->
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         UninterpretedOption
+                         -> Data.ProtoLens.Encoding.Bytes.Parser FileOptions
+                loop x mutable'uninterpretedOption
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                            (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                               mutable'uninterpretedOption)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -5355,11 +5985,11 @@ instance Data.ProtoLens.Message FileOptions where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                    (\ !t -> Prelude.reverse t)
+                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                    frozen'uninterpretedOption
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -5380,6 +6010,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                     (Lens.Labels.Proxy#) "javaPackage"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 66 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                               Data.ProtoLens.Encoding.Bytes.getBytes
                                                                 (Prelude.fromIntegral len)
@@ -5397,6 +6028,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                     (Lens.Labels.Proxy#) "javaOuterClassname"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 80 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?>
@@ -5408,6 +6040,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                     (Lens.Labels.Proxy#) "javaMultipleFiles"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 160 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                  Data.ProtoLens.Encoding.Bytes.<?>
@@ -5420,6 +6053,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                        "javaGenerateEqualsAndHash"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 216 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                  Data.ProtoLens.Encoding.Bytes.<?>
@@ -5431,6 +6065,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "javaStringCheckUtf8"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 72 -> do y <- (Prelude.fmap Prelude.toEnum
                                                  (Prelude.fmap Prelude.fromIntegral
                                                     Data.ProtoLens.Encoding.Bytes.getVarInt))
@@ -5442,6 +6077,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                     (Lens.Labels.Proxy#) "optimizeFor"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 90 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                               Data.ProtoLens.Encoding.Bytes.getBytes
                                                                 (Prelude.fromIntegral len)
@@ -5458,6 +6094,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                     (Lens.Labels.Proxy#) "goPackage"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 128 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                  Data.ProtoLens.Encoding.Bytes.<?>
@@ -5469,6 +6106,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "ccGenericServices"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 136 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                  Data.ProtoLens.Encoding.Bytes.<?>
@@ -5480,6 +6118,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "javaGenericServices"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 144 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                  Data.ProtoLens.Encoding.Bytes.<?>
@@ -5491,6 +6130,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "pyGenericServices"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 336 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                  Data.ProtoLens.Encoding.Bytes.<?>
@@ -5502,6 +6142,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "phpGenericServices"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 184 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "deprecated"
@@ -5512,6 +6153,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "deprecated"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 248 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                  Data.ProtoLens.Encoding.Bytes.<?>
@@ -5523,6 +6165,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "ccEnableArenas"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 290 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                                Data.ProtoLens.Encoding.Bytes.getBytes
                                                                  (Prelude.fromIntegral len)
@@ -5540,6 +6183,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "objcClassPrefix"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 298 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                                Data.ProtoLens.Encoding.Bytes.getBytes
                                                                  (Prelude.fromIntegral len)
@@ -5557,6 +6201,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "csharpNamespace"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 314 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                                Data.ProtoLens.Encoding.Bytes.getBytes
                                                                  (Prelude.fromIntegral len)
@@ -5573,6 +6218,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "swiftPrefix"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 322 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                                Data.ProtoLens.Encoding.Bytes.getBytes
                                                                  (Prelude.fromIntegral len)
@@ -5590,6 +6236,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "phpClassPrefix"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 330 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                                Data.ProtoLens.Encoding.Bytes.getBytes
                                                                  (Prelude.fromIntegral len)
@@ -5606,6 +6253,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "phpNamespace"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 354 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                                Data.ProtoLens.Encoding.Bytes.getBytes
                                                                  (Prelude.fromIntegral len)
@@ -5623,6 +6271,7 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "phpMetadataNamespace"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 362 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                                Data.ProtoLens.Encoding.Bytes.getBytes
                                                                  (Prelude.fromIntegral len)
@@ -5639,29 +6288,30 @@ instance Data.ProtoLens.Message FileOptions where
                                                      (Lens.Labels.Proxy#) "rubyPackage"))
                                                y
                                                x)
-                                7994 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                                 Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                   (Prelude.fromIntegral len)
-                                                     Data.ProtoLens.Encoding.Bytes.runEither
-                                                       (Data.ProtoLens.decodeMessage value))
+                                            mutable'uninterpretedOption
+                                7994 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.isolate
+                                                       (Prelude.fromIntegral len)
+                                                       Data.ProtoLens.parseMessage)
                                                    Data.ProtoLens.Encoding.Bytes.<?>
                                                    "uninterpreted_option"
-                                           loop
-                                             (Lens.Family2.over
-                                                (Lens.Labels.lensOf'
-                                                   ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                                (\ !t -> (:) y t)
-                                                x)
+                                           v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.append
+                                                     mutable'uninterpretedOption
+                                                     y)
+                                           loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'uninterpretedOption
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "FileOptions"
+              (do mutable'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'uninterpretedOption)
+                Data.ProtoLens.Encoding.Bytes.<?> "FileOptions"
         buildMessage
           = (\ _x ->
                (case
@@ -6031,29 +6681,30 @@ instance Data.ProtoLens.Message FileOptions where
                                                                        Data.Text.Encoding.encodeUtf8)
                                                                       _v)
                                                        Data.Monoid.<>
-                                                       (Data.Monoid.mconcat
-                                                          (Prelude.map
-                                                             (\ _v ->
-                                                                (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                                                   7994)
-                                                                  Data.Monoid.<>
-                                                                  (((\ bs ->
-                                                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                                                          (Prelude.fromIntegral
-                                                                             (Data.ByteString.length
-                                                                                bs)))
-                                                                         Data.Monoid.<>
-                                                                         Data.ProtoLens.Encoding.Bytes.putBytes
-                                                                           bs))
-                                                                     Prelude..
-                                                                     Data.ProtoLens.encodeMessage)
-                                                                    _v)
-                                                             (Lens.Family2.view
-                                                                (Lens.Labels.lensOf'
-                                                                   ((Lens.Labels.proxy#) ::
-                                                                      (Lens.Labels.Proxy#)
-                                                                        "uninterpretedOption"))
-                                                                _x)))
+                                                       (Data.Vector.Generic.foldr
+                                                          (\ _v as ->
+                                                             ((Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                 7994)
+                                                                Data.Monoid.<>
+                                                                (((\ bs ->
+                                                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                        (Prelude.fromIntegral
+                                                                           (Data.ByteString.length
+                                                                              bs)))
+                                                                       Data.Monoid.<>
+                                                                       Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                         bs))
+                                                                   Prelude..
+                                                                   Data.ProtoLens.encodeMessage)
+                                                                  _v)
+                                                               Data.Monoid.<> as)
+                                                          Data.Monoid.mempty
+                                                          (Lens.Family2.view
+                                                             (Lens.Labels.lensOf'
+                                                                ((Lens.Labels.proxy#) ::
+                                                                   (Lens.Labels.Proxy#)
+                                                                     "vector'uninterpretedOption"))
+                                                             _x))
                                                          Data.Monoid.<>
                                                          Data.ProtoLens.Encoding.Wire.buildFieldSet
                                                            (Lens.Family2.view
@@ -6158,9 +6809,11 @@ instance Control.DeepSeq.NFData FileOptions'OptimizeMode where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.annotation' @:: Lens' GeneratedCodeInfo [GeneratedCodeInfo'Annotation]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'annotation' @:: Lens' GeneratedCodeInfo
+  (Data.Vector.Vector GeneratedCodeInfo'Annotation)@
  -}
 data GeneratedCodeInfo = GeneratedCodeInfo{_GeneratedCodeInfo'annotation
-                                           :: ![GeneratedCodeInfo'Annotation],
+                                           :: !(Data.Vector.Vector GeneratedCodeInfo'Annotation),
                                            _GeneratedCodeInfo'_unknownFields ::
                                            !Data.ProtoLens.FieldSet}
                            deriving (Prelude.Eq, Prelude.Ord)
@@ -6171,6 +6824,15 @@ instance Prelude.Show GeneratedCodeInfo where
                  (Prelude.showChar '}' __s))
 instance a ~ ([GeneratedCodeInfo'Annotation]) =>
          Lens.Labels.HasLens' GeneratedCodeInfo "annotation" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'annotation
+               (\ x__ y__ -> x__{_GeneratedCodeInfo'annotation = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector GeneratedCodeInfo'Annotation) =>
+         Lens.Labels.HasLens' GeneratedCodeInfo "vector'annotation" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'annotation
@@ -6194,16 +6856,23 @@ instance Data.ProtoLens.Message GeneratedCodeInfo where
           = Lens.Family2.Unchecked.lens _GeneratedCodeInfo'_unknownFields
               (\ x__ y__ -> x__{_GeneratedCodeInfo'_unknownFields = y__})
         defMessage
-          = GeneratedCodeInfo{_GeneratedCodeInfo'annotation = [],
+          = GeneratedCodeInfo{_GeneratedCodeInfo'annotation =
+                                Data.Vector.Generic.empty,
                               _GeneratedCodeInfo'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      GeneratedCodeInfo ->
-                       Data.ProtoLens.Encoding.Bytes.Parser GeneratedCodeInfo
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         GeneratedCodeInfo'Annotation
+                         -> Data.ProtoLens.Encoding.Bytes.Parser GeneratedCodeInfo
+                loop x mutable'annotation
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'annotation <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                      mutable'annotation)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -6211,52 +6880,54 @@ instance Data.ProtoLens.Message GeneratedCodeInfo where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "annotation"))
-                                    (\ !t -> Prelude.reverse t)
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "vector'annotation"))
+                                    frozen'annotation
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
                             case tag of
-                                10 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                10 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "annotation"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "annotation"))
-                                              (\ !t -> (:) y t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'annotation
+                                                   y)
+                                         loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'annotation
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "GeneratedCodeInfo"
+              (do mutable'annotation <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                          Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'annotation)
+                Data.ProtoLens.Encoding.Bytes.<?> "GeneratedCodeInfo"
         buildMessage
           = (\ _x ->
-               (Data.Monoid.mconcat
-                  (Prelude.map
-                     (\ _v ->
-                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                     (Lens.Family2.view
-                        (Lens.Labels.lensOf'
-                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "annotation"))
-                        _x)))
+               (Data.Vector.Generic.foldr
+                  (\ _v as ->
+                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                        (((\ bs ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                (Prelude.fromIntegral (Data.ByteString.length bs)))
+                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                           Prelude.. Data.ProtoLens.encodeMessage)
+                          _v)
+                       Data.Monoid.<> as)
+                  Data.Monoid.mempty
+                  (Lens.Family2.view
+                     (Lens.Labels.lensOf'
+                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'annotation"))
+                     _x))
                  Data.Monoid.<>
                  Data.ProtoLens.Encoding.Wire.buildFieldSet
                    (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -6268,6 +6939,8 @@ instance Control.DeepSeq.NFData GeneratedCodeInfo where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.path' @:: Lens' GeneratedCodeInfo'Annotation [Data.Int.Int32]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'path' @:: Lens' GeneratedCodeInfo'Annotation
+  (Data.Vector.Unboxed.Vector Data.Int.Int32)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.sourceFile' @:: Lens' GeneratedCodeInfo'Annotation Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'sourceFile' @:: Lens' GeneratedCodeInfo'Annotation (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.begin' @:: Lens' GeneratedCodeInfo'Annotation Data.Int.Int32@
@@ -6276,7 +6949,9 @@ instance Control.DeepSeq.NFData GeneratedCodeInfo where
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'end' @:: Lens' GeneratedCodeInfo'Annotation (Prelude.Maybe Data.Int.Int32)@
  -}
 data GeneratedCodeInfo'Annotation = GeneratedCodeInfo'Annotation{_GeneratedCodeInfo'Annotation'path
-                                                                 :: ![Data.Int.Int32],
+                                                                 ::
+                                                                 !(Data.Vector.Unboxed.Vector
+                                                                     Data.Int.Int32),
                                                                  _GeneratedCodeInfo'Annotation'sourceFile
                                                                  :: !(Prelude.Maybe Data.Text.Text),
                                                                  _GeneratedCodeInfo'Annotation'begin
@@ -6293,6 +6968,15 @@ instance Prelude.Show GeneratedCodeInfo'Annotation where
                  (Prelude.showChar '}' __s))
 instance a ~ ([Data.Int.Int32]) =>
          Lens.Labels.HasLens' GeneratedCodeInfo'Annotation "path" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'path
+               (\ x__ y__ -> x__{_GeneratedCodeInfo'Annotation'path = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Unboxed.Vector Data.Int.Int32) =>
+         Lens.Labels.HasLens' GeneratedCodeInfo'Annotation "vector'path" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'path
@@ -6393,7 +7077,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                  x__{_GeneratedCodeInfo'Annotation'_unknownFields = y__})
         defMessage
           = GeneratedCodeInfo'Annotation{_GeneratedCodeInfo'Annotation'path =
-                                           [],
+                                           Data.Vector.Generic.empty,
                                          _GeneratedCodeInfo'Annotation'sourceFile = Prelude.Nothing,
                                          _GeneratedCodeInfo'Annotation'begin = Prelude.Nothing,
                                          _GeneratedCodeInfo'Annotation'end = Prelude.Nothing,
@@ -6401,11 +7085,18 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
         parseMessage
           = let loop ::
                      GeneratedCodeInfo'Annotation ->
-                       Data.ProtoLens.Encoding.Bytes.Parser GeneratedCodeInfo'Annotation
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Unboxed.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         Data.Int.Int32
+                         ->
+                         Data.ProtoLens.Encoding.Bytes.Parser GeneratedCodeInfo'Annotation
+                loop x mutable'path
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'path <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                             (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                mutable'path)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -6413,10 +7104,10 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "path"))
-                                    (\ !t -> Prelude.reverse t)
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'path"))
+                                    frozen'path
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -6424,37 +7115,30 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                                 8 -> do !y <- (Prelude.fmap Prelude.fromIntegral
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "path"
-                                        loop
-                                          (Lens.Family2.over
-                                             (Lens.Labels.lensOf'
-                                                ((Lens.Labels.proxy#) ::
-                                                   (Lens.Labels.Proxy#) "path"))
-                                             (\ !t -> (:) y t)
-                                             x)
-                                10 -> do bytes <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                     Data.ProtoLens.Encoding.Bytes.getBytes
-                                                       (Prelude.fromIntegral len)
-                                         y <- Data.ProtoLens.Encoding.Bytes.runEither
-                                                (Data.ProtoLens.Encoding.Bytes.runParser
-                                                   (let ploop qs
-                                                          = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
-                                                               if packedEnd then Prelude.return qs
-                                                                 else
-                                                                 do !q <- (Prelude.fmap
-                                                                             Prelude.fromIntegral
-                                                                             Data.ProtoLens.Encoding.Bytes.getVarInt)
-                                                                            Data.ProtoLens.Encoding.Bytes.<?>
-                                                                            "path"
-                                                                    ploop ((:) q qs)
-                                                      in ploop [])
-                                                   bytes)
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "path"))
-                                              (\ !t -> (y) Prelude.++ t)
-                                              x)
+                                        v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                               (Data.ProtoLens.Encoding.Growing.append mutable'path
+                                                  y)
+                                        loop x v
+                                10 -> do y <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                 Data.ProtoLens.Encoding.Bytes.isolate
+                                                   (Prelude.fromIntegral len)
+                                                   ((let ploop qs
+                                                           = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                                if packedEnd then Prelude.return qs
+                                                                  else
+                                                                  do !q <- (Prelude.fmap
+                                                                              Prelude.fromIntegral
+                                                                              Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                                                             Data.ProtoLens.Encoding.Bytes.<?>
+                                                                             "path"
+                                                                     qs' <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                                              (Data.ProtoLens.Encoding.Growing.append
+                                                                                 qs
+                                                                                 q)
+                                                                     ploop qs'
+                                                       in ploop)
+                                                      mutable'path)
+                                         loop x y
                                 18 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                               Data.ProtoLens.Encoding.Bytes.getBytes
                                                                 (Prelude.fromIntegral len)
@@ -6471,6 +7155,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                                                     (Lens.Labels.Proxy#) "sourceFile"))
                                               y
                                               x)
+                                           mutable'path
                                 24 -> do y <- (Prelude.fmap Prelude.fromIntegral
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "begin"
@@ -6481,6 +7166,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                                                     (Lens.Labels.Proxy#) "begin"))
                                               y
                                               x)
+                                           mutable'path
                                 32 -> do y <- (Prelude.fmap Prelude.fromIntegral
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "end"
@@ -6491,34 +7177,41 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                                                     (Lens.Labels.Proxy#) "end"))
                                               y
                                               x)
+                                           mutable'path
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'path
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "Annotation"
+              (do mutable'path <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                    Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'path)
+                Data.ProtoLens.Encoding.Bytes.<?> "Annotation"
         buildMessage
           = (\ _x ->
                (let p = Lens.Family2.view
                           (Lens.Labels.lensOf'
-                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "path"))
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'path"))
                           _x
                   in
-                  if Prelude.null p then Data.Monoid.mempty else
+                  if Data.Vector.Generic.null p then Data.Monoid.mempty else
                     (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
                       (\ bs ->
                          (Data.ProtoLens.Encoding.Bytes.putVarInt
                             (Prelude.fromIntegral (Data.ByteString.length bs)))
                            Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs)
                         (Data.ProtoLens.Encoding.Bytes.runBuilder
-                           (Data.Monoid.mconcat
-                              (Prelude.map
-                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
-                                    Prelude.fromIntegral)
-                                 p))))
+                           (Data.Vector.Generic.foldr
+                              (\ v bs ->
+                                 (((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                     Prelude.fromIntegral)
+                                    v)
+                                   Data.Monoid.<> bs)
+                              Data.Monoid.mempty
+                              p)))
                  Data.Monoid.<>
                  (case
                     Lens.Family2.view
@@ -6588,6 +7281,7 @@ instance Control.DeepSeq.NFData GeneratedCodeInfo'Annotation where
     * 'Proto.Google.Protobuf.Descriptor_Fields.mapEntry' @:: Lens' MessageOptions Prelude.Bool@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'mapEntry' @:: Lens' MessageOptions (Prelude.Maybe Prelude.Bool)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' MessageOptions [UninterpretedOption]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' MessageOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data MessageOptions = MessageOptions{_MessageOptions'messageSetWireFormat
                                      :: !(Prelude.Maybe Prelude.Bool),
@@ -6595,7 +7289,8 @@ data MessageOptions = MessageOptions{_MessageOptions'messageSetWireFormat
                                      !(Prelude.Maybe Prelude.Bool),
                                      _MessageOptions'deprecated :: !(Prelude.Maybe Prelude.Bool),
                                      _MessageOptions'mapEntry :: !(Prelude.Maybe Prelude.Bool),
-                                     _MessageOptions'uninterpretedOption :: ![UninterpretedOption],
+                                     _MessageOptions'uninterpretedOption ::
+                                     !(Data.Vector.Vector UninterpretedOption),
                                      _MessageOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
                         deriving (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show MessageOptions where
@@ -6672,6 +7367,15 @@ instance a ~ ([UninterpretedOption]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _MessageOptions'uninterpretedOption
                (\ x__ y__ -> x__{_MessageOptions'uninterpretedOption = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector UninterpretedOption) =>
+         Lens.Labels.HasLens' MessageOptions "vector'uninterpretedOption" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _MessageOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_MessageOptions'uninterpretedOption = y__}))
               Prelude.. Prelude.id
 instance Data.ProtoLens.Message MessageOptions where
         messageName _ = Data.Text.pack "google.protobuf.MessageOptions"
@@ -6736,16 +7440,22 @@ instance Data.ProtoLens.Message MessageOptions where
                            _MessageOptions'noStandardDescriptorAccessor = Prelude.Nothing,
                            _MessageOptions'deprecated = Prelude.Nothing,
                            _MessageOptions'mapEntry = Prelude.Nothing,
-                           _MessageOptions'uninterpretedOption = [],
+                           _MessageOptions'uninterpretedOption = Data.Vector.Generic.empty,
                            _MessageOptions'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      MessageOptions ->
-                       Data.ProtoLens.Encoding.Bytes.Parser MessageOptions
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         UninterpretedOption
+                         -> Data.ProtoLens.Encoding.Bytes.Parser MessageOptions
+                loop x mutable'uninterpretedOption
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                            (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                               mutable'uninterpretedOption)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -6753,11 +7463,11 @@ instance Data.ProtoLens.Message MessageOptions where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                    (\ !t -> Prelude.reverse t)
+                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                    frozen'uninterpretedOption
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -6773,6 +7483,7 @@ instance Data.ProtoLens.Message MessageOptions where
                                                    (Lens.Labels.Proxy#) "messageSetWireFormat"))
                                              y
                                              x)
+                                          mutable'uninterpretedOption
                                 16 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?>
@@ -6785,6 +7496,7 @@ instance Data.ProtoLens.Message MessageOptions where
                                                       "noStandardDescriptorAccessor"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 24 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "deprecated"
@@ -6795,6 +7507,7 @@ instance Data.ProtoLens.Message MessageOptions where
                                                     (Lens.Labels.Proxy#) "deprecated"))
                                               y
                                               x)
+                                           mutable'uninterpretedOption
                                 56 -> do y <- (Prelude.fmap ((Prelude./=) 0)
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "map_entry"
@@ -6805,29 +7518,30 @@ instance Data.ProtoLens.Message MessageOptions where
                                                     (Lens.Labels.Proxy#) "mapEntry"))
                                               y
                                               x)
-                                7994 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                                 Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                   (Prelude.fromIntegral len)
-                                                     Data.ProtoLens.Encoding.Bytes.runEither
-                                                       (Data.ProtoLens.decodeMessage value))
+                                           mutable'uninterpretedOption
+                                7994 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.isolate
+                                                       (Prelude.fromIntegral len)
+                                                       Data.ProtoLens.parseMessage)
                                                    Data.ProtoLens.Encoding.Bytes.<?>
                                                    "uninterpreted_option"
-                                           loop
-                                             (Lens.Family2.over
-                                                (Lens.Labels.lensOf'
-                                                   ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                                (\ !t -> (:) y t)
-                                                x)
+                                           v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.append
+                                                     mutable'uninterpretedOption
+                                                     y)
+                                           loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'uninterpretedOption
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "MessageOptions"
+              (do mutable'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'uninterpretedOption)
+                Data.ProtoLens.Encoding.Bytes.<?> "MessageOptions"
         buildMessage
           = (\ _x ->
                (case
@@ -6884,21 +7598,22 @@ instance Data.ProtoLens.Message MessageOptions where
                                                   (\ b -> if b then 1 else 0))
                                                  _v)
                        Data.Monoid.<>
-                       (Data.Monoid.mconcat
-                          (Prelude.map
-                             (\ _v ->
-                                (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                                  (((\ bs ->
-                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                          (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                         Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                     Prelude.. Data.ProtoLens.encodeMessage)
-                                    _v)
-                             (Lens.Family2.view
-                                (Lens.Labels.lensOf'
-                                   ((Lens.Labels.proxy#) ::
-                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                _x)))
+                       (Data.Vector.Generic.foldr
+                          (\ _v as ->
+                             ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                                (((\ bs ->
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                       Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                   Prelude.. Data.ProtoLens.encodeMessage)
+                                  _v)
+                               Data.Monoid.<> as)
+                          Data.Monoid.mempty
+                          (Lens.Family2.view
+                             (Lens.Labels.lensOf'
+                                ((Lens.Labels.proxy#) ::
+                                   (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                             _x))
                          Data.Monoid.<>
                          Data.ProtoLens.Encoding.Wire.buildFieldSet
                            (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -7179,11 +7894,10 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
                                                     (Lens.Labels.Proxy#) "outputType"))
                                               y
                                               x)
-                                34 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                              Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                (Prelude.fromIntegral len)
-                                                  Data.ProtoLens.Encoding.Bytes.runEither
-                                                    (Data.ProtoLens.decodeMessage value))
+                                34 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                  Data.ProtoLens.Encoding.Bytes.isolate
+                                                    (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.parseMessage)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "options"
                                          loop
                                            (Lens.Family2.set
@@ -7219,8 +7933,8 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
                                                 (\ !t -> (:) y t)
                                                 x)
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "MethodDescriptorProto"
+              (do loop Data.ProtoLens.defMessage)
+                Data.ProtoLens.Encoding.Bytes.<?> "MethodDescriptorProto"
         buildMessage
           = (\ _x ->
                (case
@@ -7344,12 +8058,14 @@ instance Control.DeepSeq.NFData MethodDescriptorProto where
     * 'Proto.Google.Protobuf.Descriptor_Fields.idempotencyLevel' @:: Lens' MethodOptions MethodOptions'IdempotencyLevel@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'idempotencyLevel' @:: Lens' MethodOptions (Prelude.Maybe MethodOptions'IdempotencyLevel)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' MethodOptions [UninterpretedOption]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' MethodOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data MethodOptions = MethodOptions{_MethodOptions'deprecated ::
                                    !(Prelude.Maybe Prelude.Bool),
                                    _MethodOptions'idempotencyLevel ::
                                    !(Prelude.Maybe MethodOptions'IdempotencyLevel),
-                                   _MethodOptions'uninterpretedOption :: ![UninterpretedOption],
+                                   _MethodOptions'uninterpretedOption ::
+                                   !(Data.Vector.Vector UninterpretedOption),
                                    _MethodOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
                        deriving (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show MethodOptions where
@@ -7388,6 +8104,15 @@ instance a ~ (Prelude.Maybe MethodOptions'IdempotencyLevel) =>
               Prelude.. Prelude.id
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' MethodOptions "uninterpretedOption" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _MethodOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_MethodOptions'uninterpretedOption = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector UninterpretedOption) =>
+         Lens.Labels.HasLens' MethodOptions "vector'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _MethodOptions'uninterpretedOption
@@ -7433,15 +8158,22 @@ instance Data.ProtoLens.Message MethodOptions where
         defMessage
           = MethodOptions{_MethodOptions'deprecated = Prelude.Nothing,
                           _MethodOptions'idempotencyLevel = Prelude.Nothing,
-                          _MethodOptions'uninterpretedOption = [],
+                          _MethodOptions'uninterpretedOption = Data.Vector.Generic.empty,
                           _MethodOptions'_unknownFields = ([])}
         parseMessage
           = let loop ::
-                     MethodOptions -> Data.ProtoLens.Encoding.Bytes.Parser MethodOptions
-                loop x
+                     MethodOptions ->
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         UninterpretedOption
+                         -> Data.ProtoLens.Encoding.Bytes.Parser MethodOptions
+                loop x mutable'uninterpretedOption
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                            (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                               mutable'uninterpretedOption)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -7449,11 +8181,11 @@ instance Data.ProtoLens.Message MethodOptions where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                    (\ !t -> Prelude.reverse t)
+                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                    frozen'uninterpretedOption
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -7468,6 +8200,7 @@ instance Data.ProtoLens.Message MethodOptions where
                                                      (Lens.Labels.Proxy#) "deprecated"))
                                                y
                                                x)
+                                            mutable'uninterpretedOption
                                 272 -> do y <- (Prelude.fmap Prelude.toEnum
                                                   (Prelude.fmap Prelude.fromIntegral
                                                      Data.ProtoLens.Encoding.Bytes.getVarInt))
@@ -7480,29 +8213,30 @@ instance Data.ProtoLens.Message MethodOptions where
                                                      (Lens.Labels.Proxy#) "idempotencyLevel"))
                                                y
                                                x)
-                                7994 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                                 Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                   (Prelude.fromIntegral len)
-                                                     Data.ProtoLens.Encoding.Bytes.runEither
-                                                       (Data.ProtoLens.decodeMessage value))
+                                            mutable'uninterpretedOption
+                                7994 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.isolate
+                                                       (Prelude.fromIntegral len)
+                                                       Data.ProtoLens.parseMessage)
                                                    Data.ProtoLens.Encoding.Bytes.<?>
                                                    "uninterpreted_option"
-                                           loop
-                                             (Lens.Family2.over
-                                                (Lens.Labels.lensOf'
-                                                   ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                                (\ !t -> (:) y t)
-                                                x)
+                                           v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.append
+                                                     mutable'uninterpretedOption
+                                                     y)
+                                           loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'uninterpretedOption
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "MethodOptions"
+              (do mutable'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'uninterpretedOption)
+                Data.ProtoLens.Encoding.Bytes.<?> "MethodOptions"
         buildMessage
           = (\ _x ->
                (case
@@ -7533,21 +8267,22 @@ instance Data.ProtoLens.Message MethodOptions where
                                               Prelude.. Prelude.fromEnum)
                                              _v)
                    Data.Monoid.<>
-                   (Data.Monoid.mconcat
-                      (Prelude.map
-                         (\ _v ->
-                            (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                              (((\ bs ->
-                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                 Prelude.. Data.ProtoLens.encodeMessage)
-                                _v)
-                         (Lens.Family2.view
-                            (Lens.Labels.lensOf'
-                               ((Lens.Labels.proxy#) ::
-                                  (Lens.Labels.Proxy#) "uninterpretedOption"))
-                            _x)))
+                   (Data.Vector.Generic.foldr
+                      (\ _v as ->
+                         ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                            (((\ bs ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                               Prelude.. Data.ProtoLens.encodeMessage)
+                              _v)
+                           Data.Monoid.<> as)
+                      Data.Monoid.mempty
+                      (Lens.Family2.view
+                         (Lens.Labels.lensOf'
+                            ((Lens.Labels.proxy#) ::
+                               (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                         _x))
                      Data.Monoid.<>
                      Data.ProtoLens.Encoding.Wire.buildFieldSet
                        (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -7731,11 +8466,10 @@ instance Data.ProtoLens.Message OneofDescriptorProto where
                                                     (Lens.Labels.Proxy#) "name"))
                                               y
                                               x)
-                                18 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                              Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                (Prelude.fromIntegral len)
-                                                  Data.ProtoLens.Encoding.Bytes.runEither
-                                                    (Data.ProtoLens.decodeMessage value))
+                                18 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                  Data.ProtoLens.Encoding.Bytes.isolate
+                                                    (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.parseMessage)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "options"
                                          loop
                                            (Lens.Family2.set
@@ -7751,8 +8485,8 @@ instance Data.ProtoLens.Message OneofDescriptorProto where
                                                 (\ !t -> (:) y t)
                                                 x)
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "OneofDescriptorProto"
+              (do loop Data.ProtoLens.defMessage)
+                Data.ProtoLens.Encoding.Bytes.<?> "OneofDescriptorProto"
         buildMessage
           = (\ _x ->
                (case
@@ -7802,9 +8536,10 @@ instance Control.DeepSeq.NFData OneofDescriptorProto where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' OneofOptions [UninterpretedOption]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' OneofOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data OneofOptions = OneofOptions{_OneofOptions'uninterpretedOption
-                                 :: ![UninterpretedOption],
+                                 :: !(Data.Vector.Vector UninterpretedOption),
                                  _OneofOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
                       deriving (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show OneofOptions where
@@ -7814,6 +8549,15 @@ instance Prelude.Show OneofOptions where
                  (Prelude.showChar '}' __s))
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' OneofOptions "uninterpretedOption" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _OneofOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_OneofOptions'uninterpretedOption = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector UninterpretedOption) =>
+         Lens.Labels.HasLens' OneofOptions "vector'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _OneofOptions'uninterpretedOption
@@ -7838,15 +8582,23 @@ instance Data.ProtoLens.Message OneofOptions where
           = Lens.Family2.Unchecked.lens _OneofOptions'_unknownFields
               (\ x__ y__ -> x__{_OneofOptions'_unknownFields = y__})
         defMessage
-          = OneofOptions{_OneofOptions'uninterpretedOption = [],
+          = OneofOptions{_OneofOptions'uninterpretedOption =
+                           Data.Vector.Generic.empty,
                          _OneofOptions'_unknownFields = ([])}
         parseMessage
           = let loop ::
-                     OneofOptions -> Data.ProtoLens.Encoding.Bytes.Parser OneofOptions
-                loop x
+                     OneofOptions ->
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         UninterpretedOption
+                         -> Data.ProtoLens.Encoding.Bytes.Parser OneofOptions
+                loop x mutable'uninterpretedOption
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                            (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                               mutable'uninterpretedOption)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -7854,55 +8606,56 @@ instance Data.ProtoLens.Message OneofOptions where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                    (\ !t -> Prelude.reverse t)
+                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                    frozen'uninterpretedOption
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
                             case tag of
-                                7994 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                                 Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                   (Prelude.fromIntegral len)
-                                                     Data.ProtoLens.Encoding.Bytes.runEither
-                                                       (Data.ProtoLens.decodeMessage value))
+                                7994 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.isolate
+                                                       (Prelude.fromIntegral len)
+                                                       Data.ProtoLens.parseMessage)
                                                    Data.ProtoLens.Encoding.Bytes.<?>
                                                    "uninterpreted_option"
-                                           loop
-                                             (Lens.Family2.over
-                                                (Lens.Labels.lensOf'
-                                                   ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                                (\ !t -> (:) y t)
-                                                x)
+                                           v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.append
+                                                     mutable'uninterpretedOption
+                                                     y)
+                                           loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'uninterpretedOption
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "OneofOptions"
+              (do mutable'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'uninterpretedOption)
+                Data.ProtoLens.Encoding.Bytes.<?> "OneofOptions"
         buildMessage
           = (\ _x ->
-               (Data.Monoid.mconcat
-                  (Prelude.map
-                     (\ _v ->
-                        (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                     (Lens.Family2.view
-                        (Lens.Labels.lensOf'
-                           ((Lens.Labels.proxy#) ::
-                              (Lens.Labels.Proxy#) "uninterpretedOption"))
-                        _x)))
+               (Data.Vector.Generic.foldr
+                  (\ _v as ->
+                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                        (((\ bs ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                (Prelude.fromIntegral (Data.ByteString.length bs)))
+                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                           Prelude.. Data.ProtoLens.encodeMessage)
+                          _v)
+                       Data.Monoid.<> as)
+                  Data.Monoid.mempty
+                  (Lens.Family2.view
+                     (Lens.Labels.lensOf'
+                        ((Lens.Labels.proxy#) ::
+                           (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                     _x))
                  Data.Monoid.<>
                  Data.ProtoLens.Encoding.Wire.buildFieldSet
                    (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -7917,13 +8670,15 @@ instance Control.DeepSeq.NFData OneofOptions where
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' ServiceDescriptorProto Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'name' @:: Lens' ServiceDescriptorProto (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.method' @:: Lens' ServiceDescriptorProto [MethodDescriptorProto]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'method' @:: Lens' ServiceDescriptorProto
+  (Data.Vector.Vector MethodDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.options' @:: Lens' ServiceDescriptorProto ServiceOptions@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'options' @:: Lens' ServiceDescriptorProto (Prelude.Maybe ServiceOptions)@
  -}
 data ServiceDescriptorProto = ServiceDescriptorProto{_ServiceDescriptorProto'name
                                                      :: !(Prelude.Maybe Data.Text.Text),
                                                      _ServiceDescriptorProto'method ::
-                                                     ![MethodDescriptorProto],
+                                                     !(Data.Vector.Vector MethodDescriptorProto),
                                                      _ServiceDescriptorProto'options ::
                                                      !(Prelude.Maybe ServiceOptions),
                                                      _ServiceDescriptorProto'_unknownFields ::
@@ -7950,6 +8705,15 @@ instance a ~ (Prelude.Maybe Data.Text.Text) =>
               Prelude.. Prelude.id
 instance a ~ ([MethodDescriptorProto]) =>
          Lens.Labels.HasLens' ServiceDescriptorProto "method" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'method
+               (\ x__ y__ -> x__{_ServiceDescriptorProto'method = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector MethodDescriptorProto) =>
+         Lens.Labels.HasLens' ServiceDescriptorProto "vector'method" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'method
@@ -8009,17 +8773,23 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
         defMessage
           = ServiceDescriptorProto{_ServiceDescriptorProto'name =
                                      Prelude.Nothing,
-                                   _ServiceDescriptorProto'method = [],
+                                   _ServiceDescriptorProto'method = Data.Vector.Generic.empty,
                                    _ServiceDescriptorProto'options = Prelude.Nothing,
                                    _ServiceDescriptorProto'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      ServiceDescriptorProto ->
-                       Data.ProtoLens.Encoding.Bytes.Parser ServiceDescriptorProto
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         MethodDescriptorProto
+                         -> Data.ProtoLens.Encoding.Bytes.Parser ServiceDescriptorProto
+                loop x mutable'method
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'method <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                               (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                  mutable'method)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -8027,10 +8797,11 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "method"))
-                                    (\ !t -> Prelude.reverse t)
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "vector'method"))
+                                    frozen'method
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -8051,24 +8822,21 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
                                                     (Lens.Labels.Proxy#) "name"))
                                               y
                                               x)
-                                18 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                           mutable'method
+                                18 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "method"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "method"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                26 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                              Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                (Prelude.fromIntegral len)
-                                                  Data.ProtoLens.Encoding.Bytes.runEither
-                                                    (Data.ProtoLens.decodeMessage value))
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'method
+                                                   y)
+                                         loop x v
+                                26 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                  Data.ProtoLens.Encoding.Bytes.isolate
+                                                    (Prelude.fromIntegral len)
+                                                    Data.ProtoLens.parseMessage)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "options"
                                          loop
                                            (Lens.Family2.set
@@ -8077,15 +8845,19 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
                                                     (Lens.Labels.Proxy#) "options"))
                                               y
                                               x)
+                                           mutable'method
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'method
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "ServiceDescriptorProto"
+              (do mutable'method <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                      Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'method)
+                Data.ProtoLens.Encoding.Bytes.<?> "ServiceDescriptorProto"
         buildMessage
           = (\ _x ->
                (case
@@ -8105,20 +8877,21 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
                                             Prelude.. Data.Text.Encoding.encodeUtf8)
                                            _v)
                  Data.Monoid.<>
-                 (Data.Monoid.mconcat
-                    (Prelude.map
-                       (\ _v ->
-                          (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
-                            (((\ bs ->
-                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                               Prelude.. Data.ProtoLens.encodeMessage)
-                              _v)
-                       (Lens.Family2.view
-                          (Lens.Labels.lensOf'
-                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "method"))
-                          _x)))
+                 (Data.Vector.Generic.foldr
+                    (\ _v as ->
+                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude.. Data.ProtoLens.encodeMessage)
+                            _v)
+                         Data.Monoid.<> as)
+                    Data.Monoid.mempty
+                    (Lens.Family2.view
+                       (Lens.Labels.lensOf'
+                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'method"))
+                       _x))
                    Data.Monoid.<>
                    (case
                       Lens.Family2.view
@@ -8154,10 +8927,12 @@ instance Control.DeepSeq.NFData ServiceDescriptorProto where
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' ServiceOptions Prelude.Bool@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'deprecated' @:: Lens' ServiceOptions (Prelude.Maybe Prelude.Bool)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' ServiceOptions [UninterpretedOption]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' ServiceOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data ServiceOptions = ServiceOptions{_ServiceOptions'deprecated ::
                                      !(Prelude.Maybe Prelude.Bool),
-                                     _ServiceOptions'uninterpretedOption :: ![UninterpretedOption],
+                                     _ServiceOptions'uninterpretedOption ::
+                                     !(Data.Vector.Vector UninterpretedOption),
                                      _ServiceOptions'_unknownFields :: !Data.ProtoLens.FieldSet}
                         deriving (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show ServiceOptions where
@@ -8181,6 +8956,15 @@ instance a ~ (Prelude.Maybe Prelude.Bool) =>
               Prelude.. Prelude.id
 instance a ~ ([UninterpretedOption]) =>
          Lens.Labels.HasLens' ServiceOptions "uninterpretedOption" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _ServiceOptions'uninterpretedOption
+               (\ x__ y__ -> x__{_ServiceOptions'uninterpretedOption = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector UninterpretedOption) =>
+         Lens.Labels.HasLens' ServiceOptions "vector'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _ServiceOptions'uninterpretedOption
@@ -8215,16 +8999,22 @@ instance Data.ProtoLens.Message ServiceOptions where
               (\ x__ y__ -> x__{_ServiceOptions'_unknownFields = y__})
         defMessage
           = ServiceOptions{_ServiceOptions'deprecated = Prelude.Nothing,
-                           _ServiceOptions'uninterpretedOption = [],
+                           _ServiceOptions'uninterpretedOption = Data.Vector.Generic.empty,
                            _ServiceOptions'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      ServiceOptions ->
-                       Data.ProtoLens.Encoding.Bytes.Parser ServiceOptions
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         UninterpretedOption
+                         -> Data.ProtoLens.Encoding.Bytes.Parser ServiceOptions
+                loop x mutable'uninterpretedOption
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                            (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                               mutable'uninterpretedOption)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -8232,11 +9022,11 @@ instance Data.ProtoLens.Message ServiceOptions where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                    (\ !t -> Prelude.reverse t)
+                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                    frozen'uninterpretedOption
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -8251,29 +9041,30 @@ instance Data.ProtoLens.Message ServiceOptions where
                                                      (Lens.Labels.Proxy#) "deprecated"))
                                                y
                                                x)
-                                7994 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                                 Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                   (Prelude.fromIntegral len)
-                                                     Data.ProtoLens.Encoding.Bytes.runEither
-                                                       (Data.ProtoLens.decodeMessage value))
+                                            mutable'uninterpretedOption
+                                7994 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                     Data.ProtoLens.Encoding.Bytes.isolate
+                                                       (Prelude.fromIntegral len)
+                                                       Data.ProtoLens.parseMessage)
                                                    Data.ProtoLens.Encoding.Bytes.<?>
                                                    "uninterpreted_option"
-                                           loop
-                                             (Lens.Family2.over
-                                                (Lens.Labels.lensOf'
-                                                   ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "uninterpretedOption"))
-                                                (\ !t -> (:) y t)
-                                                x)
+                                           v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                  (Data.ProtoLens.Encoding.Growing.append
+                                                     mutable'uninterpretedOption
+                                                     y)
+                                           loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'uninterpretedOption
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "ServiceOptions"
+              (do mutable'uninterpretedOption <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                   Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'uninterpretedOption)
+                Data.ProtoLens.Encoding.Bytes.<?> "ServiceOptions"
         buildMessage
           = (\ _x ->
                (case
@@ -8289,21 +9080,22 @@ instance Data.ProtoLens.Message ServiceOptions where
                                             (\ b -> if b then 1 else 0))
                                            _v)
                  Data.Monoid.<>
-                 (Data.Monoid.mconcat
-                    (Prelude.map
-                       (\ _v ->
-                          (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                            (((\ bs ->
-                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                               Prelude.. Data.ProtoLens.encodeMessage)
-                              _v)
-                       (Lens.Family2.view
-                          (Lens.Labels.lensOf'
-                             ((Lens.Labels.proxy#) ::
-                                (Lens.Labels.Proxy#) "uninterpretedOption"))
-                          _x)))
+                 (Data.Vector.Generic.foldr
+                    (\ _v as ->
+                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                          (((\ bs ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                             Prelude.. Data.ProtoLens.encodeMessage)
+                            _v)
+                         Data.Monoid.<> as)
+                    Data.Monoid.mempty
+                    (Lens.Family2.view
+                       (Lens.Labels.lensOf'
+                          ((Lens.Labels.proxy#) ::
+                             (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                       _x))
                    Data.Monoid.<>
                    Data.ProtoLens.Encoding.Wire.buildFieldSet
                      (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -8317,9 +9109,10 @@ instance Control.DeepSeq.NFData ServiceOptions where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.location' @:: Lens' SourceCodeInfo [SourceCodeInfo'Location]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'location' @:: Lens' SourceCodeInfo (Data.Vector.Vector SourceCodeInfo'Location)@
  -}
 data SourceCodeInfo = SourceCodeInfo{_SourceCodeInfo'location ::
-                                     ![SourceCodeInfo'Location],
+                                     !(Data.Vector.Vector SourceCodeInfo'Location),
                                      _SourceCodeInfo'_unknownFields :: !Data.ProtoLens.FieldSet}
                         deriving (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show SourceCodeInfo where
@@ -8329,6 +9122,15 @@ instance Prelude.Show SourceCodeInfo where
                  (Prelude.showChar '}' __s))
 instance a ~ ([SourceCodeInfo'Location]) =>
          Lens.Labels.HasLens' SourceCodeInfo "location" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _SourceCodeInfo'location
+               (\ x__ y__ -> x__{_SourceCodeInfo'location = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector SourceCodeInfo'Location) =>
+         Lens.Labels.HasLens' SourceCodeInfo "vector'location" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _SourceCodeInfo'location
@@ -8352,16 +9154,23 @@ instance Data.ProtoLens.Message SourceCodeInfo where
           = Lens.Family2.Unchecked.lens _SourceCodeInfo'_unknownFields
               (\ x__ y__ -> x__{_SourceCodeInfo'_unknownFields = y__})
         defMessage
-          = SourceCodeInfo{_SourceCodeInfo'location = [],
+          = SourceCodeInfo{_SourceCodeInfo'location =
+                             Data.Vector.Generic.empty,
                            _SourceCodeInfo'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      SourceCodeInfo ->
-                       Data.ProtoLens.Encoding.Bytes.Parser SourceCodeInfo
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         SourceCodeInfo'Location
+                         -> Data.ProtoLens.Encoding.Bytes.Parser SourceCodeInfo
+                loop x mutable'location
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'location <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                 (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                    mutable'location)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -8369,52 +9178,54 @@ instance Data.ProtoLens.Message SourceCodeInfo where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "location"))
-                                    (\ !t -> Prelude.reverse t)
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "vector'location"))
+                                    frozen'location
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
                             case tag of
-                                10 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                10 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "location"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "location"))
-                                              (\ !t -> (:) y t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'location
+                                                   y)
+                                         loop x v
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'location
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "SourceCodeInfo"
+              (do mutable'location <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                        Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'location)
+                Data.ProtoLens.Encoding.Bytes.<?> "SourceCodeInfo"
         buildMessage
           = (\ _x ->
-               (Data.Monoid.mconcat
-                  (Prelude.map
-                     (\ _v ->
-                        (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                     (Lens.Family2.view
-                        (Lens.Labels.lensOf'
-                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "location"))
-                        _x)))
+               (Data.Vector.Generic.foldr
+                  (\ _v as ->
+                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                        (((\ bs ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                (Prelude.fromIntegral (Data.ByteString.length bs)))
+                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                           Prelude.. Data.ProtoLens.encodeMessage)
+                          _v)
+                       Data.Monoid.<> as)
+                  Data.Monoid.mempty
+                  (Lens.Family2.view
+                     (Lens.Labels.lensOf'
+                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'location"))
+                     _x))
                  Data.Monoid.<>
                  Data.ProtoLens.Encoding.Wire.buildFieldSet
                    (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -8426,23 +9237,29 @@ instance Control.DeepSeq.NFData SourceCodeInfo where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.path' @:: Lens' SourceCodeInfo'Location [Data.Int.Int32]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'path' @:: Lens' SourceCodeInfo'Location
+  (Data.Vector.Unboxed.Vector Data.Int.Int32)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.span' @:: Lens' SourceCodeInfo'Location [Data.Int.Int32]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'span' @:: Lens' SourceCodeInfo'Location
+  (Data.Vector.Unboxed.Vector Data.Int.Int32)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.leadingComments' @:: Lens' SourceCodeInfo'Location Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'leadingComments' @:: Lens' SourceCodeInfo'Location (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.trailingComments' @:: Lens' SourceCodeInfo'Location Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'trailingComments' @:: Lens' SourceCodeInfo'Location (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.leadingDetachedComments' @:: Lens' SourceCodeInfo'Location [Data.Text.Text]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'leadingDetachedComments' @:: Lens' SourceCodeInfo'Location (Data.Vector.Vector Data.Text.Text)@
  -}
 data SourceCodeInfo'Location = SourceCodeInfo'Location{_SourceCodeInfo'Location'path
-                                                       :: ![Data.Int.Int32],
+                                                       ::
+                                                       !(Data.Vector.Unboxed.Vector Data.Int.Int32),
                                                        _SourceCodeInfo'Location'span ::
-                                                       ![Data.Int.Int32],
+                                                       !(Data.Vector.Unboxed.Vector Data.Int.Int32),
                                                        _SourceCodeInfo'Location'leadingComments ::
                                                        !(Prelude.Maybe Data.Text.Text),
                                                        _SourceCodeInfo'Location'trailingComments ::
                                                        !(Prelude.Maybe Data.Text.Text),
                                                        _SourceCodeInfo'Location'leadingDetachedComments
-                                                       :: ![Data.Text.Text],
+                                                       :: !(Data.Vector.Vector Data.Text.Text),
                                                        _SourceCodeInfo'Location'_unknownFields ::
                                                        !Data.ProtoLens.FieldSet}
                                  deriving (Prelude.Eq, Prelude.Ord)
@@ -8457,9 +9274,27 @@ instance a ~ ([Data.Int.Int32]) =>
         lensOf' _
           = (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'path
                (\ x__ y__ -> x__{_SourceCodeInfo'Location'path = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Unboxed.Vector Data.Int.Int32) =>
+         Lens.Labels.HasLens' SourceCodeInfo'Location "vector'path" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'path
+               (\ x__ y__ -> x__{_SourceCodeInfo'Location'path = y__}))
               Prelude.. Prelude.id
 instance a ~ ([Data.Int.Int32]) =>
          Lens.Labels.HasLens' SourceCodeInfo'Location "span" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'span
+               (\ x__ y__ -> x__{_SourceCodeInfo'Location'span = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Unboxed.Vector Data.Int.Int32) =>
+         Lens.Labels.HasLens' SourceCodeInfo'Location "vector'span" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'span
@@ -8506,6 +9341,19 @@ instance a ~ (Prelude.Maybe Data.Text.Text) =>
 instance a ~ ([Data.Text.Text]) =>
          Lens.Labels.HasLens' SourceCodeInfo'Location
            "leadingDetachedComments"
+           a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens
+               _SourceCodeInfo'Location'leadingDetachedComments
+               (\ x__ y__ ->
+                  x__{_SourceCodeInfo'Location'leadingDetachedComments = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector Data.Text.Text) =>
+         Lens.Labels.HasLens' SourceCodeInfo'Location
+           "vector'leadingDetachedComments"
            a
          where
         lensOf' _
@@ -8573,20 +9421,42 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
               _SourceCodeInfo'Location'_unknownFields
               (\ x__ y__ -> x__{_SourceCodeInfo'Location'_unknownFields = y__})
         defMessage
-          = SourceCodeInfo'Location{_SourceCodeInfo'Location'path = [],
-                                    _SourceCodeInfo'Location'span = [],
+          = SourceCodeInfo'Location{_SourceCodeInfo'Location'path =
+                                      Data.Vector.Generic.empty,
+                                    _SourceCodeInfo'Location'span = Data.Vector.Generic.empty,
                                     _SourceCodeInfo'Location'leadingComments = Prelude.Nothing,
                                     _SourceCodeInfo'Location'trailingComments = Prelude.Nothing,
-                                    _SourceCodeInfo'Location'leadingDetachedComments = [],
+                                    _SourceCodeInfo'Location'leadingDetachedComments =
+                                      Data.Vector.Generic.empty,
                                     _SourceCodeInfo'Location'_unknownFields = ([])}
         parseMessage
           = let loop ::
                      SourceCodeInfo'Location ->
-                       Data.ProtoLens.Encoding.Bytes.Parser SourceCodeInfo'Location
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         Data.Text.Text
+                         ->
+                         Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Unboxed.Vector
+                           Data.ProtoLens.Encoding.Growing.RealWorld
+                           Data.Int.Int32
+                           ->
+                           Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Unboxed.Vector
+                             Data.ProtoLens.Encoding.Growing.RealWorld
+                             Data.Int.Int32
+                             -> Data.ProtoLens.Encoding.Bytes.Parser SourceCodeInfo'Location
+                loop x mutable'leadingDetachedComments mutable'path mutable'span
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'leadingDetachedComments <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                                (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                                   mutable'leadingDetachedComments)
+                            frozen'path <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                             (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                mutable'path)
+                            frozen'span <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                             (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                mutable'span)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -8594,19 +9464,21 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "path"))
-                                    (\ !t -> Prelude.reverse t)
-                                    (Lens.Family2.over
+                                       ((Lens.Labels.proxy#) ::
+                                          (Lens.Labels.Proxy#) "vector'leadingDetachedComments"))
+                                    frozen'leadingDetachedComments
+                                    (Lens.Family2.set
                                        (Lens.Labels.lensOf'
-                                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "span"))
-                                       (\ !t -> Prelude.reverse t)
-                                       (Lens.Family2.over
+                                          ((Lens.Labels.proxy#) ::
+                                             (Lens.Labels.Proxy#) "vector'path"))
+                                       frozen'path
+                                       (Lens.Family2.set
                                           (Lens.Labels.lensOf'
                                              ((Lens.Labels.proxy#) ::
-                                                (Lens.Labels.Proxy#) "leadingDetachedComments"))
-                                          (\ !t -> Prelude.reverse t)
+                                                (Lens.Labels.Proxy#) "vector'span"))
+                                          frozen'span
                                           x))))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -8614,71 +9486,57 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                                 8 -> do !y <- (Prelude.fmap Prelude.fromIntegral
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?> "path"
-                                        loop
-                                          (Lens.Family2.over
-                                             (Lens.Labels.lensOf'
-                                                ((Lens.Labels.proxy#) ::
-                                                   (Lens.Labels.Proxy#) "path"))
-                                             (\ !t -> (:) y t)
-                                             x)
-                                10 -> do bytes <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                     Data.ProtoLens.Encoding.Bytes.getBytes
-                                                       (Prelude.fromIntegral len)
-                                         y <- Data.ProtoLens.Encoding.Bytes.runEither
-                                                (Data.ProtoLens.Encoding.Bytes.runParser
-                                                   (let ploop qs
-                                                          = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
-                                                               if packedEnd then Prelude.return qs
-                                                                 else
-                                                                 do !q <- (Prelude.fmap
-                                                                             Prelude.fromIntegral
-                                                                             Data.ProtoLens.Encoding.Bytes.getVarInt)
-                                                                            Data.ProtoLens.Encoding.Bytes.<?>
-                                                                            "path"
-                                                                    ploop ((:) q qs)
-                                                      in ploop [])
-                                                   bytes)
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "path"))
-                                              (\ !t -> (y) Prelude.++ t)
-                                              x)
+                                        v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                               (Data.ProtoLens.Encoding.Growing.append mutable'path
+                                                  y)
+                                        loop x mutable'leadingDetachedComments v mutable'span
+                                10 -> do y <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                 Data.ProtoLens.Encoding.Bytes.isolate
+                                                   (Prelude.fromIntegral len)
+                                                   ((let ploop qs
+                                                           = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                                if packedEnd then Prelude.return qs
+                                                                  else
+                                                                  do !q <- (Prelude.fmap
+                                                                              Prelude.fromIntegral
+                                                                              Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                                                             Data.ProtoLens.Encoding.Bytes.<?>
+                                                                             "path"
+                                                                     qs' <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                                              (Data.ProtoLens.Encoding.Growing.append
+                                                                                 qs
+                                                                                 q)
+                                                                     ploop qs'
+                                                       in ploop)
+                                                      mutable'path)
+                                         loop x mutable'leadingDetachedComments y mutable'span
                                 16 -> do !y <- (Prelude.fmap Prelude.fromIntegral
                                                   Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "span"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "span"))
-                                              (\ !t -> (:) y t)
-                                              x)
-                                18 -> do bytes <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                     Data.ProtoLens.Encoding.Bytes.getBytes
-                                                       (Prelude.fromIntegral len)
-                                         y <- Data.ProtoLens.Encoding.Bytes.runEither
-                                                (Data.ProtoLens.Encoding.Bytes.runParser
-                                                   (let ploop qs
-                                                          = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
-                                                               if packedEnd then Prelude.return qs
-                                                                 else
-                                                                 do !q <- (Prelude.fmap
-                                                                             Prelude.fromIntegral
-                                                                             Data.ProtoLens.Encoding.Bytes.getVarInt)
-                                                                            Data.ProtoLens.Encoding.Bytes.<?>
-                                                                            "span"
-                                                                    ploop ((:) q qs)
-                                                      in ploop [])
-                                                   bytes)
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "span"))
-                                              (\ !t -> (y) Prelude.++ t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append mutable'span
+                                                   y)
+                                         loop x mutable'leadingDetachedComments mutable'path v
+                                18 -> do y <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                 Data.ProtoLens.Encoding.Bytes.isolate
+                                                   (Prelude.fromIntegral len)
+                                                   ((let ploop qs
+                                                           = do packedEnd <- Data.ProtoLens.Encoding.Bytes.atEnd
+                                                                if packedEnd then Prelude.return qs
+                                                                  else
+                                                                  do !q <- (Prelude.fmap
+                                                                              Prelude.fromIntegral
+                                                                              Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                                                             Data.ProtoLens.Encoding.Bytes.<?>
+                                                                             "span"
+                                                                     qs' <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                                              (Data.ProtoLens.Encoding.Growing.append
+                                                                                 qs
+                                                                                 q)
+                                                                     ploop qs'
+                                                       in ploop)
+                                                      mutable'span)
+                                         loop x mutable'leadingDetachedComments mutable'path y
                                 26 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                               Data.ProtoLens.Encoding.Bytes.getBytes
                                                                 (Prelude.fromIntegral len)
@@ -8695,6 +9553,9 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                                                     (Lens.Labels.Proxy#) "leadingComments"))
                                               y
                                               x)
+                                           mutable'leadingDetachedComments
+                                           mutable'path
+                                           mutable'span
                                 34 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                               Data.ProtoLens.Encoding.Bytes.getBytes
                                                                 (Prelude.fromIntegral len)
@@ -8712,6 +9573,9 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                                                     (Lens.Labels.Proxy#) "trailingComments"))
                                               y
                                               x)
+                                           mutable'leadingDetachedComments
+                                           mutable'path
+                                           mutable'span
                                 50 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                                Data.ProtoLens.Encoding.Bytes.getBytes
                                                                  (Prelude.fromIntegral len)
@@ -8722,59 +9586,74 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                                                           Prelude.Right r -> Prelude.Right r))
                                                  Data.ProtoLens.Encoding.Bytes.<?>
                                                  "leading_detached_comments"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "leadingDetachedComments"))
-                                              (\ !t -> (:) y t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append
+                                                   mutable'leadingDetachedComments
+                                                   y)
+                                         loop x v mutable'path mutable'span
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'leadingDetachedComments
+                                             mutable'path
+                                             mutable'span
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "Location"
+              (do mutable'leadingDetachedComments <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                       Data.ProtoLens.Encoding.Growing.new
+                  mutable'path <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                    Data.ProtoLens.Encoding.Growing.new
+                  mutable'span <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                    Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'leadingDetachedComments
+                    mutable'path
+                    mutable'span)
+                Data.ProtoLens.Encoding.Bytes.<?> "Location"
         buildMessage
           = (\ _x ->
                (let p = Lens.Family2.view
                           (Lens.Labels.lensOf'
-                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "path"))
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'path"))
                           _x
                   in
-                  if Prelude.null p then Data.Monoid.mempty else
+                  if Data.Vector.Generic.null p then Data.Monoid.mempty else
                     (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
                       (\ bs ->
                          (Data.ProtoLens.Encoding.Bytes.putVarInt
                             (Prelude.fromIntegral (Data.ByteString.length bs)))
                            Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs)
                         (Data.ProtoLens.Encoding.Bytes.runBuilder
-                           (Data.Monoid.mconcat
-                              (Prelude.map
-                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
-                                    Prelude.fromIntegral)
-                                 p))))
+                           (Data.Vector.Generic.foldr
+                              (\ v bs ->
+                                 (((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                     Prelude.fromIntegral)
+                                    v)
+                                   Data.Monoid.<> bs)
+                              Data.Monoid.mempty
+                              p)))
                  Data.Monoid.<>
                  (let p = Lens.Family2.view
                             (Lens.Labels.lensOf'
-                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "span"))
+                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'span"))
                             _x
                     in
-                    if Prelude.null p then Data.Monoid.mempty else
+                    if Data.Vector.Generic.null p then Data.Monoid.mempty else
                       (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
                         (\ bs ->
                            (Data.ProtoLens.Encoding.Bytes.putVarInt
                               (Prelude.fromIntegral (Data.ByteString.length bs)))
                              Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs)
                           (Data.ProtoLens.Encoding.Bytes.runBuilder
-                             (Data.Monoid.mconcat
-                                (Prelude.map
-                                   ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
-                                      Prelude.fromIntegral)
-                                   p))))
+                             (Data.Vector.Generic.foldr
+                                (\ v bs ->
+                                   (((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                       Prelude.fromIntegral)
+                                      v)
+                                     Data.Monoid.<> bs)
+                                Data.Monoid.mempty
+                                p)))
                    Data.Monoid.<>
                    (case
                       Lens.Family2.view
@@ -8814,21 +9693,22 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                                                   Prelude.. Data.Text.Encoding.encodeUtf8)
                                                  _v)
                        Data.Monoid.<>
-                       (Data.Monoid.mconcat
-                          (Prelude.map
-                             (\ _v ->
-                                (Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
-                                  (((\ bs ->
-                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                          (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                         Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                     Prelude.. Data.Text.Encoding.encodeUtf8)
-                                    _v)
-                             (Lens.Family2.view
-                                (Lens.Labels.lensOf'
-                                   ((Lens.Labels.proxy#) ::
-                                      (Lens.Labels.Proxy#) "leadingDetachedComments"))
-                                _x)))
+                       (Data.Vector.Generic.foldr
+                          (\ _v as ->
+                             ((Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
+                                (((\ bs ->
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                       Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                   Prelude.. Data.Text.Encoding.encodeUtf8)
+                                  _v)
+                               Data.Monoid.<> as)
+                          Data.Monoid.mempty
+                          (Lens.Family2.view
+                             (Lens.Labels.lensOf'
+                                ((Lens.Labels.proxy#) ::
+                                   (Lens.Labels.Proxy#) "vector'leadingDetachedComments"))
+                             _x))
                          Data.Monoid.<>
                          Data.ProtoLens.Encoding.Wire.buildFieldSet
                            (Lens.Family2.view Data.ProtoLens.unknownFields _x))
@@ -8849,6 +9729,8 @@ instance Control.DeepSeq.NFData SourceCodeInfo'Location where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' UninterpretedOption [UninterpretedOption'NamePart]@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'name' @:: Lens' UninterpretedOption
+  (Data.Vector.Vector UninterpretedOption'NamePart)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.identifierValue' @:: Lens' UninterpretedOption Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'identifierValue' @:: Lens' UninterpretedOption (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.positiveIntValue' @:: Lens' UninterpretedOption Data.Word.Word64@
@@ -8864,7 +9746,8 @@ instance Control.DeepSeq.NFData SourceCodeInfo'Location where
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'aggregateValue' @:: Lens' UninterpretedOption (Prelude.Maybe Data.Text.Text)@
  -}
 data UninterpretedOption = UninterpretedOption{_UninterpretedOption'name
-                                               :: ![UninterpretedOption'NamePart],
+                                               ::
+                                               !(Data.Vector.Vector UninterpretedOption'NamePart),
                                                _UninterpretedOption'identifierValue ::
                                                !(Prelude.Maybe Data.Text.Text),
                                                _UninterpretedOption'positiveIntValue ::
@@ -8887,6 +9770,15 @@ instance Prelude.Show UninterpretedOption where
                  (Prelude.showChar '}' __s))
 instance a ~ ([UninterpretedOption'NamePart]) =>
          Lens.Labels.HasLens' UninterpretedOption "name" a
+         where
+        lensOf' _
+          = (Lens.Family2.Unchecked.lens _UninterpretedOption'name
+               (\ x__ y__ -> x__{_UninterpretedOption'name = y__}))
+              Prelude..
+              Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
+                (\ _ y__ -> Data.Vector.Generic.fromList y__)
+instance a ~ (Data.Vector.Vector UninterpretedOption'NamePart) =>
+         Lens.Labels.HasLens' UninterpretedOption "vector'name" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _UninterpretedOption'name
@@ -9059,7 +9951,8 @@ instance Data.ProtoLens.Message UninterpretedOption where
           = Lens.Family2.Unchecked.lens _UninterpretedOption'_unknownFields
               (\ x__ y__ -> x__{_UninterpretedOption'_unknownFields = y__})
         defMessage
-          = UninterpretedOption{_UninterpretedOption'name = [],
+          = UninterpretedOption{_UninterpretedOption'name =
+                                  Data.Vector.Generic.empty,
                                 _UninterpretedOption'identifierValue = Prelude.Nothing,
                                 _UninterpretedOption'positiveIntValue = Prelude.Nothing,
                                 _UninterpretedOption'negativeIntValue = Prelude.Nothing,
@@ -9070,11 +9963,17 @@ instance Data.ProtoLens.Message UninterpretedOption where
         parseMessage
           = let loop ::
                      UninterpretedOption ->
-                       Data.ProtoLens.Encoding.Bytes.Parser UninterpretedOption
-                loop x
+                       Data.ProtoLens.Encoding.Growing.Growing Data.Vector.Vector
+                         Data.ProtoLens.Encoding.Growing.RealWorld
+                         UninterpretedOption'NamePart
+                         -> Data.ProtoLens.Encoding.Bytes.Parser UninterpretedOption
+                loop x mutable'name
                   = do end <- Data.ProtoLens.Encoding.Bytes.atEnd
                        if end then
-                         do let missing = [] in
+                         do frozen'name <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                             (Data.ProtoLens.Encoding.Growing.unsafeFreeze
+                                                mutable'name)
+                            let missing = [] in
                               if Prelude.null missing then Prelude.return () else
                                 Prelude.fail
                                   (("Missing required fields: ") Prelude.++
@@ -9082,27 +9981,23 @@ instance Data.ProtoLens.Message UninterpretedOption where
                             Prelude.return
                               (Lens.Family2.over Data.ProtoLens.unknownFields
                                  (\ !t -> Prelude.reverse t)
-                                 (Lens.Family2.over
+                                 (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "name"))
-                                    (\ !t -> Prelude.reverse t)
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'name"))
+                                    frozen'name
                                     x))
                          else
                          do tag <- Data.ProtoLens.Encoding.Bytes.getVarInt
                             case tag of
-                                18 -> do !y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
-                                                               Data.ProtoLens.Encoding.Bytes.getBytes
-                                                                 (Prelude.fromIntegral len)
-                                                   Data.ProtoLens.Encoding.Bytes.runEither
-                                                     (Data.ProtoLens.decodeMessage value))
+                                18 -> do !y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                                   Data.ProtoLens.Encoding.Bytes.isolate
+                                                     (Prelude.fromIntegral len)
+                                                     Data.ProtoLens.parseMessage)
                                                  Data.ProtoLens.Encoding.Bytes.<?> "name"
-                                         loop
-                                           (Lens.Family2.over
-                                              (Lens.Labels.lensOf'
-                                                 ((Lens.Labels.proxy#) ::
-                                                    (Lens.Labels.Proxy#) "name"))
-                                              (\ !t -> (:) y t)
-                                              x)
+                                         v <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                                (Data.ProtoLens.Encoding.Growing.append mutable'name
+                                                   y)
+                                         loop x v
                                 26 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                               Data.ProtoLens.Encoding.Bytes.getBytes
                                                                 (Prelude.fromIntegral len)
@@ -9119,6 +10014,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                                                     (Lens.Labels.Proxy#) "identifierValue"))
                                               y
                                               x)
+                                           mutable'name
                                 32 -> do y <- (Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?>
                                                 "positive_int_value"
@@ -9129,6 +10025,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                                                     (Lens.Labels.Proxy#) "positiveIntValue"))
                                               y
                                               x)
+                                           mutable'name
                                 40 -> do y <- (Prelude.fmap Prelude.fromIntegral
                                                  Data.ProtoLens.Encoding.Bytes.getVarInt)
                                                 Data.ProtoLens.Encoding.Bytes.<?>
@@ -9140,6 +10037,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                                                     (Lens.Labels.Proxy#) "negativeIntValue"))
                                               y
                                               x)
+                                           mutable'name
                                 49 -> do y <- (Prelude.fmap
                                                  Data.ProtoLens.Encoding.Bytes.wordToDouble
                                                  Data.ProtoLens.Encoding.Bytes.getFixed64)
@@ -9151,6 +10049,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                                                     (Lens.Labels.Proxy#) "doubleValue"))
                                               y
                                               x)
+                                           mutable'name
                                 58 -> do y <- (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                   Data.ProtoLens.Encoding.Bytes.getBytes
                                                     (Prelude.fromIntegral len))
@@ -9162,6 +10061,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                                                     (Lens.Labels.Proxy#) "stringValue"))
                                               y
                                               x)
+                                           mutable'name
                                 66 -> do y <- (do value <- do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
                                                               Data.ProtoLens.Encoding.Bytes.getBytes
                                                                 (Prelude.fromIntegral len)
@@ -9178,31 +10078,36 @@ instance Data.ProtoLens.Message UninterpretedOption where
                                                     (Lens.Labels.Proxy#) "aggregateValue"))
                                               y
                                               x)
+                                           mutable'name
                                 wire -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                                    wire
                                            loop
                                              (Lens.Family2.over Data.ProtoLens.unknownFields
                                                 (\ !t -> (:) y t)
                                                 x)
+                                             mutable'name
               in
-              (loop Data.ProtoLens.defMessage) Data.ProtoLens.Encoding.Bytes.<?>
-                "UninterpretedOption"
+              (do mutable'name <- Data.ProtoLens.Encoding.Parser.Unsafe.unsafeLiftIO
+                                    Data.ProtoLens.Encoding.Growing.new
+                  loop Data.ProtoLens.defMessage mutable'name)
+                Data.ProtoLens.Encoding.Bytes.<?> "UninterpretedOption"
         buildMessage
           = (\ _x ->
-               (Data.Monoid.mconcat
-                  (Prelude.map
-                     (\ _v ->
-                        (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                     (Lens.Family2.view
-                        (Lens.Labels.lensOf'
-                           ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "name"))
-                        _x)))
+               (Data.Vector.Generic.foldr
+                  (\ _v as ->
+                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                        (((\ bs ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                (Prelude.fromIntegral (Data.ByteString.length bs)))
+                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                           Prelude.. Data.ProtoLens.encodeMessage)
+                          _v)
+                       Data.Monoid.<> as)
+                  Data.Monoid.mempty
+                  (Lens.Family2.view
+                     (Lens.Labels.lensOf'
+                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'name"))
+                     _x))
                  Data.Monoid.<>
                  (case
                     Lens.Family2.view
@@ -9451,7 +10356,7 @@ instance Data.ProtoLens.Message UninterpretedOption'NamePart where
                                              required'isExtension
                                              required'namePart
               in
-              (loop Data.ProtoLens.defMessage Prelude.True Prelude.True)
+              (do loop Data.ProtoLens.defMessage Prelude.True Prelude.True)
                 Data.ProtoLens.Encoding.Bytes.<?> "NamePart"
         buildMessage
           = (\ _x ->

--- a/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs
@@ -57,25 +57,25 @@ import qualified Text.Read
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' DescriptorProto Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'name' @:: Lens' DescriptorProto (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.field' @:: Lens' DescriptorProto [FieldDescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'field' @:: Lens' DescriptorProto (Data.Vector.Vector FieldDescriptorProto)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'field' @:: Lens' DescriptorProto (Data.Vector.Vector FieldDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.extension' @:: Lens' DescriptorProto [FieldDescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'extension' @:: Lens' DescriptorProto (Data.Vector.Vector FieldDescriptorProto)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'extension' @:: Lens' DescriptorProto (Data.Vector.Vector FieldDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.nestedType' @:: Lens' DescriptorProto [DescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'nestedType' @:: Lens' DescriptorProto (Data.Vector.Vector DescriptorProto)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'nestedType' @:: Lens' DescriptorProto (Data.Vector.Vector DescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.enumType' @:: Lens' DescriptorProto [EnumDescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'enumType' @:: Lens' DescriptorProto (Data.Vector.Vector EnumDescriptorProto)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'enumType' @:: Lens' DescriptorProto (Data.Vector.Vector EnumDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.extensionRange' @:: Lens' DescriptorProto [DescriptorProto'ExtensionRange]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'extensionRange' @:: Lens' DescriptorProto
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'extensionRange' @:: Lens' DescriptorProto
   (Data.Vector.Vector DescriptorProto'ExtensionRange)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.oneofDecl' @:: Lens' DescriptorProto [OneofDescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'oneofDecl' @:: Lens' DescriptorProto (Data.Vector.Vector OneofDescriptorProto)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'oneofDecl' @:: Lens' DescriptorProto (Data.Vector.Vector OneofDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.options' @:: Lens' DescriptorProto MessageOptions@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'options' @:: Lens' DescriptorProto (Prelude.Maybe MessageOptions)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.reservedRange' @:: Lens' DescriptorProto [DescriptorProto'ReservedRange]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'reservedRange' @:: Lens' DescriptorProto
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'reservedRange' @:: Lens' DescriptorProto
   (Data.Vector.Vector DescriptorProto'ReservedRange)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.reservedName' @:: Lens' DescriptorProto [Data.Text.Text]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'reservedName' @:: Lens' DescriptorProto (Data.Vector.Vector Data.Text.Text)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'reservedName' @:: Lens' DescriptorProto (Data.Vector.Vector Data.Text.Text)@
  -}
 data DescriptorProto = DescriptorProto{_DescriptorProto'name ::
                                        !(Prelude.Maybe Data.Text.Text),
@@ -127,7 +127,7 @@ instance a ~ ([FieldDescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector FieldDescriptorProto) =>
-         Lens.Labels.HasLens' DescriptorProto "vector'field" a
+         Lens.Labels.HasLens' DescriptorProto "vec'field" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'field
@@ -143,7 +143,7 @@ instance a ~ ([FieldDescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector FieldDescriptorProto) =>
-         Lens.Labels.HasLens' DescriptorProto "vector'extension" a
+         Lens.Labels.HasLens' DescriptorProto "vec'extension" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'extension
@@ -159,7 +159,7 @@ instance a ~ ([DescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector DescriptorProto) =>
-         Lens.Labels.HasLens' DescriptorProto "vector'nestedType" a
+         Lens.Labels.HasLens' DescriptorProto "vec'nestedType" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'nestedType
@@ -175,7 +175,7 @@ instance a ~ ([EnumDescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector EnumDescriptorProto) =>
-         Lens.Labels.HasLens' DescriptorProto "vector'enumType" a
+         Lens.Labels.HasLens' DescriptorProto "vec'enumType" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'enumType
@@ -191,7 +191,7 @@ instance a ~ ([DescriptorProto'ExtensionRange]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector DescriptorProto'ExtensionRange) =>
-         Lens.Labels.HasLens' DescriptorProto "vector'extensionRange" a
+         Lens.Labels.HasLens' DescriptorProto "vec'extensionRange" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'extensionRange
@@ -207,7 +207,7 @@ instance a ~ ([OneofDescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector OneofDescriptorProto) =>
-         Lens.Labels.HasLens' DescriptorProto "vector'oneofDecl" a
+         Lens.Labels.HasLens' DescriptorProto "vec'oneofDecl" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'oneofDecl
@@ -237,7 +237,7 @@ instance a ~ ([DescriptorProto'ReservedRange]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector DescriptorProto'ReservedRange) =>
-         Lens.Labels.HasLens' DescriptorProto "vector'reservedRange" a
+         Lens.Labels.HasLens' DescriptorProto "vec'reservedRange" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'reservedRange
@@ -253,7 +253,7 @@ instance a ~ ([Data.Text.Text]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector Data.Text.Text) =>
-         Lens.Labels.HasLens' DescriptorProto "vector'reservedName" a
+         Lens.Labels.HasLens' DescriptorProto "vec'reservedName" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _DescriptorProto'reservedName
@@ -444,44 +444,44 @@ instance Data.ProtoLens.Message DescriptorProto where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'enumType"))
+                                          (Lens.Labels.Proxy#) "vec'enumType"))
                                     frozen'enumType
                                     (Lens.Family2.set
                                        (Lens.Labels.lensOf'
                                           ((Lens.Labels.proxy#) ::
-                                             (Lens.Labels.Proxy#) "vector'extension"))
+                                             (Lens.Labels.Proxy#) "vec'extension"))
                                        frozen'extension
                                        (Lens.Family2.set
                                           (Lens.Labels.lensOf'
                                              ((Lens.Labels.proxy#) ::
-                                                (Lens.Labels.Proxy#) "vector'extensionRange"))
+                                                (Lens.Labels.Proxy#) "vec'extensionRange"))
                                           frozen'extensionRange
                                           (Lens.Family2.set
                                              (Lens.Labels.lensOf'
                                                 ((Lens.Labels.proxy#) ::
-                                                   (Lens.Labels.Proxy#) "vector'field"))
+                                                   (Lens.Labels.Proxy#) "vec'field"))
                                              frozen'field
                                              (Lens.Family2.set
                                                 (Lens.Labels.lensOf'
                                                    ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#) "vector'nestedType"))
+                                                      (Lens.Labels.Proxy#) "vec'nestedType"))
                                                 frozen'nestedType
                                                 (Lens.Family2.set
                                                    (Lens.Labels.lensOf'
                                                       ((Lens.Labels.proxy#) ::
-                                                         (Lens.Labels.Proxy#) "vector'oneofDecl"))
+                                                         (Lens.Labels.Proxy#) "vec'oneofDecl"))
                                                    frozen'oneofDecl
                                                    (Lens.Family2.set
                                                       (Lens.Labels.lensOf'
                                                          ((Lens.Labels.proxy#) ::
                                                             (Lens.Labels.Proxy#)
-                                                              "vector'reservedName"))
+                                                              "vec'reservedName"))
                                                       frozen'reservedName
                                                       (Lens.Family2.set
                                                          (Lens.Labels.lensOf'
                                                             ((Lens.Labels.proxy#) ::
                                                                (Lens.Labels.Proxy#)
-                                                                 "vector'reservedRange"))
+                                                                 "vec'reservedRange"))
                                                          frozen'reservedRange
                                                          x)))))))))
                          else
@@ -717,103 +717,89 @@ instance Data.ProtoLens.Message DescriptorProto where
                                             Prelude.. Data.Text.Encoding.encodeUtf8)
                                            _v)
                  Data.Monoid.<>
-                 (Data.Vector.Generic.foldr
-                    (\ _v as ->
-                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                         Data.Monoid.<> as)
-                    Data.Monoid.mempty
+                 (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                    (\ _v ->
+                       (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                         (((\ bs ->
+                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                            Prelude.. Data.ProtoLens.encodeMessage)
+                           _v)
                     (Lens.Family2.view
                        (Lens.Labels.lensOf'
-                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'field"))
+                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'field"))
                        _x))
                    Data.Monoid.<>
-                   (Data.Vector.Generic.foldr
-                      (\ _v as ->
-                         ((Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
-                            (((\ bs ->
-                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                               Prelude.. Data.ProtoLens.encodeMessage)
-                              _v)
-                           Data.Monoid.<> as)
-                      Data.Monoid.mempty
+                   (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                      (\ _v ->
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
+                           (((\ bs ->
+                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                   (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                  Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                              Prelude.. Data.ProtoLens.encodeMessage)
+                             _v)
                       (Lens.Family2.view
                          (Lens.Labels.lensOf'
-                            ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'extension"))
+                            ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'extension"))
                          _x))
                      Data.Monoid.<>
-                     (Data.Vector.Generic.foldr
-                        (\ _v as ->
-                           ((Data.ProtoLens.Encoding.Bytes.putVarInt 26) Data.Monoid.<>
-                              (((\ bs ->
-                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                 Prelude.. Data.ProtoLens.encodeMessage)
-                                _v)
-                             Data.Monoid.<> as)
-                        Data.Monoid.mempty
+                     (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                        (\ _v ->
+                           (Data.ProtoLens.Encoding.Bytes.putVarInt 26) Data.Monoid.<>
+                             (((\ bs ->
+                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                     (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                    Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                Prelude.. Data.ProtoLens.encodeMessage)
+                               _v)
                         (Lens.Family2.view
                            (Lens.Labels.lensOf'
-                              ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'nestedType"))
+                              ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'nestedType"))
                            _x))
                        Data.Monoid.<>
-                       (Data.Vector.Generic.foldr
-                          (\ _v as ->
-                             ((Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
-                                (((\ bs ->
-                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                       Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                   Prelude.. Data.ProtoLens.encodeMessage)
-                                  _v)
-                               Data.Monoid.<> as)
-                          Data.Monoid.mempty
+                       (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                          (\ _v ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
+                               (((\ bs ->
+                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                       (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                      Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                  Prelude.. Data.ProtoLens.encodeMessage)
+                                 _v)
                           (Lens.Family2.view
                              (Lens.Labels.lensOf'
-                                ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'enumType"))
+                                ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'enumType"))
                              _x))
                          Data.Monoid.<>
-                         (Data.Vector.Generic.foldr
-                            (\ _v as ->
-                               ((Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
-                                  (((\ bs ->
-                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                          (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                         Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                     Prelude.. Data.ProtoLens.encodeMessage)
-                                    _v)
-                                 Data.Monoid.<> as)
-                            Data.Monoid.mempty
+                         (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                            (\ _v ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
+                                 (((\ bs ->
+                                      (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                         (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                        Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                    Prelude.. Data.ProtoLens.encodeMessage)
+                                   _v)
                             (Lens.Family2.view
                                (Lens.Labels.lensOf'
                                   ((Lens.Labels.proxy#) ::
-                                     (Lens.Labels.Proxy#) "vector'extensionRange"))
+                                     (Lens.Labels.Proxy#) "vec'extensionRange"))
                                _x))
                            Data.Monoid.<>
-                           (Data.Vector.Generic.foldr
-                              (\ _v as ->
-                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt 66) Data.Monoid.<>
-                                    (((\ bs ->
-                                         (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                            (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                           Data.Monoid.<>
-                                           Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                       Prelude.. Data.ProtoLens.encodeMessage)
-                                      _v)
-                                   Data.Monoid.<> as)
-                              Data.Monoid.mempty
+                           (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                              (\ _v ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt 66) Data.Monoid.<>
+                                   (((\ bs ->
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                          Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                      Prelude.. Data.ProtoLens.encodeMessage)
+                                     _v)
                               (Lens.Family2.view
                                  (Lens.Labels.lensOf'
-                                    ((Lens.Labels.proxy#) ::
-                                       (Lens.Labels.Proxy#) "vector'oneofDecl"))
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'oneofDecl"))
                                  _x))
                              Data.Monoid.<>
                              (case
@@ -835,41 +821,36 @@ instance Data.ProtoLens.Message DescriptorProto where
                                                           Prelude.. Data.ProtoLens.encodeMessage)
                                                          _v)
                                Data.Monoid.<>
-                               (Data.Vector.Generic.foldr
-                                  (\ _v as ->
-                                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 74) Data.Monoid.<>
-                                        (((\ bs ->
-                                             (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                                (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                               Data.Monoid.<>
-                                               Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                           Prelude.. Data.ProtoLens.encodeMessage)
-                                          _v)
-                                       Data.Monoid.<> as)
-                                  Data.Monoid.mempty
+                               (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                                  (\ _v ->
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt 74) Data.Monoid.<>
+                                       (((\ bs ->
+                                            (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                               (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                              Data.Monoid.<>
+                                              Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                          Prelude.. Data.ProtoLens.encodeMessage)
+                                         _v)
                                   (Lens.Family2.view
                                      (Lens.Labels.lensOf'
                                         ((Lens.Labels.proxy#) ::
-                                           (Lens.Labels.Proxy#) "vector'reservedRange"))
+                                           (Lens.Labels.Proxy#) "vec'reservedRange"))
                                      _x))
                                  Data.Monoid.<>
-                                 (Data.Vector.Generic.foldr
-                                    (\ _v as ->
-                                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 82) Data.Monoid.<>
-                                          (((\ bs ->
-                                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                                  (Prelude.fromIntegral
-                                                     (Data.ByteString.length bs)))
-                                                 Data.Monoid.<>
-                                                 Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                             Prelude.. Data.Text.Encoding.encodeUtf8)
-                                            _v)
-                                         Data.Monoid.<> as)
-                                    Data.Monoid.mempty
+                                 (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                                    (\ _v ->
+                                       (Data.ProtoLens.Encoding.Bytes.putVarInt 82) Data.Monoid.<>
+                                         (((\ bs ->
+                                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                                Data.Monoid.<>
+                                                Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                            Prelude.. Data.Text.Encoding.encodeUtf8)
+                                           _v)
                                     (Lens.Family2.view
                                        (Lens.Labels.lensOf'
                                           ((Lens.Labels.proxy#) ::
-                                             (Lens.Labels.Proxy#) "vector'reservedName"))
+                                             (Lens.Labels.Proxy#) "vec'reservedName"))
                                        _x))
                                    Data.Monoid.<>
                                    Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -1308,15 +1289,15 @@ instance Control.DeepSeq.NFData DescriptorProto'ReservedRange where
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' EnumDescriptorProto Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'name' @:: Lens' EnumDescriptorProto (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.value' @:: Lens' EnumDescriptorProto [EnumValueDescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'value' @:: Lens' EnumDescriptorProto
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'value' @:: Lens' EnumDescriptorProto
   (Data.Vector.Vector EnumValueDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.options' @:: Lens' EnumDescriptorProto EnumOptions@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'options' @:: Lens' EnumDescriptorProto (Prelude.Maybe EnumOptions)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.reservedRange' @:: Lens' EnumDescriptorProto [EnumDescriptorProto'EnumReservedRange]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'reservedRange' @:: Lens' EnumDescriptorProto
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'reservedRange' @:: Lens' EnumDescriptorProto
   (Data.Vector.Vector EnumDescriptorProto'EnumReservedRange)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.reservedName' @:: Lens' EnumDescriptorProto [Data.Text.Text]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'reservedName' @:: Lens' EnumDescriptorProto (Data.Vector.Vector Data.Text.Text)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'reservedName' @:: Lens' EnumDescriptorProto (Data.Vector.Vector Data.Text.Text)@
  -}
 data EnumDescriptorProto = EnumDescriptorProto{_EnumDescriptorProto'name
                                                :: !(Prelude.Maybe Data.Text.Text),
@@ -1361,7 +1342,7 @@ instance a ~ ([EnumValueDescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector EnumValueDescriptorProto) =>
-         Lens.Labels.HasLens' EnumDescriptorProto "vector'value" a
+         Lens.Labels.HasLens' EnumDescriptorProto "vec'value" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'value
@@ -1392,7 +1373,7 @@ instance a ~ ([EnumDescriptorProto'EnumReservedRange]) =>
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~
            (Data.Vector.Vector EnumDescriptorProto'EnumReservedRange) =>
-         Lens.Labels.HasLens' EnumDescriptorProto "vector'reservedRange" a
+         Lens.Labels.HasLens' EnumDescriptorProto "vec'reservedRange" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'reservedRange
@@ -1408,7 +1389,7 @@ instance a ~ ([Data.Text.Text]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector Data.Text.Text) =>
-         Lens.Labels.HasLens' EnumDescriptorProto "vector'reservedName" a
+         Lens.Labels.HasLens' EnumDescriptorProto "vec'reservedName" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _EnumDescriptorProto'reservedName
@@ -1514,17 +1495,17 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'reservedName"))
+                                          (Lens.Labels.Proxy#) "vec'reservedName"))
                                     frozen'reservedName
                                     (Lens.Family2.set
                                        (Lens.Labels.lensOf'
                                           ((Lens.Labels.proxy#) ::
-                                             (Lens.Labels.Proxy#) "vector'reservedRange"))
+                                             (Lens.Labels.Proxy#) "vec'reservedRange"))
                                        frozen'reservedRange
                                        (Lens.Family2.set
                                           (Lens.Labels.lensOf'
                                              ((Lens.Labels.proxy#) ::
-                                                (Lens.Labels.Proxy#) "vector'value"))
+                                                (Lens.Labels.Proxy#) "vec'value"))
                                           frozen'value
                                           x))))
                          else
@@ -1637,20 +1618,18 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                                             Prelude.. Data.Text.Encoding.encodeUtf8)
                                            _v)
                  Data.Monoid.<>
-                 (Data.Vector.Generic.foldr
-                    (\ _v as ->
-                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                         Data.Monoid.<> as)
-                    Data.Monoid.mempty
+                 (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                    (\ _v ->
+                       (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                         (((\ bs ->
+                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                            Prelude.. Data.ProtoLens.encodeMessage)
+                           _v)
                     (Lens.Family2.view
                        (Lens.Labels.lensOf'
-                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'value"))
+                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'value"))
                        _x))
                    Data.Monoid.<>
                    (case
@@ -1671,38 +1650,32 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
                                                 Prelude.. Data.ProtoLens.encodeMessage)
                                                _v)
                      Data.Monoid.<>
-                     (Data.Vector.Generic.foldr
-                        (\ _v as ->
-                           ((Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
-                              (((\ bs ->
-                                   (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                      (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                     Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                 Prelude.. Data.ProtoLens.encodeMessage)
-                                _v)
-                             Data.Monoid.<> as)
-                        Data.Monoid.mempty
+                     (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                        (\ _v ->
+                           (Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
+                             (((\ bs ->
+                                  (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                     (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                    Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                Prelude.. Data.ProtoLens.encodeMessage)
+                               _v)
                         (Lens.Family2.view
                            (Lens.Labels.lensOf'
-                              ((Lens.Labels.proxy#) ::
-                                 (Lens.Labels.Proxy#) "vector'reservedRange"))
+                              ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'reservedRange"))
                            _x))
                        Data.Monoid.<>
-                       (Data.Vector.Generic.foldr
-                          (\ _v as ->
-                             ((Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
-                                (((\ bs ->
-                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                       Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                   Prelude.. Data.Text.Encoding.encodeUtf8)
-                                  _v)
-                               Data.Monoid.<> as)
-                          Data.Monoid.mempty
+                       (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                          (\ _v ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
+                               (((\ bs ->
+                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                       (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                      Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                  Prelude.. Data.Text.Encoding.encodeUtf8)
+                                 _v)
                           (Lens.Family2.view
                              (Lens.Labels.lensOf'
-                                ((Lens.Labels.proxy#) ::
-                                   (Lens.Labels.Proxy#) "vector'reservedName"))
+                                ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'reservedName"))
                              _x))
                          Data.Monoid.<>
                          Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -1925,7 +1898,7 @@ instance Control.DeepSeq.NFData
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' EnumOptions Prelude.Bool@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'deprecated' @:: Lens' EnumOptions (Prelude.Maybe Prelude.Bool)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' EnumOptions [UninterpretedOption]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' EnumOptions (Data.Vector.Vector UninterpretedOption)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'uninterpretedOption' @:: Lens' EnumOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data EnumOptions = EnumOptions{_EnumOptions'allowAlias ::
                                !(Prelude.Maybe Prelude.Bool),
@@ -1977,7 +1950,7 @@ instance a ~ ([UninterpretedOption]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector UninterpretedOption) =>
-         Lens.Labels.HasLens' EnumOptions "vector'uninterpretedOption" a
+         Lens.Labels.HasLens' EnumOptions "vec'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _EnumOptions'uninterpretedOption
@@ -2048,7 +2021,7 @@ instance Data.ProtoLens.Message EnumOptions where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                          (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                                     frozen'uninterpretedOption
                                     x))
                          else
@@ -2127,21 +2100,19 @@ instance Data.ProtoLens.Message EnumOptions where
                                               (\ b -> if b then 1 else 0))
                                              _v)
                    Data.Monoid.<>
-                   (Data.Vector.Generic.foldr
-                      (\ _v as ->
-                         ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                            (((\ bs ->
-                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                               Prelude.. Data.ProtoLens.encodeMessage)
-                              _v)
-                           Data.Monoid.<> as)
-                      Data.Monoid.mempty
+                   (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                      (\ _v ->
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                           (((\ bs ->
+                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                   (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                  Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                              Prelude.. Data.ProtoLens.encodeMessage)
+                             _v)
                       (Lens.Family2.view
                          (Lens.Labels.lensOf'
                             ((Lens.Labels.proxy#) ::
-                               (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                               (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                          _x))
                      Data.Monoid.<>
                      Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -2394,7 +2365,7 @@ instance Control.DeepSeq.NFData EnumValueDescriptorProto where
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' EnumValueOptions Prelude.Bool@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'deprecated' @:: Lens' EnumValueOptions (Prelude.Maybe Prelude.Bool)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' EnumValueOptions [UninterpretedOption]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' EnumValueOptions (Data.Vector.Vector UninterpretedOption)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'uninterpretedOption' @:: Lens' EnumValueOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data EnumValueOptions = EnumValueOptions{_EnumValueOptions'deprecated
                                          :: !(Prelude.Maybe Prelude.Bool),
@@ -2433,8 +2404,7 @@ instance a ~ ([UninterpretedOption]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector UninterpretedOption) =>
-         Lens.Labels.HasLens' EnumValueOptions "vector'uninterpretedOption"
-           a
+         Lens.Labels.HasLens' EnumValueOptions "vec'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens
@@ -2496,7 +2466,7 @@ instance Data.ProtoLens.Message EnumValueOptions where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                          (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                                     frozen'uninterpretedOption
                                     x))
                          else
@@ -2551,21 +2521,19 @@ instance Data.ProtoLens.Message EnumValueOptions where
                                             (\ b -> if b then 1 else 0))
                                            _v)
                  Data.Monoid.<>
-                 (Data.Vector.Generic.foldr
-                    (\ _v as ->
-                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                         Data.Monoid.<> as)
-                    Data.Monoid.mempty
+                 (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                    (\ _v ->
+                       (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                         (((\ bs ->
+                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                            Prelude.. Data.ProtoLens.encodeMessage)
+                           _v)
                     (Lens.Family2.view
                        (Lens.Labels.lensOf'
                           ((Lens.Labels.proxy#) ::
-                             (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                             (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                        _x))
                    Data.Monoid.<>
                    Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -2581,7 +2549,7 @@ instance Control.DeepSeq.NFData EnumValueOptions where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' ExtensionRangeOptions [UninterpretedOption]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' ExtensionRangeOptions
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'uninterpretedOption' @:: Lens' ExtensionRangeOptions
   (Data.Vector.Vector UninterpretedOption)@
  -}
 data ExtensionRangeOptions = ExtensionRangeOptions{_ExtensionRangeOptions'uninterpretedOption
@@ -2607,7 +2575,7 @@ instance a ~ ([UninterpretedOption]) =>
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector UninterpretedOption) =>
          Lens.Labels.HasLens' ExtensionRangeOptions
-           "vector'uninterpretedOption"
+           "vec'uninterpretedOption"
            a
          where
         lensOf' _
@@ -2663,7 +2631,7 @@ instance Data.ProtoLens.Message ExtensionRangeOptions where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                          (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                                     frozen'uninterpretedOption
                                     x))
                          else
@@ -2694,21 +2662,19 @@ instance Data.ProtoLens.Message ExtensionRangeOptions where
                 Data.ProtoLens.Encoding.Bytes.<?> "ExtensionRangeOptions"
         buildMessage
           = (\ _x ->
-               (Data.Vector.Generic.foldr
-                  (\ _v as ->
-                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                        (((\ bs ->
-                             (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                (Prelude.fromIntegral (Data.ByteString.length bs)))
-                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                           Prelude.. Data.ProtoLens.encodeMessage)
-                          _v)
-                       Data.Monoid.<> as)
-                  Data.Monoid.mempty
+               (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                  (\ _v ->
+                     (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                       (((\ bs ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt
+                               (Prelude.fromIntegral (Data.ByteString.length bs)))
+                              Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                          Prelude.. Data.ProtoLens.encodeMessage)
+                         _v)
                   (Lens.Family2.view
                      (Lens.Labels.lensOf'
                         ((Lens.Labels.proxy#) ::
-                           (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                           (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                      _x))
                  Data.Monoid.<>
                  Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -3663,7 +3629,7 @@ instance Control.DeepSeq.NFData FieldDescriptorProto'Type where
     * 'Proto.Google.Protobuf.Descriptor_Fields.weak' @:: Lens' FieldOptions Prelude.Bool@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'weak' @:: Lens' FieldOptions (Prelude.Maybe Prelude.Bool)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' FieldOptions [UninterpretedOption]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' FieldOptions (Data.Vector.Vector UninterpretedOption)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'uninterpretedOption' @:: Lens' FieldOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data FieldOptions = FieldOptions{_FieldOptions'ctype ::
                                  !(Prelude.Maybe FieldOptions'CType),
@@ -3775,7 +3741,7 @@ instance a ~ ([UninterpretedOption]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector UninterpretedOption) =>
-         Lens.Labels.HasLens' FieldOptions "vector'uninterpretedOption" a
+         Lens.Labels.HasLens' FieldOptions "vec'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FieldOptions'uninterpretedOption
@@ -3886,7 +3852,7 @@ instance Data.ProtoLens.Message FieldOptions where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                          (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                                     frozen'uninterpretedOption
                                     x))
                          else
@@ -4065,22 +4031,19 @@ instance Data.ProtoLens.Message FieldOptions where
                                                       Prelude.. (\ b -> if b then 1 else 0))
                                                      _v)
                            Data.Monoid.<>
-                           (Data.Vector.Generic.foldr
-                              (\ _v as ->
-                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                                    (((\ bs ->
-                                         (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                            (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                           Data.Monoid.<>
-                                           Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                       Prelude.. Data.ProtoLens.encodeMessage)
-                                      _v)
-                                   Data.Monoid.<> as)
-                              Data.Monoid.mempty
+                           (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                              (\ _v ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                                   (((\ bs ->
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                          Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                      Prelude.. Data.ProtoLens.encodeMessage)
+                                     _v)
                               (Lens.Family2.view
                                  (Lens.Labels.lensOf'
                                     ((Lens.Labels.proxy#) ::
-                                       (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                       (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                                  _x))
                              Data.Monoid.<>
                              Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -4205,22 +4168,22 @@ instance Control.DeepSeq.NFData FieldOptions'JSType where
     * 'Proto.Google.Protobuf.Descriptor_Fields.package' @:: Lens' FileDescriptorProto Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'package' @:: Lens' FileDescriptorProto (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.dependency' @:: Lens' FileDescriptorProto [Data.Text.Text]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'dependency' @:: Lens' FileDescriptorProto (Data.Vector.Vector Data.Text.Text)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'dependency' @:: Lens' FileDescriptorProto (Data.Vector.Vector Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.publicDependency' @:: Lens' FileDescriptorProto [Data.Int.Int32]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'publicDependency' @:: Lens' FileDescriptorProto
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'publicDependency' @:: Lens' FileDescriptorProto
   (Data.Vector.Unboxed.Vector Data.Int.Int32)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.weakDependency' @:: Lens' FileDescriptorProto [Data.Int.Int32]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'weakDependency' @:: Lens' FileDescriptorProto
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'weakDependency' @:: Lens' FileDescriptorProto
   (Data.Vector.Unboxed.Vector Data.Int.Int32)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.messageType' @:: Lens' FileDescriptorProto [DescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'messageType' @:: Lens' FileDescriptorProto (Data.Vector.Vector DescriptorProto)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'messageType' @:: Lens' FileDescriptorProto (Data.Vector.Vector DescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.enumType' @:: Lens' FileDescriptorProto [EnumDescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'enumType' @:: Lens' FileDescriptorProto (Data.Vector.Vector EnumDescriptorProto)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'enumType' @:: Lens' FileDescriptorProto (Data.Vector.Vector EnumDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.service' @:: Lens' FileDescriptorProto [ServiceDescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'service' @:: Lens' FileDescriptorProto
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'service' @:: Lens' FileDescriptorProto
   (Data.Vector.Vector ServiceDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.extension' @:: Lens' FileDescriptorProto [FieldDescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'extension' @:: Lens' FileDescriptorProto (Data.Vector.Vector FieldDescriptorProto)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'extension' @:: Lens' FileDescriptorProto (Data.Vector.Vector FieldDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.options' @:: Lens' FileDescriptorProto FileOptions@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'options' @:: Lens' FileDescriptorProto (Prelude.Maybe FileOptions)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.sourceCodeInfo' @:: Lens' FileDescriptorProto SourceCodeInfo@
@@ -4298,7 +4261,7 @@ instance a ~ ([Data.Text.Text]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector Data.Text.Text) =>
-         Lens.Labels.HasLens' FileDescriptorProto "vector'dependency" a
+         Lens.Labels.HasLens' FileDescriptorProto "vec'dependency" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'dependency
@@ -4315,8 +4278,7 @@ instance a ~ ([Data.Int.Int32]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Unboxed.Vector Data.Int.Int32) =>
-         Lens.Labels.HasLens' FileDescriptorProto "vector'publicDependency"
-           a
+         Lens.Labels.HasLens' FileDescriptorProto "vec'publicDependency" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens
@@ -4333,7 +4295,7 @@ instance a ~ ([Data.Int.Int32]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Unboxed.Vector Data.Int.Int32) =>
-         Lens.Labels.HasLens' FileDescriptorProto "vector'weakDependency" a
+         Lens.Labels.HasLens' FileDescriptorProto "vec'weakDependency" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'weakDependency
@@ -4349,7 +4311,7 @@ instance a ~ ([DescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector DescriptorProto) =>
-         Lens.Labels.HasLens' FileDescriptorProto "vector'messageType" a
+         Lens.Labels.HasLens' FileDescriptorProto "vec'messageType" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'messageType
@@ -4365,7 +4327,7 @@ instance a ~ ([EnumDescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector EnumDescriptorProto) =>
-         Lens.Labels.HasLens' FileDescriptorProto "vector'enumType" a
+         Lens.Labels.HasLens' FileDescriptorProto "vec'enumType" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'enumType
@@ -4381,7 +4343,7 @@ instance a ~ ([ServiceDescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector ServiceDescriptorProto) =>
-         Lens.Labels.HasLens' FileDescriptorProto "vector'service" a
+         Lens.Labels.HasLens' FileDescriptorProto "vec'service" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'service
@@ -4397,7 +4359,7 @@ instance a ~ ([FieldDescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector FieldDescriptorProto) =>
-         Lens.Labels.HasLens' FileDescriptorProto "vector'extension" a
+         Lens.Labels.HasLens' FileDescriptorProto "vec'extension" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorProto'extension
@@ -4646,39 +4608,38 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'dependency"))
+                                          (Lens.Labels.Proxy#) "vec'dependency"))
                                     frozen'dependency
                                     (Lens.Family2.set
                                        (Lens.Labels.lensOf'
                                           ((Lens.Labels.proxy#) ::
-                                             (Lens.Labels.Proxy#) "vector'enumType"))
+                                             (Lens.Labels.Proxy#) "vec'enumType"))
                                        frozen'enumType
                                        (Lens.Family2.set
                                           (Lens.Labels.lensOf'
                                              ((Lens.Labels.proxy#) ::
-                                                (Lens.Labels.Proxy#) "vector'extension"))
+                                                (Lens.Labels.Proxy#) "vec'extension"))
                                           frozen'extension
                                           (Lens.Family2.set
                                              (Lens.Labels.lensOf'
                                                 ((Lens.Labels.proxy#) ::
-                                                   (Lens.Labels.Proxy#) "vector'messageType"))
+                                                   (Lens.Labels.Proxy#) "vec'messageType"))
                                              frozen'messageType
                                              (Lens.Family2.set
                                                 (Lens.Labels.lensOf'
                                                    ((Lens.Labels.proxy#) ::
-                                                      (Lens.Labels.Proxy#)
-                                                        "vector'publicDependency"))
+                                                      (Lens.Labels.Proxy#) "vec'publicDependency"))
                                                 frozen'publicDependency
                                                 (Lens.Family2.set
                                                    (Lens.Labels.lensOf'
                                                       ((Lens.Labels.proxy#) ::
-                                                         (Lens.Labels.Proxy#) "vector'service"))
+                                                         (Lens.Labels.Proxy#) "vec'service"))
                                                    frozen'service
                                                    (Lens.Family2.set
                                                       (Lens.Labels.lensOf'
                                                          ((Lens.Labels.proxy#) ::
                                                             (Lens.Labels.Proxy#)
-                                                              "vector'weakDependency"))
+                                                              "vec'weakDependency"))
                                                       frozen'weakDependency
                                                       x))))))))
                          else
@@ -5016,119 +4977,101 @@ instance Data.ProtoLens.Message FileDescriptorProto where
                                               Prelude.. Data.Text.Encoding.encodeUtf8)
                                              _v)
                    Data.Monoid.<>
-                   (Data.Vector.Generic.foldr
-                      (\ _v as ->
-                         ((Data.ProtoLens.Encoding.Bytes.putVarInt 26) Data.Monoid.<>
-                            (((\ bs ->
-                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                               Prelude.. Data.Text.Encoding.encodeUtf8)
-                              _v)
-                           Data.Monoid.<> as)
-                      Data.Monoid.mempty
+                   (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                      (\ _v ->
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt 26) Data.Monoid.<>
+                           (((\ bs ->
+                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                   (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                  Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                              Prelude.. Data.Text.Encoding.encodeUtf8)
+                             _v)
                       (Lens.Family2.view
                          (Lens.Labels.lensOf'
-                            ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'dependency"))
+                            ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'dependency"))
                          _x))
                      Data.Monoid.<>
-                     (Data.Vector.Generic.foldr
-                        (\ _v as ->
-                           ((Data.ProtoLens.Encoding.Bytes.putVarInt 80) Data.Monoid.<>
-                              ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
-                                 Prelude.fromIntegral)
-                                _v)
-                             Data.Monoid.<> as)
-                        Data.Monoid.mempty
+                     (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                        (\ _v ->
+                           (Data.ProtoLens.Encoding.Bytes.putVarInt 80) Data.Monoid.<>
+                             ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                Prelude.fromIntegral)
+                               _v)
                         (Lens.Family2.view
                            (Lens.Labels.lensOf'
                               ((Lens.Labels.proxy#) ::
-                                 (Lens.Labels.Proxy#) "vector'publicDependency"))
+                                 (Lens.Labels.Proxy#) "vec'publicDependency"))
                            _x))
                        Data.Monoid.<>
-                       (Data.Vector.Generic.foldr
-                          (\ _v as ->
-                             ((Data.ProtoLens.Encoding.Bytes.putVarInt 88) Data.Monoid.<>
-                                ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
-                                   Prelude.fromIntegral)
-                                  _v)
-                               Data.Monoid.<> as)
-                          Data.Monoid.mempty
+                       (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                          (\ _v ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 88) Data.Monoid.<>
+                               ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                  Prelude.fromIntegral)
+                                 _v)
                           (Lens.Family2.view
                              (Lens.Labels.lensOf'
                                 ((Lens.Labels.proxy#) ::
-                                   (Lens.Labels.Proxy#) "vector'weakDependency"))
+                                   (Lens.Labels.Proxy#) "vec'weakDependency"))
                              _x))
                          Data.Monoid.<>
-                         (Data.Vector.Generic.foldr
-                            (\ _v as ->
-                               ((Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
-                                  (((\ bs ->
-                                       (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                          (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                         Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                     Prelude.. Data.ProtoLens.encodeMessage)
-                                    _v)
-                                 Data.Monoid.<> as)
-                            Data.Monoid.mempty
+                         (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                            (\ _v ->
+                               (Data.ProtoLens.Encoding.Bytes.putVarInt 34) Data.Monoid.<>
+                                 (((\ bs ->
+                                      (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                         (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                        Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                    Prelude.. Data.ProtoLens.encodeMessage)
+                                   _v)
                             (Lens.Family2.view
                                (Lens.Labels.lensOf'
-                                  ((Lens.Labels.proxy#) ::
-                                     (Lens.Labels.Proxy#) "vector'messageType"))
+                                  ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'messageType"))
                                _x))
                            Data.Monoid.<>
-                           (Data.Vector.Generic.foldr
-                              (\ _v as ->
-                                 ((Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
-                                    (((\ bs ->
-                                         (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                            (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                           Data.Monoid.<>
-                                           Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                       Prelude.. Data.ProtoLens.encodeMessage)
-                                      _v)
-                                   Data.Monoid.<> as)
-                              Data.Monoid.mempty
+                           (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                              (\ _v ->
+                                 (Data.ProtoLens.Encoding.Bytes.putVarInt 42) Data.Monoid.<>
+                                   (((\ bs ->
+                                        (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                           (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                          Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                      Prelude.. Data.ProtoLens.encodeMessage)
+                                     _v)
                               (Lens.Family2.view
                                  (Lens.Labels.lensOf'
-                                    ((Lens.Labels.proxy#) ::
-                                       (Lens.Labels.Proxy#) "vector'enumType"))
+                                    ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'enumType"))
                                  _x))
                              Data.Monoid.<>
-                             (Data.Vector.Generic.foldr
-                                (\ _v as ->
-                                   ((Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
-                                      (((\ bs ->
-                                           (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                              (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                             Data.Monoid.<>
-                                             Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                         Prelude.. Data.ProtoLens.encodeMessage)
-                                        _v)
-                                     Data.Monoid.<> as)
-                                Data.Monoid.mempty
+                             (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                                (\ _v ->
+                                   (Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
+                                     (((\ bs ->
+                                          (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                             (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                            Data.Monoid.<>
+                                            Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                        Prelude.. Data.ProtoLens.encodeMessage)
+                                       _v)
                                 (Lens.Family2.view
                                    (Lens.Labels.lensOf'
-                                      ((Lens.Labels.proxy#) ::
-                                         (Lens.Labels.Proxy#) "vector'service"))
+                                      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'service"))
                                    _x))
                                Data.Monoid.<>
-                               (Data.Vector.Generic.foldr
-                                  (\ _v as ->
-                                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 58) Data.Monoid.<>
-                                        (((\ bs ->
-                                             (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                                (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                               Data.Monoid.<>
-                                               Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                           Prelude.. Data.ProtoLens.encodeMessage)
-                                          _v)
-                                       Data.Monoid.<> as)
-                                  Data.Monoid.mempty
+                               (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                                  (\ _v ->
+                                     (Data.ProtoLens.Encoding.Bytes.putVarInt 58) Data.Monoid.<>
+                                       (((\ bs ->
+                                            (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                               (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                              Data.Monoid.<>
+                                              Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                          Prelude.. Data.ProtoLens.encodeMessage)
+                                         _v)
                                   (Lens.Family2.view
                                      (Lens.Labels.lensOf'
                                         ((Lens.Labels.proxy#) ::
-                                           (Lens.Labels.Proxy#) "vector'extension"))
+                                           (Lens.Labels.Proxy#) "vec'extension"))
                                      _x))
                                  Data.Monoid.<>
                                  (case
@@ -5224,7 +5167,7 @@ instance Control.DeepSeq.NFData FileDescriptorProto where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.file' @:: Lens' FileDescriptorSet [FileDescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'file' @:: Lens' FileDescriptorSet (Data.Vector.Vector FileDescriptorProto)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'file' @:: Lens' FileDescriptorSet (Data.Vector.Vector FileDescriptorProto)@
  -}
 data FileDescriptorSet = FileDescriptorSet{_FileDescriptorSet'file
                                            :: !(Data.Vector.Vector FileDescriptorProto),
@@ -5246,7 +5189,7 @@ instance a ~ ([FileDescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector FileDescriptorProto) =>
-         Lens.Labels.HasLens' FileDescriptorSet "vector'file" a
+         Lens.Labels.HasLens' FileDescriptorSet "vec'file" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileDescriptorSet'file
@@ -5295,7 +5238,7 @@ instance Data.ProtoLens.Message FileDescriptorSet where
                                  (\ !t -> Prelude.reverse t)
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file"))
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'file"))
                                     frozen'file
                                     x))
                          else
@@ -5324,20 +5267,18 @@ instance Data.ProtoLens.Message FileDescriptorSet where
                 Data.ProtoLens.Encoding.Bytes.<?> "FileDescriptorSet"
         buildMessage
           = (\ _x ->
-               (Data.Vector.Generic.foldr
-                  (\ _v as ->
-                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
-                        (((\ bs ->
-                             (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                (Prelude.fromIntegral (Data.ByteString.length bs)))
-                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                           Prelude.. Data.ProtoLens.encodeMessage)
-                          _v)
-                       Data.Monoid.<> as)
-                  Data.Monoid.mempty
+               (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                  (\ _v ->
+                     (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                       (((\ bs ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt
+                               (Prelude.fromIntegral (Data.ByteString.length bs)))
+                              Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                          Prelude.. Data.ProtoLens.encodeMessage)
+                         _v)
                   (Lens.Family2.view
                      (Lens.Labels.lensOf'
-                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file"))
+                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'file"))
                      _x))
                  Data.Monoid.<>
                  Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -5390,7 +5331,7 @@ instance Control.DeepSeq.NFData FileDescriptorSet where
     * 'Proto.Google.Protobuf.Descriptor_Fields.rubyPackage' @:: Lens' FileOptions Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'rubyPackage' @:: Lens' FileOptions (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' FileOptions [UninterpretedOption]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' FileOptions (Data.Vector.Vector UninterpretedOption)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'uninterpretedOption' @:: Lens' FileOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data FileOptions = FileOptions{_FileOptions'javaPackage ::
                                !(Prelude.Maybe Data.Text.Text),
@@ -5718,7 +5659,7 @@ instance a ~ ([UninterpretedOption]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector UninterpretedOption) =>
-         Lens.Labels.HasLens' FileOptions "vector'uninterpretedOption" a
+         Lens.Labels.HasLens' FileOptions "vec'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _FileOptions'uninterpretedOption
@@ -5988,7 +5929,7 @@ instance Data.ProtoLens.Message FileOptions where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                          (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                                     frozen'uninterpretedOption
                                     x))
                          else
@@ -6681,29 +6622,27 @@ instance Data.ProtoLens.Message FileOptions where
                                                                        Data.Text.Encoding.encodeUtf8)
                                                                       _v)
                                                        Data.Monoid.<>
-                                                       (Data.Vector.Generic.foldr
-                                                          (\ _v as ->
-                                                             ((Data.ProtoLens.Encoding.Bytes.putVarInt
-                                                                 7994)
-                                                                Data.Monoid.<>
-                                                                (((\ bs ->
-                                                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                                                        (Prelude.fromIntegral
-                                                                           (Data.ByteString.length
-                                                                              bs)))
-                                                                       Data.Monoid.<>
-                                                                       Data.ProtoLens.Encoding.Bytes.putBytes
-                                                                         bs))
-                                                                   Prelude..
-                                                                   Data.ProtoLens.encodeMessage)
-                                                                  _v)
-                                                               Data.Monoid.<> as)
-                                                          Data.Monoid.mempty
+                                                       (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                                                          (\ _v ->
+                                                             (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                7994)
+                                                               Data.Monoid.<>
+                                                               (((\ bs ->
+                                                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                                       (Prelude.fromIntegral
+                                                                          (Data.ByteString.length
+                                                                             bs)))
+                                                                      Data.Monoid.<>
+                                                                      Data.ProtoLens.Encoding.Bytes.putBytes
+                                                                        bs))
+                                                                  Prelude..
+                                                                  Data.ProtoLens.encodeMessage)
+                                                                 _v)
                                                           (Lens.Family2.view
                                                              (Lens.Labels.lensOf'
                                                                 ((Lens.Labels.proxy#) ::
                                                                    (Lens.Labels.Proxy#)
-                                                                     "vector'uninterpretedOption"))
+                                                                     "vec'uninterpretedOption"))
                                                              _x))
                                                          Data.Monoid.<>
                                                          Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -6809,7 +6748,7 @@ instance Control.DeepSeq.NFData FileOptions'OptimizeMode where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.annotation' @:: Lens' GeneratedCodeInfo [GeneratedCodeInfo'Annotation]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'annotation' @:: Lens' GeneratedCodeInfo
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'annotation' @:: Lens' GeneratedCodeInfo
   (Data.Vector.Vector GeneratedCodeInfo'Annotation)@
  -}
 data GeneratedCodeInfo = GeneratedCodeInfo{_GeneratedCodeInfo'annotation
@@ -6832,7 +6771,7 @@ instance a ~ ([GeneratedCodeInfo'Annotation]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector GeneratedCodeInfo'Annotation) =>
-         Lens.Labels.HasLens' GeneratedCodeInfo "vector'annotation" a
+         Lens.Labels.HasLens' GeneratedCodeInfo "vec'annotation" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'annotation
@@ -6883,7 +6822,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'annotation"))
+                                          (Lens.Labels.Proxy#) "vec'annotation"))
                                     frozen'annotation
                                     x))
                          else
@@ -6913,20 +6852,18 @@ instance Data.ProtoLens.Message GeneratedCodeInfo where
                 Data.ProtoLens.Encoding.Bytes.<?> "GeneratedCodeInfo"
         buildMessage
           = (\ _x ->
-               (Data.Vector.Generic.foldr
-                  (\ _v as ->
-                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
-                        (((\ bs ->
-                             (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                (Prelude.fromIntegral (Data.ByteString.length bs)))
-                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                           Prelude.. Data.ProtoLens.encodeMessage)
-                          _v)
-                       Data.Monoid.<> as)
-                  Data.Monoid.mempty
+               (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                  (\ _v ->
+                     (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                       (((\ bs ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt
+                               (Prelude.fromIntegral (Data.ByteString.length bs)))
+                              Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                          Prelude.. Data.ProtoLens.encodeMessage)
+                         _v)
                   (Lens.Family2.view
                      (Lens.Labels.lensOf'
-                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'annotation"))
+                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'annotation"))
                      _x))
                  Data.Monoid.<>
                  Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -6939,7 +6876,7 @@ instance Control.DeepSeq.NFData GeneratedCodeInfo where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.path' @:: Lens' GeneratedCodeInfo'Annotation [Data.Int.Int32]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'path' @:: Lens' GeneratedCodeInfo'Annotation
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'path' @:: Lens' GeneratedCodeInfo'Annotation
   (Data.Vector.Unboxed.Vector Data.Int.Int32)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.sourceFile' @:: Lens' GeneratedCodeInfo'Annotation Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'sourceFile' @:: Lens' GeneratedCodeInfo'Annotation (Prelude.Maybe Data.Text.Text)@
@@ -6976,7 +6913,7 @@ instance a ~ ([Data.Int.Int32]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Unboxed.Vector Data.Int.Int32) =>
-         Lens.Labels.HasLens' GeneratedCodeInfo'Annotation "vector'path" a
+         Lens.Labels.HasLens' GeneratedCodeInfo'Annotation "vec'path" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _GeneratedCodeInfo'Annotation'path
@@ -7106,7 +7043,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                                  (\ !t -> Prelude.reverse t)
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'path"))
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'path"))
                                     frozen'path
                                     x))
                          else
@@ -7194,7 +7131,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
           = (\ _x ->
                (let p = Lens.Family2.view
                           (Lens.Labels.lensOf'
-                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'path"))
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'path"))
                           _x
                   in
                   if Data.Vector.Generic.null p then Data.Monoid.mempty else
@@ -7204,13 +7141,9 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
                             (Prelude.fromIntegral (Data.ByteString.length bs)))
                            Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs)
                         (Data.ProtoLens.Encoding.Bytes.runBuilder
-                           (Data.Vector.Generic.foldr
-                              (\ v bs ->
-                                 (((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
-                                     Prelude.fromIntegral)
-                                    v)
-                                   Data.Monoid.<> bs)
-                              Data.Monoid.mempty
+                           (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                              ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                 Prelude.fromIntegral)
                               p)))
                  Data.Monoid.<>
                  (case
@@ -7281,7 +7214,7 @@ instance Control.DeepSeq.NFData GeneratedCodeInfo'Annotation where
     * 'Proto.Google.Protobuf.Descriptor_Fields.mapEntry' @:: Lens' MessageOptions Prelude.Bool@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'mapEntry' @:: Lens' MessageOptions (Prelude.Maybe Prelude.Bool)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' MessageOptions [UninterpretedOption]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' MessageOptions (Data.Vector.Vector UninterpretedOption)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'uninterpretedOption' @:: Lens' MessageOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data MessageOptions = MessageOptions{_MessageOptions'messageSetWireFormat
                                      :: !(Prelude.Maybe Prelude.Bool),
@@ -7371,7 +7304,7 @@ instance a ~ ([UninterpretedOption]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector UninterpretedOption) =>
-         Lens.Labels.HasLens' MessageOptions "vector'uninterpretedOption" a
+         Lens.Labels.HasLens' MessageOptions "vec'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _MessageOptions'uninterpretedOption
@@ -7466,7 +7399,7 @@ instance Data.ProtoLens.Message MessageOptions where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                          (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                                     frozen'uninterpretedOption
                                     x))
                          else
@@ -7598,21 +7531,19 @@ instance Data.ProtoLens.Message MessageOptions where
                                                   (\ b -> if b then 1 else 0))
                                                  _v)
                        Data.Monoid.<>
-                       (Data.Vector.Generic.foldr
-                          (\ _v as ->
-                             ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                                (((\ bs ->
-                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                       Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                   Prelude.. Data.ProtoLens.encodeMessage)
-                                  _v)
-                               Data.Monoid.<> as)
-                          Data.Monoid.mempty
+                       (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                          (\ _v ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                               (((\ bs ->
+                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                       (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                      Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                  Prelude.. Data.ProtoLens.encodeMessage)
+                                 _v)
                           (Lens.Family2.view
                              (Lens.Labels.lensOf'
                                 ((Lens.Labels.proxy#) ::
-                                   (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                   (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                              _x))
                          Data.Monoid.<>
                          Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -8058,7 +7989,7 @@ instance Control.DeepSeq.NFData MethodDescriptorProto where
     * 'Proto.Google.Protobuf.Descriptor_Fields.idempotencyLevel' @:: Lens' MethodOptions MethodOptions'IdempotencyLevel@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'idempotencyLevel' @:: Lens' MethodOptions (Prelude.Maybe MethodOptions'IdempotencyLevel)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' MethodOptions [UninterpretedOption]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' MethodOptions (Data.Vector.Vector UninterpretedOption)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'uninterpretedOption' @:: Lens' MethodOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data MethodOptions = MethodOptions{_MethodOptions'deprecated ::
                                    !(Prelude.Maybe Prelude.Bool),
@@ -8112,7 +8043,7 @@ instance a ~ ([UninterpretedOption]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector UninterpretedOption) =>
-         Lens.Labels.HasLens' MethodOptions "vector'uninterpretedOption" a
+         Lens.Labels.HasLens' MethodOptions "vec'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _MethodOptions'uninterpretedOption
@@ -8184,7 +8115,7 @@ instance Data.ProtoLens.Message MethodOptions where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                          (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                                     frozen'uninterpretedOption
                                     x))
                          else
@@ -8267,21 +8198,19 @@ instance Data.ProtoLens.Message MethodOptions where
                                               Prelude.. Prelude.fromEnum)
                                              _v)
                    Data.Monoid.<>
-                   (Data.Vector.Generic.foldr
-                      (\ _v as ->
-                         ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                            (((\ bs ->
-                                 (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                    (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                   Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                               Prelude.. Data.ProtoLens.encodeMessage)
-                              _v)
-                           Data.Monoid.<> as)
-                      Data.Monoid.mempty
+                   (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                      (\ _v ->
+                         (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                           (((\ bs ->
+                                (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                   (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                  Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                              Prelude.. Data.ProtoLens.encodeMessage)
+                             _v)
                       (Lens.Family2.view
                          (Lens.Labels.lensOf'
                             ((Lens.Labels.proxy#) ::
-                               (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                               (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                          _x))
                      Data.Monoid.<>
                      Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -8536,7 +8465,7 @@ instance Control.DeepSeq.NFData OneofDescriptorProto where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' OneofOptions [UninterpretedOption]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' OneofOptions (Data.Vector.Vector UninterpretedOption)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'uninterpretedOption' @:: Lens' OneofOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data OneofOptions = OneofOptions{_OneofOptions'uninterpretedOption
                                  :: !(Data.Vector.Vector UninterpretedOption),
@@ -8557,7 +8486,7 @@ instance a ~ ([UninterpretedOption]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector UninterpretedOption) =>
-         Lens.Labels.HasLens' OneofOptions "vector'uninterpretedOption" a
+         Lens.Labels.HasLens' OneofOptions "vec'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _OneofOptions'uninterpretedOption
@@ -8609,7 +8538,7 @@ instance Data.ProtoLens.Message OneofOptions where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                          (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                                     frozen'uninterpretedOption
                                     x))
                          else
@@ -8640,21 +8569,19 @@ instance Data.ProtoLens.Message OneofOptions where
                 Data.ProtoLens.Encoding.Bytes.<?> "OneofOptions"
         buildMessage
           = (\ _x ->
-               (Data.Vector.Generic.foldr
-                  (\ _v as ->
-                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                        (((\ bs ->
-                             (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                (Prelude.fromIntegral (Data.ByteString.length bs)))
-                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                           Prelude.. Data.ProtoLens.encodeMessage)
-                          _v)
-                       Data.Monoid.<> as)
-                  Data.Monoid.mempty
+               (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                  (\ _v ->
+                     (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                       (((\ bs ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt
+                               (Prelude.fromIntegral (Data.ByteString.length bs)))
+                              Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                          Prelude.. Data.ProtoLens.encodeMessage)
+                         _v)
                   (Lens.Family2.view
                      (Lens.Labels.lensOf'
                         ((Lens.Labels.proxy#) ::
-                           (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                           (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                      _x))
                  Data.Monoid.<>
                  Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -8670,7 +8597,7 @@ instance Control.DeepSeq.NFData OneofOptions where
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' ServiceDescriptorProto Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'name' @:: Lens' ServiceDescriptorProto (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.method' @:: Lens' ServiceDescriptorProto [MethodDescriptorProto]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'method' @:: Lens' ServiceDescriptorProto
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'method' @:: Lens' ServiceDescriptorProto
   (Data.Vector.Vector MethodDescriptorProto)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.options' @:: Lens' ServiceDescriptorProto ServiceOptions@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'options' @:: Lens' ServiceDescriptorProto (Prelude.Maybe ServiceOptions)@
@@ -8713,7 +8640,7 @@ instance a ~ ([MethodDescriptorProto]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector MethodDescriptorProto) =>
-         Lens.Labels.HasLens' ServiceDescriptorProto "vector'method" a
+         Lens.Labels.HasLens' ServiceDescriptorProto "vec'method" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _ServiceDescriptorProto'method
@@ -8799,8 +8726,7 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
                                  (\ !t -> Prelude.reverse t)
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'method"))
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'method"))
                                     frozen'method
                                     x))
                          else
@@ -8877,20 +8803,18 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
                                             Prelude.. Data.Text.Encoding.encodeUtf8)
                                            _v)
                  Data.Monoid.<>
-                 (Data.Vector.Generic.foldr
-                    (\ _v as ->
-                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                         Data.Monoid.<> as)
-                    Data.Monoid.mempty
+                 (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                    (\ _v ->
+                       (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                         (((\ bs ->
+                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                            Prelude.. Data.ProtoLens.encodeMessage)
+                           _v)
                     (Lens.Family2.view
                        (Lens.Labels.lensOf'
-                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'method"))
+                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'method"))
                        _x))
                    Data.Monoid.<>
                    (case
@@ -8927,7 +8851,7 @@ instance Control.DeepSeq.NFData ServiceDescriptorProto where
     * 'Proto.Google.Protobuf.Descriptor_Fields.deprecated' @:: Lens' ServiceOptions Prelude.Bool@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'deprecated' @:: Lens' ServiceOptions (Prelude.Maybe Prelude.Bool)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.uninterpretedOption' @:: Lens' ServiceOptions [UninterpretedOption]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'uninterpretedOption' @:: Lens' ServiceOptions (Data.Vector.Vector UninterpretedOption)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'uninterpretedOption' @:: Lens' ServiceOptions (Data.Vector.Vector UninterpretedOption)@
  -}
 data ServiceOptions = ServiceOptions{_ServiceOptions'deprecated ::
                                      !(Prelude.Maybe Prelude.Bool),
@@ -8964,7 +8888,7 @@ instance a ~ ([UninterpretedOption]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector UninterpretedOption) =>
-         Lens.Labels.HasLens' ServiceOptions "vector'uninterpretedOption" a
+         Lens.Labels.HasLens' ServiceOptions "vec'uninterpretedOption" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _ServiceOptions'uninterpretedOption
@@ -9025,7 +8949,7 @@ instance Data.ProtoLens.Message ServiceOptions where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                                          (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                                     frozen'uninterpretedOption
                                     x))
                          else
@@ -9080,21 +9004,19 @@ instance Data.ProtoLens.Message ServiceOptions where
                                             (\ b -> if b then 1 else 0))
                                            _v)
                  Data.Monoid.<>
-                 (Data.Vector.Generic.foldr
-                    (\ _v as ->
-                       ((Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
-                          (((\ bs ->
-                               (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                  (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                 Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                             Prelude.. Data.ProtoLens.encodeMessage)
-                            _v)
-                         Data.Monoid.<> as)
-                    Data.Monoid.mempty
+                 (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                    (\ _v ->
+                       (Data.ProtoLens.Encoding.Bytes.putVarInt 7994) Data.Monoid.<>
+                         (((\ bs ->
+                              (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                 (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                            Prelude.. Data.ProtoLens.encodeMessage)
+                           _v)
                     (Lens.Family2.view
                        (Lens.Labels.lensOf'
                           ((Lens.Labels.proxy#) ::
-                             (Lens.Labels.Proxy#) "vector'uninterpretedOption"))
+                             (Lens.Labels.Proxy#) "vec'uninterpretedOption"))
                        _x))
                    Data.Monoid.<>
                    Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -9109,7 +9031,7 @@ instance Control.DeepSeq.NFData ServiceOptions where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.location' @:: Lens' SourceCodeInfo [SourceCodeInfo'Location]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'location' @:: Lens' SourceCodeInfo (Data.Vector.Vector SourceCodeInfo'Location)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'location' @:: Lens' SourceCodeInfo (Data.Vector.Vector SourceCodeInfo'Location)@
  -}
 data SourceCodeInfo = SourceCodeInfo{_SourceCodeInfo'location ::
                                      !(Data.Vector.Vector SourceCodeInfo'Location),
@@ -9130,7 +9052,7 @@ instance a ~ ([SourceCodeInfo'Location]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector SourceCodeInfo'Location) =>
-         Lens.Labels.HasLens' SourceCodeInfo "vector'location" a
+         Lens.Labels.HasLens' SourceCodeInfo "vec'location" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _SourceCodeInfo'location
@@ -9181,7 +9103,7 @@ instance Data.ProtoLens.Message SourceCodeInfo where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'location"))
+                                          (Lens.Labels.Proxy#) "vec'location"))
                                     frozen'location
                                     x))
                          else
@@ -9211,20 +9133,18 @@ instance Data.ProtoLens.Message SourceCodeInfo where
                 Data.ProtoLens.Encoding.Bytes.<?> "SourceCodeInfo"
         buildMessage
           = (\ _x ->
-               (Data.Vector.Generic.foldr
-                  (\ _v as ->
-                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
-                        (((\ bs ->
-                             (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                (Prelude.fromIntegral (Data.ByteString.length bs)))
-                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                           Prelude.. Data.ProtoLens.encodeMessage)
-                          _v)
-                       Data.Monoid.<> as)
-                  Data.Monoid.mempty
+               (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                  (\ _v ->
+                     (Data.ProtoLens.Encoding.Bytes.putVarInt 10) Data.Monoid.<>
+                       (((\ bs ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt
+                               (Prelude.fromIntegral (Data.ByteString.length bs)))
+                              Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                          Prelude.. Data.ProtoLens.encodeMessage)
+                         _v)
                   (Lens.Family2.view
                      (Lens.Labels.lensOf'
-                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'location"))
+                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'location"))
                      _x))
                  Data.Monoid.<>
                  Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -9237,17 +9157,17 @@ instance Control.DeepSeq.NFData SourceCodeInfo where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.path' @:: Lens' SourceCodeInfo'Location [Data.Int.Int32]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'path' @:: Lens' SourceCodeInfo'Location
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'path' @:: Lens' SourceCodeInfo'Location
   (Data.Vector.Unboxed.Vector Data.Int.Int32)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.span' @:: Lens' SourceCodeInfo'Location [Data.Int.Int32]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'span' @:: Lens' SourceCodeInfo'Location
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'span' @:: Lens' SourceCodeInfo'Location
   (Data.Vector.Unboxed.Vector Data.Int.Int32)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.leadingComments' @:: Lens' SourceCodeInfo'Location Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'leadingComments' @:: Lens' SourceCodeInfo'Location (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.trailingComments' @:: Lens' SourceCodeInfo'Location Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'trailingComments' @:: Lens' SourceCodeInfo'Location (Prelude.Maybe Data.Text.Text)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.leadingDetachedComments' @:: Lens' SourceCodeInfo'Location [Data.Text.Text]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'leadingDetachedComments' @:: Lens' SourceCodeInfo'Location (Data.Vector.Vector Data.Text.Text)@
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'leadingDetachedComments' @:: Lens' SourceCodeInfo'Location (Data.Vector.Vector Data.Text.Text)@
  -}
 data SourceCodeInfo'Location = SourceCodeInfo'Location{_SourceCodeInfo'Location'path
                                                        ::
@@ -9278,7 +9198,7 @@ instance a ~ ([Data.Int.Int32]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Unboxed.Vector Data.Int.Int32) =>
-         Lens.Labels.HasLens' SourceCodeInfo'Location "vector'path" a
+         Lens.Labels.HasLens' SourceCodeInfo'Location "vec'path" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'path
@@ -9294,7 +9214,7 @@ instance a ~ ([Data.Int.Int32]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Unboxed.Vector Data.Int.Int32) =>
-         Lens.Labels.HasLens' SourceCodeInfo'Location "vector'span" a
+         Lens.Labels.HasLens' SourceCodeInfo'Location "vec'span" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _SourceCodeInfo'Location'span
@@ -9353,7 +9273,7 @@ instance a ~ ([Data.Text.Text]) =>
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector Data.Text.Text) =>
          Lens.Labels.HasLens' SourceCodeInfo'Location
-           "vector'leadingDetachedComments"
+           "vec'leadingDetachedComments"
            a
          where
         lensOf' _
@@ -9467,17 +9387,16 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
                                        ((Lens.Labels.proxy#) ::
-                                          (Lens.Labels.Proxy#) "vector'leadingDetachedComments"))
+                                          (Lens.Labels.Proxy#) "vec'leadingDetachedComments"))
                                     frozen'leadingDetachedComments
                                     (Lens.Family2.set
                                        (Lens.Labels.lensOf'
-                                          ((Lens.Labels.proxy#) ::
-                                             (Lens.Labels.Proxy#) "vector'path"))
+                                          ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'path"))
                                        frozen'path
                                        (Lens.Family2.set
                                           (Lens.Labels.lensOf'
                                              ((Lens.Labels.proxy#) ::
-                                                (Lens.Labels.Proxy#) "vector'span"))
+                                                (Lens.Labels.Proxy#) "vec'span"))
                                           frozen'span
                                           x))))
                          else
@@ -9615,7 +9534,7 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
           = (\ _x ->
                (let p = Lens.Family2.view
                           (Lens.Labels.lensOf'
-                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'path"))
+                             ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'path"))
                           _x
                   in
                   if Data.Vector.Generic.null p then Data.Monoid.mempty else
@@ -9625,18 +9544,14 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                             (Prelude.fromIntegral (Data.ByteString.length bs)))
                            Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs)
                         (Data.ProtoLens.Encoding.Bytes.runBuilder
-                           (Data.Vector.Generic.foldr
-                              (\ v bs ->
-                                 (((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
-                                     Prelude.fromIntegral)
-                                    v)
-                                   Data.Monoid.<> bs)
-                              Data.Monoid.mempty
+                           (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                              ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                 Prelude.fromIntegral)
                               p)))
                  Data.Monoid.<>
                  (let p = Lens.Family2.view
                             (Lens.Labels.lensOf'
-                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'span"))
+                               ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'span"))
                             _x
                     in
                     if Data.Vector.Generic.null p then Data.Monoid.mempty else
@@ -9646,13 +9561,9 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                               (Prelude.fromIntegral (Data.ByteString.length bs)))
                              Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs)
                           (Data.ProtoLens.Encoding.Bytes.runBuilder
-                             (Data.Vector.Generic.foldr
-                                (\ v bs ->
-                                   (((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
-                                       Prelude.fromIntegral)
-                                      v)
-                                     Data.Monoid.<> bs)
-                                Data.Monoid.mempty
+                             (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                                ((Data.ProtoLens.Encoding.Bytes.putVarInt) Prelude..
+                                   Prelude.fromIntegral)
                                 p)))
                    Data.Monoid.<>
                    (case
@@ -9693,21 +9604,19 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
                                                   Prelude.. Data.Text.Encoding.encodeUtf8)
                                                  _v)
                        Data.Monoid.<>
-                       (Data.Vector.Generic.foldr
-                          (\ _v as ->
-                             ((Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
-                                (((\ bs ->
-                                     (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                        (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                       Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                                   Prelude.. Data.Text.Encoding.encodeUtf8)
-                                  _v)
-                               Data.Monoid.<> as)
-                          Data.Monoid.mempty
+                       (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                          (\ _v ->
+                             (Data.ProtoLens.Encoding.Bytes.putVarInt 50) Data.Monoid.<>
+                               (((\ bs ->
+                                    (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                       (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                      Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                  Prelude.. Data.Text.Encoding.encodeUtf8)
+                                 _v)
                           (Lens.Family2.view
                              (Lens.Labels.lensOf'
                                 ((Lens.Labels.proxy#) ::
-                                   (Lens.Labels.Proxy#) "vector'leadingDetachedComments"))
+                                   (Lens.Labels.Proxy#) "vec'leadingDetachedComments"))
                              _x))
                          Data.Monoid.<>
                          Data.ProtoLens.Encoding.Wire.buildFieldSet
@@ -9729,7 +9638,7 @@ instance Control.DeepSeq.NFData SourceCodeInfo'Location where
 {- | Fields :
 
     * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' UninterpretedOption [UninterpretedOption'NamePart]@
-    * 'Proto.Google.Protobuf.Descriptor_Fields.vector'name' @:: Lens' UninterpretedOption
+    * 'Proto.Google.Protobuf.Descriptor_Fields.vec'name' @:: Lens' UninterpretedOption
   (Data.Vector.Vector UninterpretedOption'NamePart)@
     * 'Proto.Google.Protobuf.Descriptor_Fields.identifierValue' @:: Lens' UninterpretedOption Data.Text.Text@
     * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'identifierValue' @:: Lens' UninterpretedOption (Prelude.Maybe Data.Text.Text)@
@@ -9778,7 +9687,7 @@ instance a ~ ([UninterpretedOption'NamePart]) =>
               Lens.Family2.Unchecked.lens Data.Vector.Generic.toList
                 (\ _ y__ -> Data.Vector.Generic.fromList y__)
 instance a ~ (Data.Vector.Vector UninterpretedOption'NamePart) =>
-         Lens.Labels.HasLens' UninterpretedOption "vector'name" a
+         Lens.Labels.HasLens' UninterpretedOption "vec'name" a
          where
         lensOf' _
           = (Lens.Family2.Unchecked.lens _UninterpretedOption'name
@@ -9983,7 +9892,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
                                  (\ !t -> Prelude.reverse t)
                                  (Lens.Family2.set
                                     (Lens.Labels.lensOf'
-                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'name"))
+                                       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'name"))
                                     frozen'name
                                     x))
                          else
@@ -10093,20 +10002,18 @@ instance Data.ProtoLens.Message UninterpretedOption where
                 Data.ProtoLens.Encoding.Bytes.<?> "UninterpretedOption"
         buildMessage
           = (\ _x ->
-               (Data.Vector.Generic.foldr
-                  (\ _v as ->
-                     ((Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
-                        (((\ bs ->
-                             (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                (Prelude.fromIntegral (Data.ByteString.length bs)))
-                               Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                           Prelude.. Data.ProtoLens.encodeMessage)
-                          _v)
-                       Data.Monoid.<> as)
-                  Data.Monoid.mempty
+               (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                  (\ _v ->
+                     (Data.ProtoLens.Encoding.Bytes.putVarInt 18) Data.Monoid.<>
+                       (((\ bs ->
+                            (Data.ProtoLens.Encoding.Bytes.putVarInt
+                               (Prelude.fromIntegral (Data.ByteString.length bs)))
+                              Data.Monoid.<> Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                          Prelude.. Data.ProtoLens.encodeMessage)
+                         _v)
                   (Lens.Family2.view
                      (Lens.Labels.lensOf'
-                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'name"))
+                        ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'name"))
                      _x))
                  Data.Monoid.<>
                  (case

--- a/proto-lens/src/Proto/Google/Protobuf/Descriptor_Fields.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Descriptor_Fields.hs
@@ -13,6 +13,8 @@ import qualified Data.Monoid
 import qualified Data.Word
 import qualified Data.ProtoLens
 import qualified Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Encoding.Parser.Unsafe
 import qualified Data.ProtoLens.Encoding.Wire
 import qualified Data.ProtoLens.Message.Enum
 import qualified Data.ProtoLens.Service.Types
@@ -23,6 +25,9 @@ import qualified Data.Map
 import qualified Data.ByteString
 import qualified Data.ByteString.Char8
 import qualified Data.Text.Encoding
+import qualified Data.Vector
+import qualified Data.Vector.Generic
+import qualified Data.Vector.Unboxed
 import qualified Lens.Labels
 import qualified Text.Read
 
@@ -1086,6 +1091,185 @@ value ::
 value
   = Lens.Labels.lensOf'
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "value")
+vector'annotation ::
+                  forall f s a .
+                    (Prelude.Functor f,
+                     Lens.Labels.HasLens' s "vector'annotation" a) =>
+                    Lens.Family2.LensLike' f s a
+vector'annotation
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'annotation")
+vector'dependency ::
+                  forall f s a .
+                    (Prelude.Functor f,
+                     Lens.Labels.HasLens' s "vector'dependency" a) =>
+                    Lens.Family2.LensLike' f s a
+vector'dependency
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'dependency")
+vector'enumType ::
+                forall f s a .
+                  (Prelude.Functor f, Lens.Labels.HasLens' s "vector'enumType" a) =>
+                  Lens.Family2.LensLike' f s a
+vector'enumType
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'enumType")
+vector'extension ::
+                 forall f s a .
+                   (Prelude.Functor f, Lens.Labels.HasLens' s "vector'extension" a) =>
+                   Lens.Family2.LensLike' f s a
+vector'extension
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'extension")
+vector'extensionRange ::
+                      forall f s a .
+                        (Prelude.Functor f,
+                         Lens.Labels.HasLens' s "vector'extensionRange" a) =>
+                        Lens.Family2.LensLike' f s a
+vector'extensionRange
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "vector'extensionRange")
+vector'field ::
+             forall f s a .
+               (Prelude.Functor f, Lens.Labels.HasLens' s "vector'field" a) =>
+               Lens.Family2.LensLike' f s a
+vector'field
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'field")
+vector'file ::
+            forall f s a .
+              (Prelude.Functor f, Lens.Labels.HasLens' s "vector'file" a) =>
+              Lens.Family2.LensLike' f s a
+vector'file
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file")
+vector'leadingDetachedComments ::
+                               forall f s a .
+                                 (Prelude.Functor f,
+                                  Lens.Labels.HasLens' s "vector'leadingDetachedComments" a) =>
+                                 Lens.Family2.LensLike' f s a
+vector'leadingDetachedComments
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "vector'leadingDetachedComments")
+vector'location ::
+                forall f s a .
+                  (Prelude.Functor f, Lens.Labels.HasLens' s "vector'location" a) =>
+                  Lens.Family2.LensLike' f s a
+vector'location
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'location")
+vector'messageType ::
+                   forall f s a .
+                     (Prelude.Functor f,
+                      Lens.Labels.HasLens' s "vector'messageType" a) =>
+                     Lens.Family2.LensLike' f s a
+vector'messageType
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'messageType")
+vector'method ::
+              forall f s a .
+                (Prelude.Functor f, Lens.Labels.HasLens' s "vector'method" a) =>
+                Lens.Family2.LensLike' f s a
+vector'method
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'method")
+vector'name ::
+            forall f s a .
+              (Prelude.Functor f, Lens.Labels.HasLens' s "vector'name" a) =>
+              Lens.Family2.LensLike' f s a
+vector'name
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'name")
+vector'nestedType ::
+                  forall f s a .
+                    (Prelude.Functor f,
+                     Lens.Labels.HasLens' s "vector'nestedType" a) =>
+                    Lens.Family2.LensLike' f s a
+vector'nestedType
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'nestedType")
+vector'oneofDecl ::
+                 forall f s a .
+                   (Prelude.Functor f, Lens.Labels.HasLens' s "vector'oneofDecl" a) =>
+                   Lens.Family2.LensLike' f s a
+vector'oneofDecl
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'oneofDecl")
+vector'path ::
+            forall f s a .
+              (Prelude.Functor f, Lens.Labels.HasLens' s "vector'path" a) =>
+              Lens.Family2.LensLike' f s a
+vector'path
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'path")
+vector'publicDependency ::
+                        forall f s a .
+                          (Prelude.Functor f,
+                           Lens.Labels.HasLens' s "vector'publicDependency" a) =>
+                          Lens.Family2.LensLike' f s a
+vector'publicDependency
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "vector'publicDependency")
+vector'reservedName ::
+                    forall f s a .
+                      (Prelude.Functor f,
+                       Lens.Labels.HasLens' s "vector'reservedName" a) =>
+                      Lens.Family2.LensLike' f s a
+vector'reservedName
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "vector'reservedName")
+vector'reservedRange ::
+                     forall f s a .
+                       (Prelude.Functor f,
+                        Lens.Labels.HasLens' s "vector'reservedRange" a) =>
+                       Lens.Family2.LensLike' f s a
+vector'reservedRange
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "vector'reservedRange")
+vector'service ::
+               forall f s a .
+                 (Prelude.Functor f, Lens.Labels.HasLens' s "vector'service" a) =>
+                 Lens.Family2.LensLike' f s a
+vector'service
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'service")
+vector'span ::
+            forall f s a .
+              (Prelude.Functor f, Lens.Labels.HasLens' s "vector'span" a) =>
+              Lens.Family2.LensLike' f s a
+vector'span
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'span")
+vector'uninterpretedOption ::
+                           forall f s a .
+                             (Prelude.Functor f,
+                              Lens.Labels.HasLens' s "vector'uninterpretedOption" a) =>
+                             Lens.Family2.LensLike' f s a
+vector'uninterpretedOption
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "vector'uninterpretedOption")
+vector'value ::
+             forall f s a .
+               (Prelude.Functor f, Lens.Labels.HasLens' s "vector'value" a) =>
+               Lens.Family2.LensLike' f s a
+vector'value
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'value")
+vector'weakDependency ::
+                      forall f s a .
+                        (Prelude.Functor f,
+                         Lens.Labels.HasLens' s "vector'weakDependency" a) =>
+                        Lens.Family2.LensLike' f s a
+vector'weakDependency
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "vector'weakDependency")
 weak ::
      forall f s a .
        (Prelude.Functor f, Lens.Labels.HasLens' s "weak" a) =>

--- a/proto-lens/src/Proto/Google/Protobuf/Descriptor_Fields.hs
+++ b/proto-lens/src/Proto/Google/Protobuf/Descriptor_Fields.hs
@@ -1091,185 +1091,176 @@ value ::
 value
   = Lens.Labels.lensOf'
       ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "value")
-vector'annotation ::
-                  forall f s a .
-                    (Prelude.Functor f,
-                     Lens.Labels.HasLens' s "vector'annotation" a) =>
-                    Lens.Family2.LensLike' f s a
-vector'annotation
+vec'annotation ::
+               forall f s a .
+                 (Prelude.Functor f, Lens.Labels.HasLens' s "vec'annotation" a) =>
+                 Lens.Family2.LensLike' f s a
+vec'annotation
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'annotation")
-vector'dependency ::
-                  forall f s a .
-                    (Prelude.Functor f,
-                     Lens.Labels.HasLens' s "vector'dependency" a) =>
-                    Lens.Family2.LensLike' f s a
-vector'dependency
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'annotation")
+vec'dependency ::
+               forall f s a .
+                 (Prelude.Functor f, Lens.Labels.HasLens' s "vec'dependency" a) =>
+                 Lens.Family2.LensLike' f s a
+vec'dependency
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'dependency")
-vector'enumType ::
-                forall f s a .
-                  (Prelude.Functor f, Lens.Labels.HasLens' s "vector'enumType" a) =>
-                  Lens.Family2.LensLike' f s a
-vector'enumType
-  = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'enumType")
-vector'extension ::
-                 forall f s a .
-                   (Prelude.Functor f, Lens.Labels.HasLens' s "vector'extension" a) =>
-                   Lens.Family2.LensLike' f s a
-vector'extension
-  = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'extension")
-vector'extensionRange ::
-                      forall f s a .
-                        (Prelude.Functor f,
-                         Lens.Labels.HasLens' s "vector'extensionRange" a) =>
-                        Lens.Family2.LensLike' f s a
-vector'extensionRange
-  = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) ::
-         (Lens.Labels.Proxy#) "vector'extensionRange")
-vector'field ::
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'dependency")
+vec'enumType ::
              forall f s a .
-               (Prelude.Functor f, Lens.Labels.HasLens' s "vector'field" a) =>
+               (Prelude.Functor f, Lens.Labels.HasLens' s "vec'enumType" a) =>
                Lens.Family2.LensLike' f s a
-vector'field
+vec'enumType
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'field")
-vector'file ::
-            forall f s a .
-              (Prelude.Functor f, Lens.Labels.HasLens' s "vector'file" a) =>
-              Lens.Family2.LensLike' f s a
-vector'file
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'enumType")
+vec'extension ::
+              forall f s a .
+                (Prelude.Functor f, Lens.Labels.HasLens' s "vec'extension" a) =>
+                Lens.Family2.LensLike' f s a
+vec'extension
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'file")
-vector'leadingDetachedComments ::
-                               forall f s a .
-                                 (Prelude.Functor f,
-                                  Lens.Labels.HasLens' s "vector'leadingDetachedComments" a) =>
-                                 Lens.Family2.LensLike' f s a
-vector'leadingDetachedComments
-  = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) ::
-         (Lens.Labels.Proxy#) "vector'leadingDetachedComments")
-vector'location ::
-                forall f s a .
-                  (Prelude.Functor f, Lens.Labels.HasLens' s "vector'location" a) =>
-                  Lens.Family2.LensLike' f s a
-vector'location
-  = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'location")
-vector'messageType ::
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'extension")
+vec'extensionRange ::
                    forall f s a .
                      (Prelude.Functor f,
-                      Lens.Labels.HasLens' s "vector'messageType" a) =>
+                      Lens.Labels.HasLens' s "vec'extensionRange" a) =>
                      Lens.Family2.LensLike' f s a
-vector'messageType
+vec'extensionRange
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'messageType")
-vector'method ::
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'extensionRange")
+vec'field ::
+          forall f s a .
+            (Prelude.Functor f, Lens.Labels.HasLens' s "vec'field" a) =>
+            Lens.Family2.LensLike' f s a
+vec'field
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'field")
+vec'file ::
+         forall f s a .
+           (Prelude.Functor f, Lens.Labels.HasLens' s "vec'file" a) =>
+           Lens.Family2.LensLike' f s a
+vec'file
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'file")
+vec'leadingDetachedComments ::
+                            forall f s a .
+                              (Prelude.Functor f,
+                               Lens.Labels.HasLens' s "vec'leadingDetachedComments" a) =>
+                              Lens.Family2.LensLike' f s a
+vec'leadingDetachedComments
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) ::
+         (Lens.Labels.Proxy#) "vec'leadingDetachedComments")
+vec'location ::
+             forall f s a .
+               (Prelude.Functor f, Lens.Labels.HasLens' s "vec'location" a) =>
+               Lens.Family2.LensLike' f s a
+vec'location
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'location")
+vec'messageType ::
+                forall f s a .
+                  (Prelude.Functor f, Lens.Labels.HasLens' s "vec'messageType" a) =>
+                  Lens.Family2.LensLike' f s a
+vec'messageType
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'messageType")
+vec'method ::
+           forall f s a .
+             (Prelude.Functor f, Lens.Labels.HasLens' s "vec'method" a) =>
+             Lens.Family2.LensLike' f s a
+vec'method
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'method")
+vec'name ::
+         forall f s a .
+           (Prelude.Functor f, Lens.Labels.HasLens' s "vec'name" a) =>
+           Lens.Family2.LensLike' f s a
+vec'name
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'name")
+vec'nestedType ::
+               forall f s a .
+                 (Prelude.Functor f, Lens.Labels.HasLens' s "vec'nestedType" a) =>
+                 Lens.Family2.LensLike' f s a
+vec'nestedType
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'nestedType")
+vec'oneofDecl ::
               forall f s a .
-                (Prelude.Functor f, Lens.Labels.HasLens' s "vector'method" a) =>
+                (Prelude.Functor f, Lens.Labels.HasLens' s "vec'oneofDecl" a) =>
                 Lens.Family2.LensLike' f s a
-vector'method
+vec'oneofDecl
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'method")
-vector'name ::
-            forall f s a .
-              (Prelude.Functor f, Lens.Labels.HasLens' s "vector'name" a) =>
-              Lens.Family2.LensLike' f s a
-vector'name
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'oneofDecl")
+vec'path ::
+         forall f s a .
+           (Prelude.Functor f, Lens.Labels.HasLens' s "vec'path" a) =>
+           Lens.Family2.LensLike' f s a
+vec'path
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'name")
-vector'nestedType ::
-                  forall f s a .
-                    (Prelude.Functor f,
-                     Lens.Labels.HasLens' s "vector'nestedType" a) =>
-                    Lens.Family2.LensLike' f s a
-vector'nestedType
-  = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'nestedType")
-vector'oneofDecl ::
-                 forall f s a .
-                   (Prelude.Functor f, Lens.Labels.HasLens' s "vector'oneofDecl" a) =>
-                   Lens.Family2.LensLike' f s a
-vector'oneofDecl
-  = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'oneofDecl")
-vector'path ::
-            forall f s a .
-              (Prelude.Functor f, Lens.Labels.HasLens' s "vector'path" a) =>
-              Lens.Family2.LensLike' f s a
-vector'path
-  = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'path")
-vector'publicDependency ::
-                        forall f s a .
-                          (Prelude.Functor f,
-                           Lens.Labels.HasLens' s "vector'publicDependency" a) =>
-                          Lens.Family2.LensLike' f s a
-vector'publicDependency
-  = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) ::
-         (Lens.Labels.Proxy#) "vector'publicDependency")
-vector'reservedName ::
-                    forall f s a .
-                      (Prelude.Functor f,
-                       Lens.Labels.HasLens' s "vector'reservedName" a) =>
-                      Lens.Family2.LensLike' f s a
-vector'reservedName
-  = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) ::
-         (Lens.Labels.Proxy#) "vector'reservedName")
-vector'reservedRange ::
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'path")
+vec'publicDependency ::
                      forall f s a .
                        (Prelude.Functor f,
-                        Lens.Labels.HasLens' s "vector'reservedRange" a) =>
+                        Lens.Labels.HasLens' s "vec'publicDependency" a) =>
                        Lens.Family2.LensLike' f s a
-vector'reservedRange
+vec'publicDependency
   = Lens.Labels.lensOf'
       ((Lens.Labels.proxy#) ::
-         (Lens.Labels.Proxy#) "vector'reservedRange")
-vector'service ::
-               forall f s a .
-                 (Prelude.Functor f, Lens.Labels.HasLens' s "vector'service" a) =>
-                 Lens.Family2.LensLike' f s a
-vector'service
+         (Lens.Labels.Proxy#) "vec'publicDependency")
+vec'reservedName ::
+                 forall f s a .
+                   (Prelude.Functor f, Lens.Labels.HasLens' s "vec'reservedName" a) =>
+                   Lens.Family2.LensLike' f s a
+vec'reservedName
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'service")
-vector'span ::
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'reservedName")
+vec'reservedRange ::
+                  forall f s a .
+                    (Prelude.Functor f,
+                     Lens.Labels.HasLens' s "vec'reservedRange" a) =>
+                    Lens.Family2.LensLike' f s a
+vec'reservedRange
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'reservedRange")
+vec'service ::
             forall f s a .
-              (Prelude.Functor f, Lens.Labels.HasLens' s "vector'span" a) =>
+              (Prelude.Functor f, Lens.Labels.HasLens' s "vec'service" a) =>
               Lens.Family2.LensLike' f s a
-vector'span
+vec'service
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'span")
-vector'uninterpretedOption ::
-                           forall f s a .
-                             (Prelude.Functor f,
-                              Lens.Labels.HasLens' s "vector'uninterpretedOption" a) =>
-                             Lens.Family2.LensLike' f s a
-vector'uninterpretedOption
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'service")
+vec'span ::
+         forall f s a .
+           (Prelude.Functor f, Lens.Labels.HasLens' s "vec'span" a) =>
+           Lens.Family2.LensLike' f s a
+vec'span
   = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) ::
-         (Lens.Labels.Proxy#) "vector'uninterpretedOption")
-vector'value ::
-             forall f s a .
-               (Prelude.Functor f, Lens.Labels.HasLens' s "vector'value" a) =>
-               Lens.Family2.LensLike' f s a
-vector'value
-  = Lens.Labels.lensOf'
-      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vector'value")
-vector'weakDependency ::
-                      forall f s a .
-                        (Prelude.Functor f,
-                         Lens.Labels.HasLens' s "vector'weakDependency" a) =>
-                        Lens.Family2.LensLike' f s a
-vector'weakDependency
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'span")
+vec'uninterpretedOption ::
+                        forall f s a .
+                          (Prelude.Functor f,
+                           Lens.Labels.HasLens' s "vec'uninterpretedOption" a) =>
+                          Lens.Family2.LensLike' f s a
+vec'uninterpretedOption
   = Lens.Labels.lensOf'
       ((Lens.Labels.proxy#) ::
-         (Lens.Labels.Proxy#) "vector'weakDependency")
+         (Lens.Labels.Proxy#) "vec'uninterpretedOption")
+vec'value ::
+          forall f s a .
+            (Prelude.Functor f, Lens.Labels.HasLens' s "vec'value" a) =>
+            Lens.Family2.LensLike' f s a
+vec'value
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'value")
+vec'weakDependency ::
+                   forall f s a .
+                     (Prelude.Functor f,
+                      Lens.Labels.HasLens' s "vec'weakDependency" a) =>
+                     Lens.Family2.LensLike' f s a
+vec'weakDependency
+  = Lens.Labels.lensOf'
+      ((Lens.Labels.proxy#) :: (Lens.Labels.Proxy#) "vec'weakDependency")
 weak ::
      forall f s a .
        (Prelude.Functor f, Lens.Labels.HasLens' s "weak" a) =>

--- a/proto-lens/tests/growing_test.hs
+++ b/proto-lens/tests/growing_test.hs
@@ -1,0 +1,37 @@
+-- | Unit and property tests for Data.ProtoLens.Encoding.Growing.
+module Main (main) where
+
+import Control.Monad (void)
+import Control.Monad.ST
+import qualified Data.Vector.Unboxed as V
+import Test.QuickCheck
+import Test.Framework (defaultMain)
+import Test.Framework.Providers.QuickCheck2 (testProperty)
+
+import Data.ProtoLens.Encoding.Growing
+
+main :: IO ()
+main = defaultMain
+    [ testProperty "fromList" testFromList
+    , testProperty "unchanged" testUnchanged
+    ]
+
+testFromList :: [Int] -> Property
+testFromList xs = fromListGrowing xs === V.fromList xs
+
+fromListGrowing :: V.Unbox a => [a] -> V.Vector a
+fromListGrowing xs0 = runST (new >>= fill xs0 >>= unsafeFreeze)
+
+fill :: V.Unbox a => [a] -> Growing V.Vector s a -> ST s (Growing V.Vector s a)
+fill [] v = return v
+fill (x:xs) v = append v x >>= fill xs
+
+-- Test a weak form of immutability: filling in more values (which may or may
+-- not cause reallocations) doesn't affect the current value.
+testUnchanged :: [Int] -> [Int] -> Property
+testUnchanged xs ys =
+    let xs' = runST (do
+                        v <- new >>= fill xs
+                        void $ fill ys v
+                        unsafeFreeze v)
+    in xs' === V.fromList xs

--- a/proto-lens/tests/growing_test.hs
+++ b/proto-lens/tests/growing_test.hs
@@ -3,6 +3,7 @@ module Main (main) where
 
 import Control.Monad (void)
 import Control.Monad.ST
+import Data.Foldable (foldlM)
 import qualified Data.Vector.Unboxed as V
 import Test.QuickCheck
 import Test.Framework (defaultMain)
@@ -23,8 +24,7 @@ fromListGrowing :: V.Unbox a => [a] -> V.Vector a
 fromListGrowing xs0 = runST (new >>= fill xs0 >>= unsafeFreeze)
 
 fill :: V.Unbox a => [a] -> Growing V.Vector s a -> ST s (Growing V.Vector s a)
-fill [] v = return v
-fill (x:xs) v = append v x >>= fill xs
+fill xs v = foldlM append v xs
 
 -- Test a weak form of immutability: filling in more values (which may or may
 -- not cause reallocations) doesn't affect the current value.


### PR DESCRIPTION
Fixes #58.

For every repeated field `foo`, add a new lens `vector'foo`
whose field type is a `Vector` instead of a list.  Internally,
repeated fields are always stored as `Vectors`, whether or not
the field is actually packed.  Specifically:
- `Data.Vector.Unboxed.Vector` if the field's Haskell representation is
  fixed-length (`Int32`, `Float`, etc.), or
- `Data.Vector.Vector` (i.e., boxed) otherwise (`Text`, `ByteString`, messages,
  etc).

For backwards compatibility, the name `foo` continues to be used
for a list and is implemented as

    foo = vector'foo . iso Vector.toList Vector.fromList

The generated encoding/decoding code uses those `vector'*` lenses
internally.  For parsing, we keep a separate mutable vector for each
repeated field and grow it manually using the
`Data.ProtoLens.Encoding.Growing` module.

Two potentially dodgy things about this change:
1. I couldn't come up with an efficient, simple, and fully safe API
   for interleaving the vector mutation and parsing effects.  I settled
   for exposing `unsafeLiftIO :: IO a -> Parser a` in a separate module
   `Data.ProtoLens.Encoding.Parser.Unsafe`.
   The standard ST functions (e.g. `create` and `createT` from `vector`)
   don't really work here because we have an arbitary set of vectors
   of different element types.
2. In order to get the inner loops to optimize well, I introduced
   a function (born of much testing and staring at Core output):
   ```Data.ProtoLens.Encoding.Bytes.foldMapBuilder :: Vector v a => (a -> Builder) -> v a -> Builder```
   It uses internal Builder functions but produces large speedups
   due to getting GHC to inline the inner loop correctly.  (In fact,
   without it this change is slightly *worse* in encoding performance
   than the version with lists.)

TODO:
- Store enums in unboxed vectors.
- Also store unknown fields in a Vector (boxed) rather than a list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/302)
<!-- Reviewable:end -->
