### PR TITLE
 Simplify the Parser monad implementation.

### DIFF
--- a/proto-lens/src/Data/ProtoLens/Encoding/Parser/Unsafe.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Parser/Unsafe.hs
@@ -1,7 +1,6 @@
 module Data.ProtoLens.Encoding.Parser.Unsafe
     ( unsafeLiftIO ) where
 
-import Control.Monad.Trans.Class (lift)
 import Data.ProtoLens.Encoding.Parser.Internal
 
 -- | Runs an arbitrary @IO@ action inside a @Parser@.
@@ -19,4 +18,4 @@ import Data.ProtoLens.Encoding.Parser.Internal
 --   'runParser' will be sequenced according to their order in the Parser
 --   monad.
 unsafeLiftIO :: IO a -> Parser a
-unsafeLiftIO m = Parser $ \_ p -> ParserResult p <$> lift m
+unsafeLiftIO m = Parser $ \_ p -> ParseSuccess p <$> m


### PR DESCRIPTION
Previously it was `ExceptT String IO (ParseResult a)`, which is equivalent
to `IO (Either String (ParseResult a))`.  Elide that nested
type into a single datatype:

```
data ParseResult a = ParseSuccess {...} | ParseFailure String
```

Provides ~10% speedup for some benchmarks.  (Less for those
with a packed, fixed-length field.)  Was also suggested to
make the code more clear.

Results, on top of the other pending PRs:

flat(602B)/decode/whnf         8.238 μs => 7.684 μs

nested(900B)/decode/whnf       11.25 μs => 10.67 μs

int32-packed(1003B)/decode/whnf 7.651 μs => 6.697 μs

int32-unpacked(2000B)/decode/whnf 13.30 μs => 11.43 μs

fixed32-packed(4003B)/decode/whnf 2.531 μs => 2.530 μs

fixed32-unpacked(5000B)/decode/whnf 9.264 μs => 8.477 μs

float-packed(4003B)/decode/whnf 4.460 μs => 4.371 μs

float-unpacked(5000B)/decode/whnf 10.23 μs => 9.098 μs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/proto-lens/305)
<!-- Reviewable:end -->
