### PR TITLE
Bump the ghc-source-gen dependency to 0.3.0.0.

### DIFF
--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -22,7 +22,7 @@ dependencies:
   - lens-family >= 1.2 && < 2.1
   - proto-lens == 0.5.*
   - text == 1.2.*
-  - ghc-source-gen == 0.2.*
+  - ghc-source-gen == 0.3.*
   - ghc >= 8.2 && < 8.10
 
 

--- a/proto-lens-tutorial/stack-ghc-8.6.yaml
+++ b/proto-lens-tutorial/stack-ghc-8.6.yaml
@@ -1,1 +1,0 @@
-stack.yaml

--- a/proto-lens-tutorial/stack-nightly.yaml
+++ b/proto-lens-tutorial/stack-nightly.yaml
@@ -13,4 +13,4 @@ packages:
     - proto-lens-setup
 
 extra-deps:
-- ghc-source-gen-0.2.0.1
+- ghc-source-gen-0.3.0.0

--- a/proto-lens-tutorial/stack.yaml
+++ b/proto-lens-tutorial/stack.yaml
@@ -13,4 +13,4 @@ packages:
     - proto-lens-setup
 
 extra-deps:
-- ghc-source-gen-0.2.0.1
+- ghc-source-gen-0.3.0.0

--- a/stack-bootstrap.yaml
+++ b/stack-bootstrap.yaml
@@ -6,7 +6,7 @@ packages:
 # Build the current HEAD proto-lens-protoc against older revisions of proto-lens
 # and proto-lens-descriptors that are consistent with each other.
 extra-deps:
-- ghc-source-gen-0.2.0.1
+- ghc-source-gen-0.3.0.0
 - git: https://github.com/google/proto-lens
   # To use the current repository:
   # git: ../..  # stack runs 'git clone' in a subdirectory

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -11,7 +11,7 @@ packages:
 - proto-lens-tests
 - proto-lens-tests-dep
 extra-deps:
-- ghc-source-gen-0.2.0.1
+- ghc-source-gen-0.3.0.0
 
 ghc-options:
   "$locals": -Wall -Werror

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,7 +13,7 @@ packages:
 - proto-lens-tests
 - proto-lens-tests-dep
 extra-deps:
-- ghc-source-gen-0.2.0.1
+- ghc-source-gen-0.3.0.0
 - discrimination-0.4
 - promises-0.3
 - primitive-0.6.4.0  # For discrimination-0.4 on older LTSes


### PR DESCRIPTION
We need it for RPCs with a single method, which require
google/ghc-source-gen#55.

Also remove an old stack-ghc-8.6.yaml file that isn't used anymore.