### PR TITLE
Support cabal new-build, and add a Travis case.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
     addons: {apt: {packages: [cabal-install-2.2, ghc-8.4.4], sources: [hvr-ghc]}}
   - env: BUILD=cabal GHCVER=8.6.5 CABALVER=2.4
     addons: {apt: {packages: [cabal-install-2.4, ghc-8.6.5], sources: [hvr-ghc]}}
+  # TODO: switch everything to cabal new-build
+  - env: BUILD=cabal-new GHCVER=8.6.5 CABALVER=2.4
+    addons: {apt: {packages: [cabal-install-2.4, ghc-8.6.5], sources: [hvr-ghc]}}
   - env: BUILD=stack STACK='stack --resolver=lts-11.22'
     addons: {apt: {packages: [libgmp-dev]}}
   - env: BUILD=stack STACK='stack --resolver=lts-12.26'
@@ -35,6 +38,8 @@ before_install:
       stack)
         export PATH=/opt/ghc/$GHCVER/bin:$HOME/.local/bin:$PATH;;
       cabal)
+        export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$HOME/.cabal/bin:$PATH;;
+      cabal-new)
         export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$HOME/.cabal/bin:$PATH;;
     esac
   - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'
@@ -66,4 +71,6 @@ script:
         (cd proto-lens-tutorial && $STACK build "${STACK_ARGS[@]}");;
       cabal)
         ./travis-cabal.sh;;
+      cabal-new)
+        ./travis-cabal-new.sh;;
     esac

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ First, edit the `.cabal` file of your project to:
 
 * Specify `build-type: Custom`, and add a `custom-setup` clause that
   depends on `proto-lens-setup`.
+* Add `build-tool-depends: proto-lens-protoc:proto-lens-protoc`.
 * List the .proto files in `extra-source-files`.  Note that the field belongs
   at the top level of the `.cabal` file, rather than once per
   library/executable/etc.
@@ -60,6 +61,7 @@ For example, in `foo-bar-proto.cabal`:
     ...
     custom-setup
       setup-depends: base, Cabal, proto-lens-setup
+      build-tools-depends: proto-lens-protoc:proto-lens-protoc
 
     library
         exposed-modules: Proto.Foo.Bar, Proto.Foo.Bar_Fields

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,13 @@
+packages:
+  discrimination-ieee754
+  proto-lens
+  proto-lens-arbitrary
+  proto-lens-benchmarks
+  proto-lens-discrimination
+  proto-lens-optparse
+  proto-lens-protobuf-types
+  proto-lens-protoc
+  proto-lens-runtime
+  proto-lens-setup
+  proto-lens-tests
+  proto-lens-tests-dep

--- a/proto-lens-discrimination/package.yaml
+++ b/proto-lens-discrimination/package.yaml
@@ -19,6 +19,8 @@ custom-setup:
     - Cabal
     - proto-lens-setup >= 0.4 && < 0.5
 
+build-tools: proto-lens-protoc:proto-lens-protoc
+
 dependencies:
   - base >= 4.10 && < 4.13
   - bytestring == 0.10.*

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -24,6 +24,8 @@ custom-setup:
     - Cabal
     - proto-lens-setup == 0.4.*
 
+build-tools: proto-lens-protoc:proto-lens-protoc
+
 dependencies:
   - base >= 4.10 && < 4.14
   - lens-family >= 1.2 && < 2.1

--- a/proto-lens-tests-dep/package.yaml
+++ b/proto-lens-tests-dep/package.yaml
@@ -24,6 +24,8 @@ custom-setup:
     - Cabal
     - proto-lens-setup
 
+build-tools: proto-lens-protoc:proto-lens-protoc
+
 dependencies:
   - proto-lens-runtime
   - base

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -19,6 +19,8 @@ custom-setup:
     - Cabal
     - proto-lens-setup
 
+build-tools: proto-lens-protoc:proto-lens-protoc
+
 # Dependencies shared by the library and/or several of the tests:
 dependencies:
     - HUnit
@@ -40,6 +42,8 @@ library:
   source-dirs: src
   exposed-modules:
     - Data.ProtoLens.TestUtil
+
+  generated-exposed-modules:
     - Proto.Lib
 
 tests:
@@ -49,7 +53,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Canonical
       - Proto.Canonical_Fields
 
@@ -58,7 +62,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Group
       - Proto.Group_Fields
 
@@ -67,7 +71,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Map
       - Proto.Map_Fields
 
@@ -76,7 +80,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Oneof
       - Proto.Oneof_Fields
 
@@ -85,7 +89,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Optional
       - Proto.Optional_Fields
 
@@ -94,7 +98,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Proto3
       - Proto.Proto3_Fields
 
@@ -104,7 +108,7 @@ tests:
     dependencies:
       - proto-lens-tests
       - vector
-    other-modules:
+    generated-other-modules:
       - Proto.Repeated
       - Proto.Repeated_Fields
 
@@ -114,7 +118,7 @@ tests:
     dependencies:
       - proto-lens-protobuf-types
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.TextFormat
       - Proto.TextFormat_Fields
 
@@ -129,7 +133,7 @@ tests:
       - -Werror
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Enum
       - Proto.Enum_Fields
 
@@ -138,7 +142,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Names
       - Proto.Names_Fields
 
@@ -147,7 +151,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.NoPackage
       - Proto.NoPackage_Fields
 
@@ -156,7 +160,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Packed
       - Proto.Packed_Fields
 
@@ -165,7 +169,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.RawFields
       - Proto.RawFields_Fields
 
@@ -175,7 +179,7 @@ tests:
     dependencies:
       - lens-family-core
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Required
       - Proto.Required_Fields
 
@@ -185,7 +189,7 @@ tests:
     dependencies:
       - lens-family-core
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Canonical
       - Proto.Canonical_Fields
 
@@ -195,7 +199,7 @@ tests:
     dependencies:
       - proto-lens-tests
       - proto-lens-tests-dep
-    other-modules:
+    generated-other-modules:
       - Proto.PackageDeps
       - Proto.PackageDeps_Fields
 
@@ -205,7 +209,7 @@ tests:
     dependencies:
       - proto-lens-protobuf-types
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Any
       - Proto.Any_Fields
 
@@ -216,7 +220,7 @@ tests:
       - proto-lens-protobuf-types
       - proto-lens-tests
       - temporary
-    other-modules:
+    generated-other-modules:
       - Proto.DecodeDelimited
       - Proto.DecodeDelimited_Fields
 
@@ -231,7 +235,7 @@ tests:
     dependencies:
       - proto-lens-protobuf-types
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Service
       - Proto.Service_Fields
 
@@ -240,7 +244,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.UnknownFields
       - Proto.UnknownFields_Fields
 
@@ -249,7 +253,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Empty
       - Proto.Enum
       - Proto.Imports
@@ -263,7 +267,7 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Pathological
 
   dependent_test:
@@ -271,12 +275,12 @@ tests:
     source-dirs: tests
     dependencies:
       - proto-lens-tests
-    other-modules:
+    generated-other-modules:
       - Proto.Dependent
 
   combinators_test:
     main: combinators_test.hs
     source-dirs: tests
-    other-modules:
+    generated-other-modules:
       Proto.Combinators
       Proto.Combinators_Fields

--- a/proto-lens-tutorial/coffee-order/package.yaml
+++ b/proto-lens-tutorial/coffee-order/package.yaml
@@ -16,6 +16,8 @@ custom-setup:
     - Cabal
     - proto-lens-setup
 
+build-tools: proto-lens-protoc:proto-lens-protoc
+
 dependencies:
   - base >= 4.7 && < 5
   - microlens

--- a/proto-lens-tutorial/person/package.yaml
+++ b/proto-lens-tutorial/person/package.yaml
@@ -6,6 +6,8 @@ custom-setup:
     - Cabal
     - proto-lens-setup
 
+build-tools: proto-lens-protoc:proto-lens-protoc
+
 extra-source-files: proto/**/*.proto
 
 library:

--- a/travis-cabal-new.sh
+++ b/travis-cabal-new.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# A script for running Cabal new-build on this project.
+
+set -euo pipefail
+set -x
+
+echo Installing hpack
+curl -L https://github.com/sol/hpack/releases/download/0.31.2/hpack_linux.gz \
+  | gunzip > $HOME/.local/bin/hpack
+chmod +x $HOME/.local/bin/hpack
+
+# Work around #354: With new-build we don't include .proto files from
+# dependencies in the same project.
+# For now, just copy the files in directly.
+cp -Rv proto-lens-tests-dep/protos/* proto-lens-tests/tests/
+
+for p in */package.yaml
+do
+  hpack $p
+done
+
+cabal new-update
+cabal new-test all

--- a/travis-cabal.sh
+++ b/travis-cabal.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 set -x
 
 echo Installing hpack
-curl -L https://github.com/sol/hpack/releases/download/0.28.2/hpack_linux.gz \
+curl -L https://github.com/sol/hpack/releases/download/0.31.2/hpack_linux.gz \
   | gunzip > $HOME/.local/bin/hpack
 chmod +x $HOME/.local/bin/hpack
 


### PR DESCRIPTION
- Make all the .cabal files explicitly declare
  `build-tool-depends: proto-lens-protoc:proto-lens-protoc`.
  Also bump hpack to support that syntax.
- Use `generated-exposed-modules` and `generated-other-modules`
  consistently.

For now, Travis just has a single case (8.6.5).  Switching
completely is be blocked on #354 (including .protos from deps).