### PR TITLE
Fix a bug in text format parsing

### DIFF
--- a/proto-lens-tests/tests/text_format_test.hs
+++ b/proto-lens-tests/tests/text_format_test.hs
@@ -80,6 +80,10 @@ main = testMain
              ++ " (including ones we do not emit)")
          (Just $ def1 & b .~ "\a\b\f\n\r\t\v\\\'\"")
          (Data.Text.Lazy.pack "b: \"\a\b\f\n\r\t\v\\\\\\\'\\\"\"")
+    , readFrom
+         ("Parse string with legal non-escaped \' quote character")
+         (Just $ def1 & b .~ "'")
+         (Data.Text.Lazy.pack "b: \"'\"")
     , testCase "Render string with escape sequences" $
         escapeRendered @=? showMessageShort escapeMessage
     , readFrom "Parse rendered string with escape sequences"


### PR DESCRIPTION
It's valid for text format protobufs to contain strings with unescaped quote
characters different from the characters used to delimit the string.