### PR TITLE
Switch from test-framework to tasty.

### DIFF
--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -30,9 +30,9 @@ dependencies:
     - proto-lens
     - proto-lens-arbitrary
     - proto-lens-runtime
-    - test-framework
-    - test-framework-hunit
-    - test-framework-quickcheck2
+    - tasty
+    - tasty-hunit
+    - tasty-quickcheck
     - text
 
 

--- a/proto-lens-tests/tests/any_test.hs
+++ b/proto-lens-tests/tests/any_test.hs
@@ -8,7 +8,7 @@ import Data.ProtoLens.Any
 import Data.ProtoLens.Arbitrary (ArbitraryMessage(..))
 import Proto.Google.Protobuf.Any_Fields (typeUrl, value)
 import Lens.Family2 ((&), (.~), (^.))
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 import qualified Data.Text as Text
 import Test.QuickCheck ((===), counterexample, listOf, elements)

--- a/proto-lens-tests/tests/canonical_test.hs
+++ b/proto-lens-tests/tests/canonical_test.hs
@@ -16,7 +16,7 @@ module Main where
 import Lens.Family2 ((&), (.~))
 import Proto.Canonical (Test1, Test2, Test3, Test4)
 import Proto.Canonical_Fields (a, b, c, d)
-import Test.Framework (testGroup)
+import Test.Tasty (testGroup)
 import Data.ProtoLens
 import qualified Data.ByteString as B
 import Data.ByteString.Builder (word8)
@@ -29,11 +29,11 @@ main = testMain
            [int32Test, stringTest, embeddedTest, packedIntsTest, roundTripTests]
 
 canonicalTest :: (Show a, Eq a, Message a)
-              => String -> a -> Doc -> [Word8] -> Test
+              => String -> a -> Doc -> [Word8] -> TestTree
 canonicalTest name val text bytes
     = testGroup name [serializeTo "bytes" val text $ mconcat $ map word8 bytes]
 
-int32Test, stringTest, embeddedTest, packedIntsTest, roundTripTests :: Test
+int32Test, stringTest, embeddedTest, packedIntsTest, roundTripTests :: TestTree
 int32Test = canonicalTest
     "int32"
     (defMessage & a .~ 150 :: Test1)

--- a/proto-lens-tests/tests/decode_delimited_test.hs
+++ b/proto-lens-tests/tests/decode_delimited_test.hs
@@ -7,7 +7,7 @@ import qualified Data.Text as T
 import Data.ProtoLens
 import Data.ProtoLens.Encoding.Bytes (runBuilder)
 import Lens.Family2 ((&), (.~))
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 
 import Data.ProtoLens.TestUtil

--- a/proto-lens-tests/tests/dependent_test.hs
+++ b/proto-lens-tests/tests/dependent_test.hs
@@ -1,15 +1,15 @@
 module Main (main) where
 
 import Data.ProtoLens (defMessage)
-import Test.Framework (defaultMain)
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 
 import Proto.Dependent (Dependent)
 import Proto.Lib (LibMessage)
 
 main :: IO ()
-main = defaultMain
+main = defaultMain $ testGroup "tests"
     [ testCase "LibMessage" $ (defMessage :: LibMessage) @=? defMessage
     , testCase "Dependent" $ (defMessage :: Dependent) @=? defMessage
     ]

--- a/proto-lens-tests/tests/enum_test.hs
+++ b/proto-lens-tests/tests/enum_test.hs
@@ -22,9 +22,8 @@ import Data.Function (on)
 import Data.ProtoLens
 import Data.ProtoLens.Arbitrary
 import Lens.Family2 ((&), (.~), (^.))
-import Test.Framework (plusTestOptions, testGroup)
-import Test.Framework.Options (topt_timeout)
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty (localOption, mkTimeout, testGroup)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@?=))
 
 import Data.ProtoLens.TestUtil
@@ -52,7 +51,7 @@ main = testMain
 testExternalEnum, testNestedEnum, testDefaults, testBadEnumValues,
     testNamedEnumValues, testRoundTrip, testBounded, testMaybeSuccAndPred,
     testEnumFromThenTo, testMonotonicFromEnum, testAliases,
-    testManyCases :: Test
+    testManyCases :: TestTree
 
 testExternalEnum = testGroup "external"
     [ serializeTo (show e1)
@@ -114,7 +113,7 @@ testMaybeSuccAndPred = testGroup "succPred"
         ]
     ]
 
-testEnumFromThenTo = plusTestOptions testOptions $ testGroup "enumFromThenTo"
+testEnumFromThenTo = localOption testOptions $ testGroup "enumFromThenTo"
     [ testCaseEnum "[min ..]" [minBound :: Baz ..]
         [BAZ1, BAZ2, BAZ3, BAZ4, BAZ5, BAZ6, BAZ7, BAZ8]
     , testCaseEnum "[3..5]" [BAZ3 .. BAZ5] [BAZ3, BAZ4, BAZ5]
@@ -131,7 +130,7 @@ testEnumFromThenTo = plusTestOptions testOptions $ testGroup "enumFromThenTo"
     ]
   where
     -- One second timeout in µs in case there's an infinite loop.
-    testOptions = mempty {topt_timeout = Just $ Just 1000000}
+    testOptions = mkTimeout 1000000
     testCaseEnum name actual expected =
         -- We limit the actual to 10 in case of accidental infinite sequences.
         -- Note that there are only 10 values, so this should happen rarely.

--- a/proto-lens-tests/tests/group_test.hs
+++ b/proto-lens-tests/tests/group_test.hs
@@ -13,7 +13,7 @@ import Data.Monoid ((<>))
 import Proto.Group
 import Proto.Group_Fields
 import Lens.Family2 ((&), (.~))
-import Test.Framework (testGroup)
+import Test.Tasty (testGroup)
 
 import Data.ProtoLens.TestUtil
 
@@ -26,7 +26,7 @@ main = testMain
            ]
 
 serializeSimple, deserializeEndMismatch, roundTripSimple,
-    roundTripComplicated :: Test
+    roundTripComplicated :: TestTree
 
 serializeSimple = serializeTo
     "serialize Simple"

--- a/proto-lens-tests/tests/imports_test.hs
+++ b/proto-lens-tests/tests/imports_test.hs
@@ -7,10 +7,10 @@ module Main where
 import Data.ProtoLens (Message, defMessage)
 import Data.ProtoLens.Labels ()
 import Lens.Family2 (Lens', view, set)
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 
-import Data.ProtoLens.TestUtil (Test, testMain)
+import Data.ProtoLens.TestUtil (TestTree, testMain)
 import qualified Proto.Enum as Enum
 import qualified Proto.Imports as Imports
 import qualified Proto.ImportsDep as ImportsDep
@@ -35,7 +35,7 @@ testField
     => Lens' a b -> IO ()
 testField f = defMessage @=? view f (set f defMessage defMessage)
 
-testFoo :: Test
+testFoo :: TestTree
 testFoo = testCase "testFoo" $ do
     testField @Imports.Foo @Nested.A #a
     testField @Imports.Foo @Nested.A'B #b
@@ -44,7 +44,7 @@ testFoo = testCase "testFoo" $ do
     Enum.BAR5 @=? view #bar (defMessage :: Imports.Foo)
     Enum.Foo'BAZ4 @=? view #baz (defMessage :: Imports.Foo)
 
-testUseDep :: Test
+testUseDep :: TestTree
 testUseDep = testCase "testUseDep" $ do
     testField @Imports.UseDep @ImportsDep.DepPkg #foo
     testField @Imports.UseDep @ImportsTransitive.TransitiveDep #bar
@@ -55,7 +55,7 @@ testUseDep = testCase "testUseDep" $ do
     testField @Imports.UseDep @ImportsDep.TransitiveDep2 #baz
     testField @Imports.UseDep @ImportsTransitive.TransitiveDep2 #baz
 
-testUseBootstrapped :: Test
+testUseBootstrapped :: TestTree
 testUseBootstrapped = testCase "testUseBootstrapped" $ do
     testField @Imports.UseBootstrapped @Descriptor.DescriptorProto #descriptor
     testField @Imports.UseBootstrapped @Plugin.CodeGeneratorRequest #request

--- a/proto-lens-tests/tests/labels_test.hs
+++ b/proto-lens-tests/tests/labels_test.hs
@@ -11,7 +11,7 @@ import Data.ProtoLens (build, defMessage)
 import Data.ProtoLens.Labels ()
 import Data.ProtoLens.TestUtil
 import Test.HUnit ((@?=))
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty.HUnit (testCase)
 
 main :: IO ()
 main = testMain

--- a/proto-lens-tests/tests/names_test.hs
+++ b/proto-lens-tests/tests/names_test.hs
@@ -16,8 +16,8 @@ import Data.ProtoLens (Message(defMessage))
 import Lens.Family2 (Lens', (&), view, set)
 import Prelude hiding (Maybe, maybe, map, head, span)
 import qualified Prelude
-import Test.Framework (Test, testGroup)
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 
 import Proto.Names
@@ -44,13 +44,13 @@ main = testMain
 
 testNames, testPreludeType, testHaskellKeywords, testProtoKeywords,
     testOddCasedMessage, testProtoKeywordTypes, testReadReservedName,
-    testMessageEnumOverlap :: Test
+    testMessageEnumOverlap :: TestTree
 
 -- | Test that we can get/set each individual field.
 testFields :: forall a . (Show a, Message a, Eq a)
            => String -> a
            -> [SomeLens a Int32]
-           -> Test
+           -> TestTree
 testFields name defValue fields = testGroup name
     [ testCase "fields" $ mapM_ testField fields
     , runTypedTest (roundTripTest "roundTrip" :: TypedTest a)

--- a/proto-lens-tests/tests/no_package_test.hs
+++ b/proto-lens-tests/tests/no_package_test.hs
@@ -4,17 +4,17 @@ module Main where
 
 import Data.ProtoLens
 import Lens.Family2 ((&), (.~), (^.))
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 
-import Data.ProtoLens.TestUtil (Test, testMain)
+import Data.ProtoLens.TestUtil (TestTree, testMain)
 import Proto.NoPackage
 import Proto.NoPackage_Fields
 
 main :: IO ()
 main = testMain [testNames]
 
-testNames :: Test
+testNames :: TestTree
 testNames = testCase "testNoPackage" $ do
     42 @=? (defMessage & c . a .~ 42 :: Foo) ^. c . a
     42 @=? (defMessage & d . e .~ 42 :: Foo) ^. d . e

--- a/proto-lens-tests/tests/oneof_test.hs
+++ b/proto-lens-tests/tests/oneof_test.hs
@@ -6,7 +6,7 @@ import Proto.Oneof_Fields
 import Data.ProtoLens
 import Data.ProtoLens.Prism (_Just, (#))
 import Lens.Family2 ((&), (.~), (^?), (%~), view)
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit
 
 import Data.ProtoLens.TestUtil

--- a/proto-lens-tests/tests/optional_test.hs
+++ b/proto-lens-tests/tests/optional_test.hs
@@ -10,8 +10,8 @@ import Proto.Optional
 import Proto.Optional_Fields
 import Data.ProtoLens
 import Lens.Family2 ((&), (.~), (^.))
-import Test.Framework (testGroup)
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty (testGroup)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 
 import Data.ProtoLens.TestUtil

--- a/proto-lens-tests/tests/package-deps_test.hs
+++ b/proto-lens-tests/tests/package-deps_test.hs
@@ -2,10 +2,10 @@ module Main where
 
 import Data.ProtoLens (defMessage)
 import Lens.Family2 ((&), (.~), (^.))
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 
-import Data.ProtoLens.TestUtil (Test, testMain)
+import Data.ProtoLens.TestUtil (TestTree, testMain)
 import Proto.PackageDeps (Bar)
 import Proto.PackageDeps_Fields (foo)
 import Proto.TestDep.Foo_Fields (value)
@@ -13,6 +13,6 @@ import Proto.TestDep.Foo_Fields (value)
 main :: IO ()
 main = testMain [testWrapper]
 
-testWrapper :: Test
+testWrapper :: TestTree
 testWrapper = testCase "testWrapper" $
     42 @=? (defMessage & foo . value .~ 42 :: Bar) ^. foo . value

--- a/proto-lens-tests/tests/proto3_test.hs
+++ b/proto-lens-tests/tests/proto3_test.hs
@@ -33,8 +33,8 @@ import Proto.Proto3_Fields
     , bytes
     , string
     )
-import Test.Framework (testGroup)
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty (testGroup)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?), assertBool)
 
 import Data.ProtoLens.TestUtil

--- a/proto-lens-tests/tests/raw_fields_test.hs
+++ b/proto-lens-tests/tests/raw_fields_test.hs
@@ -18,7 +18,7 @@ import Data.ProtoLens
 import Lens.Family2 (Lens', (&), (.~))
 import Data.Int (Int32, Int64)
 import Data.Word (Word32, Word64)
-import Test.Framework (testGroup)
+import Test.Tasty (testGroup)
 import qualified Data.ByteString as B
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -28,10 +28,10 @@ import Data.ByteString.Builder (Builder, byteString)
 
 import Data.ProtoLens.TestUtil
 
-readFails :: String -> LT.Text -> Test
+readFails :: String -> LT.Text -> TestTree
 readFails name = readFrom name (Nothing :: Maybe Raw)
 
-readSucceeds :: String -> Raw -> LT.Text -> Test
+readSucceeds :: String -> Raw -> LT.Text -> TestTree
 readSucceeds name value = readFrom name (Just value)
 
 main :: IO ()
@@ -59,16 +59,16 @@ main = testMain
 testInt32, testInt64, testUInt32, testUInt64, testSInt32, testSInt64,
     testFixed32, testFixed64, testSFixed32, testSFixed64, testFloat,
     testDouble, testBool, testString, testUnicode, testBytes,
-    testFailedDecoding :: Test
+    testFailedDecoding :: TestTree
 
 testRawValues :: String -> Lens' Raw a -> (a -> Doc)
-              -> (a -> Builder) -> [(String, a)] -> Test
+              -> (a -> Builder) -> [(String, a)] -> TestTree
 testRawValues groupName access showMsg encode values
     = testRawValuePairs groupName access showMsg encode
         [(name, x, x) | (name, x) <- values]
 
 testRawValuePairs :: String -> Lens' Raw a -> (a -> Doc)
-                  -> (b -> Builder) -> [(String, a, b)] -> Test
+                  -> (b -> Builder) -> [(String, a, b)] -> TestTree
 testRawValuePairs groupName access showMsg encode values
     = testGroup groupName
           [ serializeTo name (defMessage & access .~ x) (showMsg x)

--- a/proto-lens-tests/tests/repeated_test.hs
+++ b/proto-lens-tests/tests/repeated_test.hs
@@ -13,7 +13,7 @@ module Main where
 import Data.ByteString.Builder (byteString)
 import Data.Monoid ((<>))
 import Lens.Family2 (Lens', (&), (.~), view, set)
-import Test.Framework (testGroup)
+import Test.Tasty (testGroup)
 import Test.QuickCheck
 import qualified Data.Text as T
 import qualified Data.Vector.Generic as V
@@ -35,7 +35,7 @@ defBar = defMessage
 vectorTest ::
     forall a v b . (Eq a, Eq b, Show a, Show b, Message a, V.Vector v b)
     => String -> Gen b
-    -> Lens' a [b] -> Lens' a (v b) -> Test
+    -> Lens' a [b] -> Lens' a (v b) -> TestTree
 vectorTest name arbitraryElem listLens vecLens = testGroup name
     [ testProperty "get"
         $ \(ArbitraryMessage (m :: a)) ->

--- a/proto-lens-tests/tests/required_test.hs
+++ b/proto-lens-tests/tests/required_test.hs
@@ -13,7 +13,7 @@ import Data.Proxy (Proxy(..))
 import Lens.Family ((&), (.~))
 import Proto.Required (Foo, Bar)
 import Proto.Required_Fields (a, b)
-import Test.Framework (testGroup)
+import Test.Tasty (testGroup)
 
 import Data.ProtoLens.TestUtil
 
@@ -33,7 +33,7 @@ main = testMain
     ]
 
 empty, onlyRequired, onlyOptional, both,
-    multipleRequired :: Test
+    multipleRequired :: TestTree
 
 empty = testGroup "empty"
     [ deserializeFrom "wire" failedFoo mempty

--- a/proto-lens-tests/tests/service_test.hs
+++ b/proto-lens-tests/tests/service_test.hs
@@ -11,8 +11,8 @@ import Control.Monad (void)
 import Data.ProtoLens (defMessage)
 import Data.Proxy (Proxy (..))
 import Lens.Family2 (set)
-import Test.Framework (testGroup, Test)
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty (testGroup, TestTree)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 import Proto.Service
 import Data.ProtoLens.Service.Types
@@ -105,7 +105,7 @@ revMessagesMetadataTest
        ) => Proxy m
 revMessagesMetadataTest = Proxy
 
-testMethodOption :: Test
+testMethodOption :: TestTree
 testMethodOption = testGroup "methodOption"
     [ testCase "default" $
         defMessage

--- a/proto-lens-tests/tests/text_format_test.hs
+++ b/proto-lens-tests/tests/text_format_test.hs
@@ -20,7 +20,7 @@ import Data.Proxy (Proxy(..))
 import Lens.Family2 ((&), (.~))
 import Proto.TextFormat
 import Proto.TextFormat_Fields
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 import Text.PrettyPrint (renderStyle, style, lineLength)
 

--- a/proto-lens-tests/tests/unknown_fields_test.hs
+++ b/proto-lens-tests/tests/unknown_fields_test.hs
@@ -9,7 +9,7 @@ import Data.ProtoLens
 import qualified Data.ProtoLens.Encoding.Wire as Wire
 import qualified Data.Text.Lazy as LT
 import Lens.Family2 ((&), (.~))
-import Test.Framework.Providers.HUnit (testCase)
+import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 
 import Data.ProtoLens.TestUtil
@@ -24,7 +24,7 @@ main = testMain
     ]
 
 
-testPreserveUnknownFields :: Test
+testPreserveUnknownFields :: TestTree
 testPreserveUnknownFields =
     let sub = tagged 50 (VarInt 43) <> tagged 51 (Lengthy $ tagged 52 (Fixed32 44))
     in testUnknownSerialization
@@ -58,7 +58,7 @@ testPreserveUnknownFields =
               , tagged 100 $ VarInt 102
               ])
 
-testPreserveMismatchedFields :: Test
+testPreserveMismatchedFields :: TestTree
 testPreserveMismatchedFields =
     testUnknownSerialization
         "mismatched fields"
@@ -78,7 +78,7 @@ testPreserveMismatchedFields =
 
 
 -- TODO: The way that we display groups is somewhat hacky.
-testUnknownGroup :: Test
+testUnknownGroup :: TestTree
 testUnknownGroup =
     testUnknownSerialization "unknown group"
           ((defMessage :: Raw)
@@ -105,7 +105,7 @@ testUnknownGroup =
 
 testUnknownSerialization
     :: forall msg . (Eq msg, Show msg, Message msg)
-    => String -> msg -> Doc -> Builder -> Test
+    => String -> msg -> Doc -> Builder -> TestTree
 testUnknownSerialization name msg ts bs = testCase name $ do
     let bs' = toStrictByteString bs
     bs' @=? encodeMessage msg

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -59,8 +59,8 @@ tests:
     - bytestring
     - proto-lens
     - QuickCheck
-    - test-framework
-    - test-framework-quickcheck2
+    - tasty
+    - tasty-quickcheck
 
   growing_test:
     main: growing_test.hs
@@ -70,5 +70,5 @@ tests:
     - vector
     - proto-lens
     - QuickCheck
-    - test-framework
-    - test-framework-quickcheck2
+    - tasty
+    - tasty-quickcheck

--- a/proto-lens/tests/growing_test.hs
+++ b/proto-lens/tests/growing_test.hs
@@ -6,13 +6,13 @@ import Control.Monad.ST
 import Data.Foldable (foldlM)
 import qualified Data.Vector.Unboxed as V
 import Test.QuickCheck
-import Test.Framework (defaultMain)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
 
 import Data.ProtoLens.Encoding.Growing
 
 main :: IO ()
-main = defaultMain
+main = defaultMain $ testGroup "tests"
     [ testProperty "fromList" testFromList
     , testProperty "unchanged" testUnchanged
     ]

--- a/proto-lens/tests/parser_test.hs
+++ b/proto-lens/tests/parser_test.hs
@@ -6,14 +6,14 @@ import qualified Data.ByteString as B
 import Data.Either (isLeft)
 
 import Test.QuickCheck
-import Test.Framework (defaultMain, testGroup, Test)
-import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.Tasty (defaultMain, testGroup, TestTree)
+import Test.Tasty.QuickCheck (testProperty)
 
 import Data.ProtoLens.Encoding.Bytes
 import Data.ProtoLens.Encoding.Parser
 
 main :: IO ()
-main = defaultMain
+main = defaultMain $ testGroup "tests"
     [ testGroup "Parser" testParser
     , testGroup "getWord8" testGetWord8
     , testGroup "getBytes" testGetBytes
@@ -22,7 +22,7 @@ main = defaultMain
     , testGroup "isolate" testIsolate
     ]
 
-testParser :: [Test]
+testParser :: [TestTree]
 testParser =
     -- Test out the Applicative instance by using "traverse" to read the same number of bytes
     -- as in the input.
@@ -32,14 +32,14 @@ testParser =
                                     === Right ws
     ]
 
-testGetWord8 :: [Test]
+testGetWord8 :: [TestTree]
 testGetWord8 =
     [ testProperty "atEnd" $ \ws -> runParser atEnd (B.pack ws) === Right (null ws)
     , testProperty "manyTillEnd"
             $ \ws -> runParser (manyTillEnd getWord8) (B.pack ws) === Right ws
     ]
 
-testGetBytes :: [Test]
+testGetBytes :: [TestTree]
 testGetBytes =
     [ testProperty "many"
             $ \ws -> let
@@ -51,7 +51,7 @@ testGetBytes =
                                 (runParser (getBytes n) $ B.pack ws)
     ]
 
-testGetWord32le :: [Test]
+testGetWord32le :: [TestTree]
 testGetWord32le =
     [ testProperty "align"
         $ \ws -> length ws `mod` 4 /= 0 ==>
@@ -61,7 +61,7 @@ testGetWord32le =
                 === Right ws
     ]
 
-testFailure :: [Test]
+testFailure :: [TestTree]
 testFailure =
     [ testProperty "fail-fast" $ \bs ->
         runParser (fail "abcde") (B.pack bs)
@@ -71,7 +71,7 @@ testFailure =
             === (Left "fghij: abcde" :: Either String ())
     ]
 
-testIsolate :: [Test]
+testIsolate :: [TestTree]
 testIsolate =
     [ testProperty "many" $ \bs bs' ->
         runParser (liftA2 (,) (isolate (length bs) $ manyTillEnd getWord8)


### PR DESCRIPTION
test-framework isn't in Stackage nightly, in part due to
its dependency regex-posix not yet building with ghc-8.8.
test-framework also doesn't seem to be as actively developed
anymore.

Luckily, the translation was fairly mechanical.