### PR TITLE
Fix a naming conflict between message constructors and enum values.

### DIFF
--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog for `proto-lens-protoc`
 
+## Pending
+- Fix a potential naming conflict when message types and enum values
+  are the same except for case.
+
 ## v0.5.0.0
 
 ### Breaking Changes

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -134,6 +134,7 @@ data Definition n = Message (MessageInfo n) | Enum (EnumInfo n)
 -- | All the information needed to define or use a proto message type.
 data MessageInfo n = MessageInfo
     { messageName :: n  -- ^ Haskell type name
+    , messageConstructorName :: n  -- ^ Haskell constructor name
     , messageDescriptor :: DescriptorProto
     , messageFields :: [PlainFieldInfo] -- ^ Fields not belonging to a oneof.
     , messageOneofFields :: [OneofInfo]
@@ -381,6 +382,10 @@ messageDefs syntaxType protoPrefix hsPrefix groups d
     thisDef =
         Message MessageInfo
             { messageName = fromString $ hsPrefix ++ hsName (d ^. name)
+              -- Set the constructor name to not conflict with enum values.
+            , messageConstructorName =
+                 fromString $ hsPrefix ++ hsName (d ^. name)
+                                ++ "'_constructor"
             , messageDescriptor = d
             , messageFields =
                   map (liftA2 PlainFieldInfo

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -246,7 +246,7 @@ generateMessageDecls fieldModName env protoName info =
     -- }
     [ commented (messageComment fieldModName (messageName info) allFields)
         $ dataDecl dataName
-            [recDecl dataName $
+            [recDecl (messageConstructorName info) $
                       [ (recordFieldName f, recordFieldType f)
                       | f <- allFields
                       ]
@@ -881,7 +881,7 @@ messageInstance env protoName m =
               $ "Data.Map.fromList" @@ list fieldsByTag ]
     , [ match "unknownFields" [] $ rawFieldAccessor (unQual $ messageUnknownFields m) ]
     , [ match "defMessage" []
-           $ recConstr (unQual $ messageName m) $
+           $ recConstr (unQual $ messageConstructorName m) $
                   [ fieldUpdate (unQual $ haskellRecordFieldName
                                     $ fieldName $ plainFieldInfo f)
                         (hsFieldDefault env f)

--- a/proto-lens-tests/tests/names.proto
+++ b/proto-lens-tests/tests/names.proto
@@ -117,3 +117,13 @@ message ProtoKeywordTypes {
   optional package package = 2;
   optional import import = 3;
 }
+
+message MessageEnumOverlap {
+}
+
+enum OverlapEnum {
+    // protoc doesn't allow enum values to have the same name
+    // as a message.  However, since we upper-case enum values, it's still
+    // possible for us to get an overlap.
+    messageEnumOverlap = 1;
+}

--- a/proto-lens-tests/tests/names_test.hs
+++ b/proto-lens-tests/tests/names_test.hs
@@ -39,10 +39,12 @@ main = testMain
     , testProtoKeywords
     , testProtoKeywordTypes
     , testReadReservedName
+    , testMessageEnumOverlap
     ]
 
 testNames, testPreludeType, testHaskellKeywords, testProtoKeywords,
-    testOddCasedMessage, testProtoKeywordTypes, testReadReservedName :: Test
+    testOddCasedMessage, testProtoKeywordTypes, testReadReservedName,
+    testMessageEnumOverlap :: Test
 
 -- | Test that we can get/set each individual field.
 testFields :: forall a . (Show a, Message a, Eq a)
@@ -160,3 +162,7 @@ testProtoKeywordTypes = testFields "protoKeywordTypes" (defMessage :: ProtoKeywo
 testReadReservedName = readFrom "testReadReservedName"
       (Just $ defMessage & set import' 1 :: Prelude.Maybe HaskellKeywords)
       "import: 1"
+
+testMessageEnumOverlap = testCase "messageEnumOverlap" $ do
+    trivial (defMessage :: MessageEnumOverlap)
+    trivial (MessageEnumOverlap :: OverlapEnum)


### PR DESCRIPTION
In general, protoc doesn't allow message types and enum values to be the same.
However, since we change the case of enum values, it's possible for us
to produce an overlap.  (For example, a message called "Job" and an enum value
called "job").

I fixed it by changing the name of the message constructor, which is an internal detail
not exposed by our API.