### PR TITLE
Move descriptor/plugin bindings to proto-lens-protobuf-types.

### DIFF
--- a/bootstrap.hs
+++ b/bootstrap.hs
@@ -15,24 +15,38 @@ import System.Process (callProcess, readProcess)
 
 protoRoot = "google/protobuf/src"
 protoc = "protoc"
-bootstrapModuleRoot = "proto-lens/src"
+bootstrapModuleRoot = "proto-lens-protoc/app"
 useBootstrappingYaml = "--stack-yaml=stack-bootstrap.yaml"
 
+-- Change this to build with an older version of stack.
+-- TODO: remove this after we can use stack v2 (#332).
+stack = "stack"
+
+-- This should match (or at least be API-compatible with) the value of bootstrapCommit
+-- in stack-bootstrap.yaml.
+bootstrapCommit = "master"
+
 main = do
-  callProcess "stack" [useBootstrappingYaml, "setup"]
-  do
-      [installRoot] <- lines <$> readProcess "stack"
-                        [useBootstrappingYaml, "path", "--local-install-root"] ""
-      let protocGenHaskell = installRoot </> "bin/proto-lens-protoc"
-      callProcess "stack" [useBootstrappingYaml, "build", "proto-lens-protoc"]
-      callProcess protoc $
-          [ "--plugin=protoc-gen-haskell=" ++ protocGenHaskell
-          , "--haskell_out=no-runtime:" ++ bootstrapModuleRoot
-          , "--proto_path=" ++ protoRoot
-          ]
-          ++ map (protoRoot </>)
-              [ "google/protobuf/descriptor.proto"
-              , "google/protobuf/compiler/plugin.proto"
-              ]
-      -- Verify that the generated code compiles successfully.
-      callProcess "stack" ["build", "proto-lens"]
+    -- 1. Temporarily replace the bootstrap proto bindings in proto-lens-protoc
+    --    with an older version that's compatible with the bootstrap version of
+    --    proto-lens.
+    -- 2. Build proto-lens-protoc against the older proto-lens.
+    -- 3. Use it to generate new versions of the bootstrap proto bindings,
+    --    overwriting the previous versions.
+    callProcess "git" ["checkout", bootstrapCommit, "--",
+                       bootstrapModuleRoot </> "Proto"]
+    [installRoot] <- lines <$> readProcess stack
+                    [useBootstrappingYaml, "path", "--local-install-root"] ""
+    let protocGenHaskell = installRoot </> "bin/proto-lens-protoc"
+    callProcess stack [useBootstrappingYaml, "build", "proto-lens-protoc"]
+    callProcess protoc $
+        [ "--plugin=protoc-gen-haskell=" ++ protocGenHaskell
+        , "--haskell_out=no-runtime:" ++ bootstrapModuleRoot
+        , "--proto_path=" ++ protoRoot
+        ]
+        ++ map (protoRoot </>)
+            [ "google/protobuf/descriptor.proto"
+            , "google/protobuf/compiler/plugin.proto"
+            ]
+    -- Verify that the generated code compiles successfully.
+    callProcess stack ["build", "proto-lens-protoc"]

--- a/proto-lens-protobuf-types/Changelog.md
+++ b/proto-lens-protobuf-types/Changelog.md
@@ -3,6 +3,9 @@
 ## Pending
 - Bump lower bounds to base-4.10 (ghc-8.2).
 - Support dependencies on base-4.13 (ghc-8.8) and lens-family-2.0.
+- Add new bindings `Proto.Google.Protobuf.Descriptor` and
+  `Proto.Google.Protobuf.Compiler.Plugin`, which were previously exported
+  by the `proto-lens` package.
 
 ## v0.5.0.0
 - Bump upper bounds to support `proto-lens-0.5.*`.

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -13,6 +13,8 @@ github: google/proto-lens/proto-lens-protobuf-types
 extra-source-files:
   - Changelog.md
   - proto-src/google/protobuf/any.proto
+  - proto-src/google/protobuf/compiler/plugin.proto
+  - proto-src/google/protobuf/descriptor.proto
   - proto-src/google/protobuf/duration.proto
   - proto-src/google/protobuf/empty.proto
   - proto-src/google/protobuf/wrappers.proto
@@ -40,6 +42,10 @@ library:
   generated-exposed-modules:
     - Proto.Google.Protobuf.Any
     - Proto.Google.Protobuf.Any_Fields
+    - Proto.Google.Protobuf.Compiler.Plugin
+    - Proto.Google.Protobuf.Compiler.Plugin_Fields
+    - Proto.Google.Protobuf.Descriptor
+    - Proto.Google.Protobuf.Descriptor_Fields
     - Proto.Google.Protobuf.Duration
     - Proto.Google.Protobuf.Duration_Fields
     - Proto.Google.Protobuf.Empty

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Generate.hs
@@ -12,8 +12,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Data.ProtoLens.Compiler.Generate(
     generateModule,
-    ModifyImports,
-    reexported,
     ) where
 
 
@@ -63,12 +61,11 @@ data UseRuntime = UseRuntime | UseOriginal
 generateModule :: ModuleNameStr
                -> [ModuleNameStr]  -- ^ The imported modules
                -> [ModuleNameStr]  -- ^ The publicly imported modules
-               -> ModifyImports
                -> Env OccNameStr      -- ^ Definitions in this file
                -> Env RdrNameStr     -- ^ Definitions in the imported modules
                -> [ServiceInfo]
                -> [CommentedModule]
-generateModule modName imports publicImports modifyImport definitions importedEnv services
+generateModule modName imports publicImports definitions importedEnv services
     = [ CommentedModule pragmas
             (module' (Just modName)
                 (Just $ serviceExports
@@ -104,9 +101,9 @@ generateModule modName imports publicImports modifyImport definitions importedEn
             -- Don't warn if empty "import public" modules are reexported.
           , optionsGhcPragma "-Wno-dodgy-exports"
           ]
-    mainImports = map (modifyImport . importQualified)
+    mainImports = map (reexported . importQualified)
                     [ "Control.DeepSeq", "Data.ProtoLens.Prism" ]
-    sharedImports = map (modifyImport . importQualified)
+    sharedImports = map (reexported . importQualified)
               [ "Prelude", "Data.Int", "Data.Monoid", "Data.Word"
               , "Data.ProtoLens"
               , "Data.ProtoLens.Encoding.Bytes"

--- a/proto-lens-protoc/app/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens-protoc/app/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -7,31 +7,31 @@ module Proto.Google.Protobuf.Compiler.Plugin (
         CodeGeneratorRequest(), CodeGeneratorResponse(),
         CodeGeneratorResponse'File(), Version()
     ) where
-import qualified Control.DeepSeq
-import qualified Data.ProtoLens.Prism
-import qualified Prelude
-import qualified Data.Int
-import qualified Data.Monoid
-import qualified Data.Word
-import qualified Data.ProtoLens
-import qualified Data.ProtoLens.Encoding.Bytes
-import qualified Data.ProtoLens.Encoding.Growing
-import qualified Data.ProtoLens.Encoding.Parser.Unsafe
-import qualified Data.ProtoLens.Encoding.Wire
-import qualified Data.ProtoLens.Field
-import qualified Data.ProtoLens.Message.Enum
-import qualified Data.ProtoLens.Service.Types
-import qualified Lens.Family2
-import qualified Lens.Family2.Unchecked
-import qualified Data.Text
-import qualified Data.Map
-import qualified Data.ByteString
-import qualified Data.ByteString.Char8
-import qualified Data.Text.Encoding
-import qualified Data.Vector
-import qualified Data.Vector.Generic
-import qualified Data.Vector.Unboxed
-import qualified Text.Read
+import qualified Data.ProtoLens.Runtime.Control.DeepSeq as Control.DeepSeq
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Prism as Data.ProtoLens.Prism
+import qualified Data.ProtoLens.Runtime.Prelude as Prelude
+import qualified Data.ProtoLens.Runtime.Data.Int as Data.Int
+import qualified Data.ProtoLens.Runtime.Data.Monoid as Data.Monoid
+import qualified Data.ProtoLens.Runtime.Data.Word as Data.Word
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens as Data.ProtoLens
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Bytes as Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Growing as Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Parser.Unsafe as Data.ProtoLens.Encoding.Parser.Unsafe
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire as Data.ProtoLens.Encoding.Wire
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Field as Data.ProtoLens.Field
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Message.Enum as Data.ProtoLens.Message.Enum
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Service.Types as Data.ProtoLens.Service.Types
+import qualified Data.ProtoLens.Runtime.Lens.Family2 as Lens.Family2
+import qualified Data.ProtoLens.Runtime.Lens.Family2.Unchecked as Lens.Family2.Unchecked
+import qualified Data.ProtoLens.Runtime.Data.Text as Data.Text
+import qualified Data.ProtoLens.Runtime.Data.Map as Data.Map
+import qualified Data.ProtoLens.Runtime.Data.ByteString as Data.ByteString
+import qualified Data.ProtoLens.Runtime.Data.ByteString.Char8 as Data.ByteString.Char8
+import qualified Data.ProtoLens.Runtime.Data.Text.Encoding as Data.Text.Encoding
+import qualified Data.ProtoLens.Runtime.Data.Vector as Data.Vector
+import qualified Data.ProtoLens.Runtime.Data.Vector.Generic as Data.Vector.Generic
+import qualified Data.ProtoLens.Runtime.Data.Vector.Unboxed as Data.Vector.Unboxed
+import qualified Data.ProtoLens.Runtime.Text.Read as Text.Read
 import qualified Proto.Google.Protobuf.Descriptor
 {- | Fields :
      

--- a/proto-lens-protoc/app/Proto/Google/Protobuf/Compiler/Plugin_Fields.hs
+++ b/proto-lens-protoc/app/Proto/Google/Protobuf/Compiler/Plugin_Fields.hs
@@ -4,29 +4,29 @@
 {-# OPTIONS_GHC -Wno-duplicate-exports#-}
 {-# OPTIONS_GHC -Wno-dodgy-exports#-}
 module Proto.Google.Protobuf.Compiler.Plugin_Fields where
-import qualified Prelude
-import qualified Data.Int
-import qualified Data.Monoid
-import qualified Data.Word
-import qualified Data.ProtoLens
-import qualified Data.ProtoLens.Encoding.Bytes
-import qualified Data.ProtoLens.Encoding.Growing
-import qualified Data.ProtoLens.Encoding.Parser.Unsafe
-import qualified Data.ProtoLens.Encoding.Wire
-import qualified Data.ProtoLens.Field
-import qualified Data.ProtoLens.Message.Enum
-import qualified Data.ProtoLens.Service.Types
-import qualified Lens.Family2
-import qualified Lens.Family2.Unchecked
-import qualified Data.Text
-import qualified Data.Map
-import qualified Data.ByteString
-import qualified Data.ByteString.Char8
-import qualified Data.Text.Encoding
-import qualified Data.Vector
-import qualified Data.Vector.Generic
-import qualified Data.Vector.Unboxed
-import qualified Text.Read
+import qualified Data.ProtoLens.Runtime.Prelude as Prelude
+import qualified Data.ProtoLens.Runtime.Data.Int as Data.Int
+import qualified Data.ProtoLens.Runtime.Data.Monoid as Data.Monoid
+import qualified Data.ProtoLens.Runtime.Data.Word as Data.Word
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens as Data.ProtoLens
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Bytes as Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Growing as Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Parser.Unsafe as Data.ProtoLens.Encoding.Parser.Unsafe
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire as Data.ProtoLens.Encoding.Wire
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Field as Data.ProtoLens.Field
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Message.Enum as Data.ProtoLens.Message.Enum
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Service.Types as Data.ProtoLens.Service.Types
+import qualified Data.ProtoLens.Runtime.Lens.Family2 as Lens.Family2
+import qualified Data.ProtoLens.Runtime.Lens.Family2.Unchecked as Lens.Family2.Unchecked
+import qualified Data.ProtoLens.Runtime.Data.Text as Data.Text
+import qualified Data.ProtoLens.Runtime.Data.Map as Data.Map
+import qualified Data.ProtoLens.Runtime.Data.ByteString as Data.ByteString
+import qualified Data.ProtoLens.Runtime.Data.ByteString.Char8 as Data.ByteString.Char8
+import qualified Data.ProtoLens.Runtime.Data.Text.Encoding as Data.Text.Encoding
+import qualified Data.ProtoLens.Runtime.Data.Vector as Data.Vector
+import qualified Data.ProtoLens.Runtime.Data.Vector.Generic as Data.Vector.Generic
+import qualified Data.ProtoLens.Runtime.Data.Vector.Unboxed as Data.Vector.Unboxed
+import qualified Data.ProtoLens.Runtime.Text.Read as Text.Read
 import qualified Proto.Google.Protobuf.Descriptor
 compilerVersion ::
   forall f s a.

--- a/proto-lens-protoc/app/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens-protoc/app/Proto/Google/Protobuf/Descriptor.hs
@@ -23,31 +23,31 @@ module Proto.Google.Protobuf.Descriptor (
         SourceCodeInfo(), SourceCodeInfo'Location(), UninterpretedOption(),
         UninterpretedOption'NamePart()
     ) where
-import qualified Control.DeepSeq
-import qualified Data.ProtoLens.Prism
-import qualified Prelude
-import qualified Data.Int
-import qualified Data.Monoid
-import qualified Data.Word
-import qualified Data.ProtoLens
-import qualified Data.ProtoLens.Encoding.Bytes
-import qualified Data.ProtoLens.Encoding.Growing
-import qualified Data.ProtoLens.Encoding.Parser.Unsafe
-import qualified Data.ProtoLens.Encoding.Wire
-import qualified Data.ProtoLens.Field
-import qualified Data.ProtoLens.Message.Enum
-import qualified Data.ProtoLens.Service.Types
-import qualified Lens.Family2
-import qualified Lens.Family2.Unchecked
-import qualified Data.Text
-import qualified Data.Map
-import qualified Data.ByteString
-import qualified Data.ByteString.Char8
-import qualified Data.Text.Encoding
-import qualified Data.Vector
-import qualified Data.Vector.Generic
-import qualified Data.Vector.Unboxed
-import qualified Text.Read
+import qualified Data.ProtoLens.Runtime.Control.DeepSeq as Control.DeepSeq
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Prism as Data.ProtoLens.Prism
+import qualified Data.ProtoLens.Runtime.Prelude as Prelude
+import qualified Data.ProtoLens.Runtime.Data.Int as Data.Int
+import qualified Data.ProtoLens.Runtime.Data.Monoid as Data.Monoid
+import qualified Data.ProtoLens.Runtime.Data.Word as Data.Word
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens as Data.ProtoLens
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Bytes as Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Growing as Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Parser.Unsafe as Data.ProtoLens.Encoding.Parser.Unsafe
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire as Data.ProtoLens.Encoding.Wire
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Field as Data.ProtoLens.Field
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Message.Enum as Data.ProtoLens.Message.Enum
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Service.Types as Data.ProtoLens.Service.Types
+import qualified Data.ProtoLens.Runtime.Lens.Family2 as Lens.Family2
+import qualified Data.ProtoLens.Runtime.Lens.Family2.Unchecked as Lens.Family2.Unchecked
+import qualified Data.ProtoLens.Runtime.Data.Text as Data.Text
+import qualified Data.ProtoLens.Runtime.Data.Map as Data.Map
+import qualified Data.ProtoLens.Runtime.Data.ByteString as Data.ByteString
+import qualified Data.ProtoLens.Runtime.Data.ByteString.Char8 as Data.ByteString.Char8
+import qualified Data.ProtoLens.Runtime.Data.Text.Encoding as Data.Text.Encoding
+import qualified Data.ProtoLens.Runtime.Data.Vector as Data.Vector
+import qualified Data.ProtoLens.Runtime.Data.Vector.Generic as Data.Vector.Generic
+import qualified Data.ProtoLens.Runtime.Data.Vector.Unboxed as Data.Vector.Unboxed
+import qualified Data.ProtoLens.Runtime.Text.Read as Text.Read
 {- | Fields :
      
          * 'Proto.Google.Protobuf.Descriptor_Fields.name' @:: Lens' DescriptorProto Data.Text.Text@

--- a/proto-lens-protoc/app/Proto/Google/Protobuf/Descriptor_Fields.hs
+++ b/proto-lens-protoc/app/Proto/Google/Protobuf/Descriptor_Fields.hs
@@ -4,29 +4,29 @@
 {-# OPTIONS_GHC -Wno-duplicate-exports#-}
 {-# OPTIONS_GHC -Wno-dodgy-exports#-}
 module Proto.Google.Protobuf.Descriptor_Fields where
-import qualified Prelude
-import qualified Data.Int
-import qualified Data.Monoid
-import qualified Data.Word
-import qualified Data.ProtoLens
-import qualified Data.ProtoLens.Encoding.Bytes
-import qualified Data.ProtoLens.Encoding.Growing
-import qualified Data.ProtoLens.Encoding.Parser.Unsafe
-import qualified Data.ProtoLens.Encoding.Wire
-import qualified Data.ProtoLens.Field
-import qualified Data.ProtoLens.Message.Enum
-import qualified Data.ProtoLens.Service.Types
-import qualified Lens.Family2
-import qualified Lens.Family2.Unchecked
-import qualified Data.Text
-import qualified Data.Map
-import qualified Data.ByteString
-import qualified Data.ByteString.Char8
-import qualified Data.Text.Encoding
-import qualified Data.Vector
-import qualified Data.Vector.Generic
-import qualified Data.Vector.Unboxed
-import qualified Text.Read
+import qualified Data.ProtoLens.Runtime.Prelude as Prelude
+import qualified Data.ProtoLens.Runtime.Data.Int as Data.Int
+import qualified Data.ProtoLens.Runtime.Data.Monoid as Data.Monoid
+import qualified Data.ProtoLens.Runtime.Data.Word as Data.Word
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens as Data.ProtoLens
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Bytes as Data.ProtoLens.Encoding.Bytes
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Growing as Data.ProtoLens.Encoding.Growing
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Parser.Unsafe as Data.ProtoLens.Encoding.Parser.Unsafe
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire as Data.ProtoLens.Encoding.Wire
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Field as Data.ProtoLens.Field
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Message.Enum as Data.ProtoLens.Message.Enum
+import qualified Data.ProtoLens.Runtime.Data.ProtoLens.Service.Types as Data.ProtoLens.Service.Types
+import qualified Data.ProtoLens.Runtime.Lens.Family2 as Lens.Family2
+import qualified Data.ProtoLens.Runtime.Lens.Family2.Unchecked as Lens.Family2.Unchecked
+import qualified Data.ProtoLens.Runtime.Data.Text as Data.Text
+import qualified Data.ProtoLens.Runtime.Data.Map as Data.Map
+import qualified Data.ProtoLens.Runtime.Data.ByteString as Data.ByteString
+import qualified Data.ProtoLens.Runtime.Data.ByteString.Char8 as Data.ByteString.Char8
+import qualified Data.ProtoLens.Runtime.Data.Text.Encoding as Data.Text.Encoding
+import qualified Data.ProtoLens.Runtime.Data.Vector as Data.Vector
+import qualified Data.ProtoLens.Runtime.Data.Vector.Generic as Data.Vector.Generic
+import qualified Data.ProtoLens.Runtime.Data.Vector.Unboxed as Data.Vector.Unboxed
+import qualified Data.ProtoLens.Runtime.Text.Read as Text.Read
 aggregateValue ::
   forall f s a.
   (Prelude.Functor f,

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -39,4 +39,5 @@ executables:
       - pretty == 1.1.*
       - proto-lens == 0.5.*
       - proto-lens-protoc
+      - proto-lens-runtime == 0.5.*
       - text == 1.2.*

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -252,6 +252,7 @@ tests:
     main: imports_test.hs
     source-dirs: tests
     dependencies:
+      - proto-lens-protobuf-types
       - proto-lens-tests
     generated-other-modules:
       - Proto.Empty

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -4,6 +4,9 @@
 
 ### Breaking Changes
 - Bump lower bounds to base-4.10 (ghc-8.2).
+- Move `Proto.Google.Protobuf.Descriptor` and
+  `Proto.Google.Protobuf.Compiler.Plugin` to the `proto-lens-protobuf-types`
+  package.
 
 ### Backwards-Compatible Changes
 - Bump upper bound to allo profunctors-5.5.

--- a/stack-bootstrap.yaml
+++ b/stack-bootstrap.yaml
@@ -10,6 +10,8 @@ extra-deps:
 - git: https://github.com/google/proto-lens
   # To use the current repository:
   # git: ../..  # stack runs 'git clone' in a subdirectory
+  # Note: this commit should match the value of bootstrapCommit in bootstrap.hs
   commit: master
   subdirs:
   - proto-lens
+  - proto-lens-runtime


### PR DESCRIPTION
Previously the checked-in bootstrap protos were part of the proto-lens package.
After this change, they're included in the `other-modules` of
proto-lens-protoc`.  Instead, the exposed versions of the modules are
provided by proto-lens-protobuf-types, just like the other proto
files.

Fixed #344, which describes why this was causing issues with some
build systems like Bazel.

Another side effect of this change is: previously the bootstrap protos
had special logic for how they imported modules.  After this change
they can depend on them from proto-lens-runtime, just like other
generated protos.  This simplifies some logic in proto-lens-protoc.

Also update the bootstrap script.  It's mostly the same as before,
except that we first checkout an old version of the bootstrap proto
bindings that will be compatible with the version of proto-lens we're
bootstrapping against. (They'll be overwritten at the end of the
script anyway.)