### PR TITLE
Get proto-lens working with stack nightly (ghc-8.8, Cabal-3.0, etc).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
     addons: {apt: {packages: [libgmp-dev]}}
   - env: BUILD=stack STACK='stack'  # Use the resolver in stack.yaml
     addons: {apt: {packages: [libgmp-dev]}}
+  - env: BUILD=stack STACK='stack --stack-yaml=stack-nightly.yaml'
+    addons: {apt: {packages: [libgmp-dev]}}
 
 before_install:
   - mkdir -p $HOME/.local/bin

--- a/proto-lens-arbitrary/Changelog.md
+++ b/proto-lens-arbitrary/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Pending
 - Bump lower bounds to base-4.10 (ghc-8.2).
+- Support dependencies on base-4.13 (ghc-8.8) and lens-family-2.0.
 
 ## v0.1.2.7
 - Bump the dependency for `QuickCheck-2.13`.

--- a/proto-lens-arbitrary/package.yaml
+++ b/proto-lens-arbitrary/package.yaml
@@ -15,11 +15,11 @@ extra-source-files:
 
 dependencies:
   - proto-lens >= 0.4 && < 0.6
-  - base >= 4.10 && < 4.13
+  - base >= 4.10 && < 4.14
   - bytestring == 0.10.*
   - containers >= 0.5 && < 0.7
   - text == 1.2.*
-  - lens-family == 1.2.*
+  - lens-family >= 1.2 && < 2.1
   - QuickCheck >= 2.8 && < 2.14
 
 library:

--- a/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
+++ b/proto-lens-benchmarks/src/Data/ProtoLens/BenchmarkUtil.hs
@@ -4,6 +4,7 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 -- | A utility library for writing proto-lens benchmarks.
@@ -15,7 +16,9 @@ import qualified Criterion.Main.Options as Criterion
 import qualified Data.ByteString as BS
 import Data.Maybe (fromMaybe)
 import qualified Options.Applicative as Options
+#if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup ((<>))
+#endif
 
 import Data.ProtoLens (Message, encodeMessage, decodeMessageOrDie)
 -- | Generate a group of benchmarks for encoding and decoding the given proto

--- a/proto-lens-optparse/Changelog.md
+++ b/proto-lens-optparse/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Pending
 - Bump lower bounds to base-4.10 (ghc-8.2).
+- Support dependencies on base-4.13 (ghc-8.8) and optparse-applicative-0.15.
+
 
 ## v0.1.1.5
 - Bump the upper bound to `proto-lens-0.5.*`.

--- a/proto-lens-optparse/package.yaml
+++ b/proto-lens-optparse/package.yaml
@@ -16,8 +16,8 @@ extra-source-files:
 
 dependencies:
   - proto-lens >= 0.1 && < 0.6
-  - base >= 4.10 && < 4.13
-  - optparse-applicative >= 0.13 && < 0.15
+  - base >= 4.10 && < 4.14
+  - optparse-applicative >= 0.13 && < 0.16
   - text == 1.2.*
 
 library:

--- a/proto-lens-protobuf-types/Changelog.md
+++ b/proto-lens-protobuf-types/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Pending
 - Bump lower bounds to base-4.10 (ghc-8.2).
+- Support dependencies on base-4.13 (ghc-8.8) and lens-family-2.0.
 
 ## v0.5.0.0
 - Bump upper bounds to support `proto-lens-0.5.*`.

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -20,13 +20,13 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.10 && < 4.13
+    - base >= 4.10 && < 4.14
     - Cabal
     - proto-lens-setup == 0.4.*
 
 dependencies:
-  - base >= 4.10 && < 4.13
-  - lens-family == 1.2.*
+  - base >= 4.10 && < 4.14
+  - lens-family >= 1.2 && < 2.1
   - proto-lens == 0.5.*
   - proto-lens-runtime == 0.5.*
   - text == 1.2.*

--- a/proto-lens-protobuf-types/src/Data/ProtoLens/Any.hs
+++ b/proto-lens-protobuf-types/src/Data/ProtoLens/Any.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -11,7 +12,9 @@ module Data.ProtoLens.Any
     ) where
 
 import Control.Exception (Exception(..))
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import qualified Data.Text as Text
 import Data.Text (Text)
 import Data.Typeable (Typeable)

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -14,6 +14,7 @@
 ### Backwards-Compatible Changes
 - Fix a potential naming conflict when message types and enum values
   are the same except for case.
+- Support dependencies on base-4.13 (ghc-8.8) and lens-family-2.0.
 
 ## v0.5.0.0
 

--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -4,6 +4,7 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -11,7 +12,9 @@ module Main where
 
 import qualified Data.ByteString as B
 import Data.Map.Strict ((!))
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import Data.Text (Text, pack)

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -17,14 +17,14 @@ extra-source-files:
   - Changelog.md
 
 dependencies:
-  - base >= 4.10 && < 4.13
+  - base >= 4.10 && < 4.14
   - bytestring == 0.10.*
   - containers >= 0.5 && < 0.7
-  - lens-family == 1.2.*
+  - lens-family >= 1.2 && < 2.1
   - proto-lens == 0.5.*
   - text == 1.2.*
   - ghc-source-gen == 0.2.*
-  - ghc >= 8.2 && < 8.8
+  - ghc >= 8.2 && < 8.10
 
 
 library:

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -6,6 +6,7 @@
 
 -- | This module builds the actual, generated Haskell file
 -- for a given input .proto file.
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -22,7 +23,9 @@ import qualified Data.Foldable as F
 import qualified Data.List as List
 import qualified Data.Map as Map
 import Data.Maybe (isJust)
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import Data.Ord (comparing)
 import Data.ProtoLens (encodeMessage)
 import qualified Data.Set as Set

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Encoding.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate/Encoding.hs
@@ -1,6 +1,7 @@
 -- | This module generates code for decoding and encoding protocol buffer messages.
 --
 -- Upstream docs: <https://developers.google.com/protocol-buffers/docs/encoding>
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
@@ -13,7 +14,9 @@ module Data.ProtoLens.Compiler.Generate.Encoding
 
 import Data.Int (Int32)
 import qualified Data.Map as Map
+#if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup ((<>))
+#endif
 import qualified Data.Text as Text
 import Lens.Family2 (view, (^.))
 import GHC.SourceGen

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Plugin.hs
@@ -6,6 +6,7 @@
 --
 -- Code for writing protocol compiler plugins.
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Data.ProtoLens.Compiler.Plugin
@@ -22,7 +23,9 @@ import Data.Char (toUpper)
 import Data.List (foldl', intercalate)
 import qualified Data.Map.Strict as Map
 import Data.Map.Strict (Map, unions, (!))
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import Data.String (fromString)
 import qualified Data.Text as T
 import Data.Text (Text)

--- a/proto-lens-runtime/Changelog.md
+++ b/proto-lens-runtime/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Pending
 - Bump lower bounds to base-4.10 (ghc-8.2).
+- Support dependencies on base-4.13 (ghc-8.8) and lens-family-2.0.
 
 ## v0.5.0.0
 - Export more modules from proto-lens, to support generated encoding/decoding

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -16,12 +16,12 @@ extra-source-files:
 
 library:
   dependencies:
-    - base >= 4.10 && < 4.13
+    - base >= 4.10 && < 4.14
     - bytestring == 0.10.*
     - containers >= 0.5 && < 0.7
     - deepseq == 1.4.*
     - filepath >= 1.4 && < 1.6
-    - lens-family == 1.2.*
+    - lens-family >= 1.2 && < 2.1
     - proto-lens == 0.5.*
     - text == 1.2.*
     - vector >= 0.11 && < 0.13

--- a/proto-lens-setup/Changelog.md
+++ b/proto-lens-setup/Changelog.md
@@ -2,6 +2,7 @@
 
 ## Pending
 - Bump lower bounds to base-4.10 (ghc-8.2) and Cabal-2.0.
+- Support dependencies on base-4.13 (ghc-8.8) and Cabal-3.0.
 
 ## v0.4.0.2
 - Bump upper bounds to support `proto-lens-0.5.*`.

--- a/proto-lens-setup/package.yaml
+++ b/proto-lens-setup/package.yaml
@@ -50,10 +50,10 @@ extra-source-files:
 library:
   source-dirs: src
   dependencies:
-    - base >= 4.10 && < 4.13
+    - base >= 4.10 && < 4.14
     - bytestring == 0.10.*
     - containers >= 0.5 && < 0.7
-    - Cabal >= 2.0 && < 2.5
+    - Cabal >= 2.0 && < 3.1
     - deepseq == 1.4.*
     - directory >= 1.2 && < 1.4
     - filepath >= 1.4 && < 1.6

--- a/proto-lens-setup/src/Data/ProtoLens/Setup.hs
+++ b/proto-lens-setup/src/Data/ProtoLens/Setup.hs
@@ -60,6 +60,9 @@ import Distribution.Simple.LocalBuildInfo
     , componentPackageDeps
     , allComponentsInBuildOrder
     , componentNameMap
+#if MIN_VERSION_Cabal(3,0,0)
+    , LibraryName(..)
+#endif
     )
 import qualified Distribution.Simple.PackageIndex as PackageIndex
 import Distribution.Simple.Setup (fromFlag, copyDest, copyVerbosity)
@@ -375,7 +378,12 @@ collectActiveModules
 collectActiveModules l = map (\(n, c) -> (c, f n)) $ Map.toList $ allComponents l
   where
     p = localPkgDescr l
-    f CLibName = maybeToList (library p) >>=
+#if MIN_VERSION_Cabal(3,0,0)
+    f (CLibName LMainLibName)
+#else
+    f CLibName
+#endif
+        = maybeToList (library p) >>=
                     \lib -> exposedModules lib
                                 ++ otherModules (libBuildInfo lib)
     f (CExeName n) = otherModules . buildInfo $ exes Map.! n

--- a/proto-lens-tests/src/Data/ProtoLens/TestUtil.hs
+++ b/proto-lens-tests/src/Data/ProtoLens/TestUtil.hs
@@ -34,6 +34,9 @@ module Data.ProtoLens.TestUtil(
     PrettyPrint.vcat,
     (PrettyPrint.$+$),
     satisfies,
+    -- TODO: remove this after we drop support for base-4.10 (ghc-8.2),
+    -- which didn't export (<>) from Prelude.
+    (<>)
     ) where
 
 import Data.ProtoLens
@@ -57,7 +60,9 @@ import Test.HUnit ((@=?), assertBool, assertFailure)
 import Data.Either (isLeft)
 import Data.Bits (shiftL, shiftR, (.|.), (.&.))
 import qualified Data.Text.Lazy as TL
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import Data.Word (Word32, Word64)
 import qualified Text.PrettyPrint as PrettyPrint
 import Text.PrettyPrint

--- a/proto-lens-tests/tests/group_test.hs
+++ b/proto-lens-tests/tests/group_test.hs
@@ -9,7 +9,6 @@
 module Main where
 
 import Data.ProtoLens
-import Data.Monoid ((<>))
 import Proto.Group
 import Proto.Group_Fields
 import Lens.Family2 ((&), (.~))

--- a/proto-lens-tests/tests/map_test.hs
+++ b/proto-lens-tests/tests/map_test.hs
@@ -14,7 +14,6 @@ import Data.ProtoLens
 import Lens.Family2 ((&), (.~))
 import qualified Data.ByteString.Char8 as C
 import Data.ByteString.Builder (Builder, byteString)
-import Data.Monoid ((<>))
 import Data.Word (Word64)
 
 import Data.ProtoLens.TestUtil

--- a/proto-lens-tests/tests/proto3_test.hs
+++ b/proto-lens-tests/tests/proto3_test.hs
@@ -10,7 +10,6 @@ module Main where
 import Data.ProtoLens
 import Lens.Family2 ((&), (.~), (^.))
 import qualified Data.ByteString.Builder as Builder
-import Data.Monoid ((<>))
 import Proto.Proto3
     ( Foo
     , Foo'FooEnum(..)

--- a/proto-lens-tests/tests/repeated_test.hs
+++ b/proto-lens-tests/tests/repeated_test.hs
@@ -11,7 +11,6 @@
 module Main where
 
 import Data.ByteString.Builder (byteString)
-import Data.Monoid ((<>))
 import Lens.Family2 (Lens', (&), (.~), view, set)
 import Test.Tasty (testGroup)
 import Test.QuickCheck

--- a/proto-lens-tests/tests/required_test.hs
+++ b/proto-lens-tests/tests/required_test.hs
@@ -4,10 +4,13 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Data.Monoid ((<>), mempty)
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import Data.ProtoLens (defMessage)
 import Data.Proxy (Proxy(..))
 import Lens.Family ((&), (.~))

--- a/proto-lens-tests/tests/text_format_test.hs
+++ b/proto-lens-tests/tests/text_format_test.hs
@@ -10,7 +10,6 @@ module Main where
 
 import qualified Data.ByteString
 import Data.Char (ord)
-import Data.Monoid ((<>))
 import qualified Data.Text.Lazy
 import qualified Data.ProtoLens.Any as Any
 import Data.ProtoLens (

--- a/proto-lens-tests/tests/unknown_fields_test.hs
+++ b/proto-lens-tests/tests/unknown_fields_test.hs
@@ -4,7 +4,6 @@ module Main (main) where
 
 import Data.ByteString.Builder (Builder)
 import Data.Either (isLeft)
-import Data.Monoid ((<>))
 import Data.ProtoLens
 import qualified Data.ProtoLens.Encoding.Wire as Wire
 import qualified Data.Text.Lazy as LT

--- a/proto-lens-tutorial/stack-nightly.yaml
+++ b/proto-lens-tutorial/stack-nightly.yaml
@@ -1,0 +1,16 @@
+resolver: nightly-2019-09-28
+packages:
+- person
+- coffee-order
+
+- extra-dep: true
+  location:
+    '..'
+  subdirs:
+    - proto-lens
+    - proto-lens-protoc
+    - proto-lens-runtime
+    - proto-lens-setup
+
+extra-deps:
+- ghc-source-gen-0.2.0.1

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -8,6 +8,7 @@
 
 ### Backwards-Compatible Changes
 - Bump upper bound to allo profunctors-5.5.
+- Support dependencies on base-4.13 (ghc-8.8) and lens-family-2.0.
 
 ## v0.5.1.0
 - Add `decodeMessageDelimitedH` to decode delimited messages from a file handle

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -34,12 +34,12 @@ library:
     - Data.ProtoLens.Encoding.Parser.Internal
     - Data.ProtoLens.TextFormat.Parser
   dependencies:
-    - base >= 4.10 && < 4.13
+    - base >= 4.10 && < 4.14
     - bytestring == 0.10.*
     - containers >= 0.5 && < 0.7
     - deepseq == 1.4.*
     - ghc-prim >= 0.4 && < 0.6
-    - lens-family == 1.2.*
+    - lens-family >= 1.2 && < 2.1
     - parsec == 3.1.*
     - pretty == 1.1.*
     - primitive >= 0.6 && < 0.8

--- a/proto-lens/src/Data/ProtoLens/Encoding.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Data.ProtoLens.Encoding (
     encodeMessage,
     buildMessage,
@@ -19,7 +20,9 @@ import qualified Data.ProtoLens.Encoding.Bytes as Bytes
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except (runExceptT, ExceptT(..))
 import qualified Data.ByteString as B
+#if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup ((<>))
+#endif
 
 -- | Decode a message from its wire format.  Returns 'Left' if the decoding
 -- fails.

--- a/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
@@ -55,7 +55,9 @@ import Data.ByteString.Lazy.Builder as Builder
 import qualified Data.ByteString.Builder.Internal as Internal
 import qualified Data.ByteString.Lazy as L
 import Data.Int (Int32, Int64)
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import qualified Data.Vector.Generic as V
 import Data.Word (Word8, Word32, Word64)
 import Foreign.Marshal (malloc, free)

--- a/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
@@ -5,6 +5,7 @@
 -- Upstream docs:
 -- <https://developers.google.com/protocol-buffers/docs/encoding#structure>
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Data.ProtoLens.Encoding.Wire
     ( Tag(..)
@@ -21,7 +22,9 @@ module Data.ProtoLens.Encoding.Wire
 import Control.DeepSeq (NFData(..))
 import Data.Bits ((.&.), (.|.), shiftL, shiftR)
 import qualified Data.ByteString as B
+#if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup ((<>))
+#endif
 import Data.Word (Word8, Word32, Word64)
 
 import Data.ProtoLens.Encoding.Bytes

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,0 +1,17 @@
+resolver: nightly-2019-09-28
+packages:
+- proto-lens
+- proto-lens-arbitrary
+- proto-lens-benchmarks
+- proto-lens-optparse
+- proto-lens-protobuf-types
+- proto-lens-protoc
+- proto-lens-runtime
+- proto-lens-setup
+- proto-lens-tests
+- proto-lens-tests-dep
+extra-deps:
+- ghc-source-gen-0.2.0.1
+
+ghc-options:
+  "$locals": -Wall -Werror


### PR DESCRIPTION
Other packages that were trivial to extend bounds for:
- optparse-applicative-0.15
- lens-family-2.0

I had to replace imports like

    import Data.Semigroup ((<>))

with

    #if !MIN_VERSION_ghc(4,11,0)
    import Data.Semigroup ((<>))
    #endi

`(<>)` was in base-4.11, but previously GHC didn't warn about the unconditional import.  In ghc-8.8 it does, so we need to wrap it in CPP
until we drop support for ghc-8.2 (probably next year).