### PR TITLE
Bump the upper bound on QuickCheck to 2.13.

### DIFF
--- a/proto-lens-arbitrary/Changelog.md
+++ b/proto-lens-arbitrary/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-arbitrary`
 
+## v0.1.2.7
+- Bump the dependency for `QuickCheck-2.13`.
+
 ## v0.1.2.6
 - Bump upper bounds to support `proto-lens-0.5.*`.
 

--- a/proto-lens-arbitrary/package.yaml
+++ b/proto-lens-arbitrary/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-arbitrary
-version: "0.1.2.6"
+version: "0.1.2.7"
 synopsis: Arbitrary instances for proto-lens.
 description: >
   The proto-lens-arbitrary allows generating arbitrary messages for
@@ -20,7 +20,7 @@ dependencies:
   - containers >= 0.5 && < 0.7
   - text == 1.2.*
   - lens-family == 1.2.*
-  - QuickCheck >= 2.8 && < 2.13
+  - QuickCheck >= 2.8 && < 2.14
 
 library:
   source-dirs: src


### PR DESCRIPTION
Also bump proto-lens-arbitrary's version number and changelog.

Tested by adding the new version to `stack-ghc-8.6.yaml`, and
running:
```
$ stack test --resolver lts-13.15 --stack-yaml=stack-ghc-8.6.yaml
```