### PR TITLE
In `protoc` install commands, also extract `include/`

### DIFF
--- a/docs/installing-protoc.md
+++ b/docs/installing-protoc.md
@@ -5,7 +5,10 @@ somewhere on your `$PATH`.  You can get it by downloading the corresponding
 file for your system from https://github.com/google/protobuf/releases.   (The
 corresponding file will be named something like `protoc-*-.zip`.)
 
-Here are some OS-specific options for installing the binary:
+Here are some OS-specific options for installing the binary.  These instructions
+also install basic `.proto` files like `wrappers.proto`, `any.proto` and
+`descriptor.proto`.  (Those files aren't needed by `proto-lens` itself,
+but they may be useful for other language bindings/plugins.)
 
 ## Mac OS X
 

--- a/docs/installing-protoc.md
+++ b/docs/installing-protoc.md
@@ -23,6 +23,7 @@ Here are some OS-specific options for installing the binary:
       PROTOC_ZIP=protoc-3.7.1-osx-x86_64.zip
       curl -OL https://github.com/google/protobuf/releases/download/v3.7.1/$PROTOC_ZIP
       sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+      sudo unzip -o $PROTOC_ZIP -d /usr/local include/*
       rm -f $PROTOC_ZIP
 
 ## Linux
@@ -31,6 +32,7 @@ Here are some OS-specific options for installing the binary:
       PROTOC_ZIP=protoc-3.7.1-linux-x86_64.zip
       curl -OL https://github.com/google/protobuf/releases/download/v3.7.1/$PROTOC_ZIP
       sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+      sudo unzip -o $PROTOC_ZIP -d /usr/local include/*
       rm -f $PROTOC_ZIP
 
 - Alternately, manually download and install `protoc` from [here](https://github.com/google/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip).


### PR DESCRIPTION
Also unzip `include/` folder into `usr/local/include` to make sure plugins that commonly requires them works immediately.