### PR TITLE
Bump proto-lens to 0.5.1.0 and update the Changelog.

### DIFF
--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog for `proto-lens`
 
+## v0.5.1.0
+- Add `decodeMessageDelimitedH` to decode delimited messages from a file handle
+  (#61).
+
 ## v0.5.0.1
 - Bump the upper bound on `profunctors` to allow 5.4.
 - Bump the upper bound on `primitive` to allow 0.7.

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens
-version: "0.5.0.1"
+version: "0.5.1.0"
 synopsis: A lens-based implementation of protocol buffers in Haskell.
 description: >
   The proto-lens library provides an API for protocol buffers using modern


### PR DESCRIPTION
We need a minor version bump due to adding a new function
(`decodeMessageDelimitedH`).