### PR TITLE
Allow primitive-0.7.

### DIFF
--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -2,6 +2,7 @@
 
 ## v0.5.0.1
 - Bump the upper bound on `profunctors` to allow 5.4.
+- Bump the upper bound on `primitive` to allow 0.7.
 - Allow text format protobuf strings to contain unescaped quote characters
   different from the delimiters (#320).
 

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -42,7 +42,7 @@ library:
     - lens-family == 1.2.*
     - parsec == 3.1.*
     - pretty == 1.1.*
-    - primitive == 0.6.*
+    - primitive >= 0.6 && < 0.8
     - profunctors >= 5.2 && < 5.5
     - tagged == 0.8.*
     - text == 1.2.*


### PR DESCRIPTION
Tested via `stack test` with the following (local) `stack.yaml` changes: added newer versions of `vector` and `vector-algorithms`, and commented out the dicrimination packages since the released version doesn't build yet with `primitive-0.7`.  (Which should be irrelevant for this PR which is only about the `proto-lens` package.)


```
 resolver: lts-12.7
 packages:
-- discrimination-ieee754
+#- discrimination-ieee754
 - proto-lens
 - proto-lens-arbitrary
-- proto-lens-discrimination
+#- proto-lens-discrimination
 - proto-lens-optparse
 - proto-lens-protobuf-types
 - proto-lens-protoc
@@ -14,8 +14,11 @@ packages:
 - proto-lens-tests
 - proto-lens-tests-dep
 extra-deps:
-- discrimination-0.3
+#- discrimination-0.3
 - promises-0.3
+- primitive-0.7.0.0
+- vector-0.12.0.3
+- vector-algorithms-0.8.0.1
```