### PR TITLE
Prevent warnings for "import public" on an empty .proto file.

### DIFF
--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -95,10 +95,12 @@ generateModule modName imports publicImports modifyImport definitions importedEn
                "DataKinds", "BangPatterns", "TypeApplications"]
               -- Allow unused imports in case we don't import anything from
               -- Data.Text, Data.Int, etc.
-          , optionsGhcPragma "-fno-warn-unused-imports"
-          -- haskell-src-exts doesn't support exporting `Foo(..., A, B)`
-          -- in a single entry, so we use two: `Foo(..)` and `Foo(A, B)`.
-          , optionsGhcPragma "-fno-warn-duplicate-exports"
+          , optionsGhcPragma "-Wno-unused-imports"
+            -- haskell-src-exts doesn't support exporting `Foo(..., A, B)`
+            -- in a single entry, so we use two: `Foo(..)` and `Foo(A, B)`.
+          , optionsGhcPragma "-Wno-duplicate-exports"
+            -- Don't warn if empty "import public" modules are reexported.
+          , optionsGhcPragma "-Wno-dodgy-exports"
           ]
     mainImports = map (modifyImport . importSimple)
                     [ "Control.DeepSeq", "Data.ProtoLens.Prism" ]

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -250,6 +250,7 @@ tests:
     dependencies:
       - proto-lens-tests
     other-modules:
+      - Proto.Empty
       - Proto.Enum
       - Proto.Imports
       - Proto.ImportsDep

--- a/proto-lens-tests/tests/empty.proto
+++ b/proto-lens-tests/tests/empty.proto
@@ -1,0 +1,4 @@
+// An empty proto file.
+syntax = "proto3";
+
+package empty;

--- a/proto-lens-tests/tests/imports_dep.proto
+++ b/proto-lens-tests/tests/imports_dep.proto
@@ -4,6 +4,8 @@ syntax = "proto2";
 package dep.pkg;
 
 import public "imports_transitive.proto";
+// Test that we supress warnings about reexporting empty modules.
+import public "empty.proto";
 
 message DepPkg {
   optional int32 x = 1;


### PR DESCRIPTION
Previously, if we reexported an empty module, we ran into `-Wdodgy-imports`.
In practice, this came up because of a proto file that only defined an
extension, which proto-lens doesn't support yet, so it generated an
empty module.

I think proto-lens-protoc's architecture makes it nontrivial to detect whether a module
has no exports.  So I just suppressed the `-Wdodgy-imports` warning.  I also
converted the other warnings from `-fno-warn-*` to `-Wno-*` for consistency,
since GHC has supported that form for a while.