### PR TITLE
Bump the upper bound on profunctors to allow 5.4.

### DIFF
--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -1,6 +1,9 @@
 # Changelog for `proto-lens`
 
-## v0.5.0.0
+## v0.5.0.1
+- Bump the upper bound on `profunctors` to allow 5.4.
+- Allow text format protobuf strings to contain unescaped quote characters
+  different from the delimiters (#320).
 
 ### Breaking Changes
 - Merge the `lens-labels` library into `proto-lens`:

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens
-version: "0.5.0.0"
+version: "0.5.0.1"
 synopsis: A lens-based implementation of protocol buffers in Haskell.
 description: >
   The proto-lens library provides an API for protocol buffers using modern
@@ -43,7 +43,7 @@ library:
     - parsec == 3.1.*
     - pretty == 1.1.*
     - primitive == 0.6.*
-    - profunctors >= 5.2 && < 5.4
+    - profunctors >= 5.2 && < 5.5
     - tagged == 0.8.*
     - text == 1.2.*
     - transformers >= 0.4 && < 0.6


### PR DESCRIPTION
Also update the version and changelog to prepare for another release.