### PR TITLE
Revert #331 and remove `methodOptions`.

### DIFF
--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -5,7 +5,6 @@
 ### Breaking Changes
 - Reexport transitive definitions from modules generated for `.proto` files
   with `import public` statements (#329).
-- Add `methodOptions` to `HasMethodImpl` to provide custom method options.
 - Bump lower bounds to base-4.10 (ghc-8.2).
 - Use `ghc-source-gen` instead of `haskell-src-exts`.  Removes
   `Data.ProtoLens.Compiler.Combinators` and adds

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -17,8 +17,7 @@ extra-source-files:
   - Changelog.md
 
 dependencies:
-  - base >= 4.10 && < 4.14
-  - bytestring == 0.10.*
+  - base >= 4.9 && < 4.14
   - containers >= 0.5 && < 0.7
   - lens-family >= 1.2 && < 2.1
   - proto-lens == 0.5.*
@@ -44,4 +43,5 @@ executables:
     source-dirs: app
     dependencies:
       - ghc-paths == 0.1.*
+      - bytestring == 0.10.*
       - proto-lens-protoc

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Definitions.hs
@@ -72,7 +72,6 @@ import Proto.Google.Protobuf.Descriptor
     , FieldDescriptorProto'Type(..)
     , FileDescriptorProto
     , MethodDescriptorProto
-    , MethodOptions
     , ServiceDescriptorProto
     )
 import GHC.SourceGen
@@ -137,7 +136,6 @@ data MethodInfo = MethodInfo
     , methodOutput :: Text
     , methodClientStreaming :: Bool
     , methodServerStreaming :: Bool
-    , methodOptions :: MethodOptions
     }
 
 -- | Information about a single field of a proto message,
@@ -330,7 +328,6 @@ collectServices fd = fmap (toServiceInfo $ fd ^. #package) $ fd ^. #service
             , methodOutput = fromString . T.unpack $ md ^. #outputType
             , methodClientStreaming = md ^. #clientStreaming
             , methodServerStreaming = md ^. #serverStreaming
-            , methodOptions = md ^. #options
             }
 
 messageAndEnumDefs ::

--- a/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/src/Data/ProtoLens/Compiler/Generate.hs
@@ -18,7 +18,6 @@ module Data.ProtoLens.Compiler.Generate(
 
 
 import Control.Arrow (second)
-import qualified Data.ByteString.Char8 as B
 import qualified Data.Foldable as F
 import qualified Data.List as List
 import qualified Data.Map as Map
@@ -27,7 +26,6 @@ import Data.Maybe (isJust)
 import Data.Semigroup ((<>))
 #endif
 import Data.Ord (comparing)
-import Data.ProtoLens (encodeMessage)
 import qualified Data.Set as Set
 import Data.String (fromString)
 import Data.Text (unpack)
@@ -247,12 +245,6 @@ generateServiceDecls env si =
                      (True,  False) -> "Data.ProtoLens.Service.Types.ClientStreaming"
                      (False, True)  -> "Data.ProtoLens.Service.Types.ServerStreaming"
                      (True,  True)  -> "Data.ProtoLens.Service.Types.BiDiStreaming"
-        -- methodOptions _ _ = decodeMessageOrDie (pack "...")
-        -- (where "..." is the encoded version of the proto message).
-        , funBind "methodOptions" $ match [wildP, wildP]
-            $ var "Data.ProtoLens.decodeMessageOrDie"
-                  @@ (var "Data.ByteString.Char8.pack"
-                        @@ string (B.unpack $ encodeMessage $ methodOptions m))
         ]
     | m <- serviceMethods si
     , let instanceHead = stringTy (T.unpack $ methodIdent m)

--- a/proto-lens-tests/tests/service.proto
+++ b/proto-lens-tests/tests/service.proto
@@ -17,9 +17,5 @@ service TestService {
   rpc ClientStreaming (stream Foo) returns (Bar);
   rpc ServerStreaming (Foo)        returns (stream Bar);
   rpc BiDiStreaming   (stream Foo) returns (stream Bar);
-  // Test that we pass method options through the API:
-  rpc Deprecated      (Foo)        returns (Bar) {
-    option deprecated = true;
-  }
 }
 

--- a/proto-lens-tests/tests/service_test.hs
+++ b/proto-lens-tests/tests/service_test.hs
@@ -8,16 +8,11 @@ module Main (main) where
 
 import Control.Exception (evaluate)
 import Control.Monad (void)
-import Data.ProtoLens (defMessage)
 import Data.Proxy (Proxy (..))
-import Lens.Family2 (set)
-import Test.Tasty (testGroup, TestTree)
 import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
 import Proto.Service
 import Data.ProtoLens.Service.Types
 import Data.ProtoLens.TestUtil (testMain)
-import Proto.Google.Protobuf.Descriptor_Fields (deprecated)
 
 
 main :: IO ()
@@ -31,7 +26,6 @@ main = testMain
         void $ evaluate serverStreamingMethodMetadataTest
         void $ evaluate bidiStreamingMethodMetadataTest
         void $ evaluate revMessagesMetadataTest
-    , testMethodOption
     ]
 
 
@@ -42,7 +36,6 @@ serviceMetadataTest
        -- proto-lens generates this list in alphabetical order.
        , ServiceMethods s ~ '[ "biDiStreaming"
                              , "clientStreaming"
-                             , "deprecated"
                              , "normal"
                              , "revMessages"
                              , "serverStreaming"
@@ -104,14 +97,4 @@ revMessagesMetadataTest
        , MethodStreamingType s m ~ 'NonStreaming
        ) => Proxy m
 revMessagesMetadataTest = Proxy
-
-testMethodOption :: TestTree
-testMethodOption = testGroup "methodOption"
-    [ testCase "default" $
-        defMessage
-            @=? methodOptions TestService (Proxy :: Proxy "normal")
-    , testCase "deprecated" $
-        set deprecated True defMessage
-            @=? methodOptions TestService (Proxy :: Proxy "deprecated")
-    ]
 

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -3,7 +3,6 @@
 ## Pending
 
 ### Breaking Changes
-- Add `methodOptions` to `HasMethodImpl` to provide custom method options.
 - Bump lower bounds to base-4.10 (ghc-8.2).
 
 ### Backwards-Compatible Changes

--- a/proto-lens/src/Data/ProtoLens/Service/Types.hs
+++ b/proto-lens/src/Data/ProtoLens/Service/Types.hs
@@ -25,9 +25,7 @@ module Data.ProtoLens.Service.Types
 
 import Data.Kind (Constraint)
 import Data.ProtoLens.Message (Message)
-import {-# SOURCE #-} Proto.Google.Protobuf.Descriptor (MethodOptions)
 import GHC.TypeLits
-import Data.Proxy (Proxy)
 
 
 -- | Reifies the fact that there is a 'HasMethod' instance for every symbol
@@ -87,7 +85,6 @@ class ( KnownSymbol m
   type MethodInput         s m :: *
   type MethodOutput        s m :: *
   type MethodStreamingType s m :: StreamingType
-  methodOptions :: s -> Proxy m -> MethodOptions
 
 
 -- | Helper constraint that expands to a user-friendly error message when 'm'

--- a/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs-boot
+++ b/proto-lens/src/Proto/Google/Protobuf/Descriptor.hs-boot
@@ -1,3 +1,0 @@
-module Proto.Google.Protobuf.Descriptor where
-
-data MethodOptions


### PR DESCRIPTION
We're not using it currently.  Also, the existing approach
doesn't work well with our internal Blaze rules.  If we still
want this long-term, we can revisit it after fixing #334.