### PR TITLE
Bump the version to 0.6.

### DIFF
--- a/proto-lens-arbitrary/Changelog.md
+++ b/proto-lens-arbitrary/Changelog.md
@@ -1,7 +1,8 @@
 # Changelog for `proto-lens-arbitrary`
 
-## Pending
+## v0.1.2.8
 - Bump lower bounds to base-4.10 (ghc-8.2).
+- Bump upper bounds for proto-lens-0.6.
 - Support dependencies on base-4.13 (ghc-8.8) and lens-family-2.0.
 
 ## v0.1.2.7

--- a/proto-lens-arbitrary/package.yaml
+++ b/proto-lens-arbitrary/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-arbitrary
-version: "0.1.2.7"
+version: "0.1.2.8"
 synopsis: Arbitrary instances for proto-lens.
 description: >
   The proto-lens-arbitrary allows generating arbitrary messages for
@@ -14,7 +14,7 @@ extra-source-files:
   - Changelog.md
 
 dependencies:
-  - proto-lens >= 0.4 && < 0.6
+  - proto-lens >= 0.4 && < 0.7
   - base >= 4.10 && < 4.14
   - bytestring == 0.10.*
   - containers >= 0.5 && < 0.7

--- a/proto-lens-discrimination/package.yaml
+++ b/proto-lens-discrimination/package.yaml
@@ -29,8 +29,8 @@ dependencies:
   - discrimination >= 0.3 && < 0.5
   - discrimination-ieee754 == 0.1.*
   - lens-family == 1.2.*
-  - proto-lens == 0.5.*
-  - proto-lens-runtime == 0.5.*
+  - proto-lens == 0.6.*
+  - proto-lens-runtime == 0.6.*
   - text == 1.2.*
 
 library:

--- a/proto-lens-optparse/Changelog.md
+++ b/proto-lens-optparse/Changelog.md
@@ -1,8 +1,9 @@
 # Changelog for `proto-lens-optparse`
 
-## Pending
+## v0.1.1.6
 - Bump lower bounds to base-4.10 (ghc-8.2).
 - Support dependencies on base-4.13 (ghc-8.8) and optparse-applicative-0.15.
+- Bump upper bounds for proto-lens-0.6.
 
 
 ## v0.1.1.5

--- a/proto-lens-optparse/package.yaml
+++ b/proto-lens-optparse/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-optparse
-version: '0.1.1.5'
+version: '0.1.1.6'
 synopsis: Adapting proto-lens to optparse-applicative ReadMs.
 description: >
   A package adapting proto-lens to optparse-applicative ReadMs.
@@ -15,7 +15,7 @@ extra-source-files:
   - Changelog.md
 
 dependencies:
-  - proto-lens >= 0.1 && < 0.6
+  - proto-lens >= 0.1 && < 0.7
   - base >= 4.10 && < 4.14
   - optparse-applicative >= 0.13 && < 0.16
   - text == 1.2.*

--- a/proto-lens-protobuf-types/Changelog.md
+++ b/proto-lens-protobuf-types/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog for `proto-lens-protobuf-types`
 
-## Pending
+## v0.6.0.0
 - Bump lower bounds to base-4.10 (ghc-8.2).
 - Support dependencies on base-4.13 (ghc-8.8) and lens-family-2.0.
 

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-protobuf-types
-version: '0.5.0.0'
+version: '0.6.0.0'
 synopsis: Basic protocol buffer message types.
 description: >
   This package provides bindings standard protocol message types,
@@ -29,8 +29,8 @@ build-tools: proto-lens-protoc:proto-lens-protoc
 dependencies:
   - base >= 4.10 && < 4.14
   - lens-family >= 1.2 && < 2.1
-  - proto-lens == 0.5.*
-  - proto-lens-runtime == 0.5.*
+  - proto-lens == 0.6.*
+  - proto-lens-runtime == 0.6.*
   - text == 1.2.*
 
 library:

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog for `proto-lens-protoc`
 
-## Pending
+## v0.6.0.0
 
 ### Breaking Changes
 - Reexport transitive definitions from modules generated for `.proto` files

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-protoc
-version: '0.5.0.0'
+version: '0.6.0.0'
 synopsis: Protocol buffer compiler for the proto-lens library.
 description: >
   Turn protocol buffer files (.proto) into Haskell files (.hs) which
@@ -37,6 +37,6 @@ executables:
       - ghc-source-gen == 0.3.*
       - lens-family >= 1.2 && < 2.1
       - pretty == 1.1.*
-      - proto-lens == 0.5.*
+      - proto-lens == 0.6.*
       - proto-lens-protoc
       - text == 1.2.*

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -39,5 +39,5 @@ executables:
       - pretty == 1.1.*
       - proto-lens == 0.6.*
       - proto-lens-protoc
-      - proto-lens-runtime == 0.5.*
+      - proto-lens-runtime == 0.6.*
       - text == 1.2.*

--- a/proto-lens-runtime/Changelog.md
+++ b/proto-lens-runtime/Changelog.md
@@ -1,8 +1,9 @@
 # Changelog for `proto-lens-runtime`
 
-## Pending
+## v0.6.0.0
 - Bump lower bounds to base-4.10 (ghc-8.2).
 - Support dependencies on base-4.13 (ghc-8.8) and lens-family-2.0.
+- Bump upper bounds to proto-lens-0.6.
 
 ## v0.5.0.0
 - Export more modules from proto-lens, to support generated encoding/decoding

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-runtime
-version: '0.5.0.0'
+version: '0.6.0.0'
 author: Judah Jacobson
 maintainer: proto-lens@googlegroups.com
 github: google/proto-lens/proto-lens-runtime
@@ -22,7 +22,7 @@ library:
     - deepseq == 1.4.*
     - filepath >= 1.4 && < 1.6
     - lens-family >= 1.2 && < 2.1
-    - proto-lens == 0.5.*
+    - proto-lens == 0.6.*
     - text == 1.2.*
     - vector >= 0.11 && < 0.13
 

--- a/proto-lens-setup/Changelog.md
+++ b/proto-lens-setup/Changelog.md
@@ -1,8 +1,9 @@
 # Changelog for `proto-lens-setup`
 
-## Pending
+## v0.4.0.3
 - Bump lower bounds to base-4.10 (ghc-8.2) and Cabal-2.0.
 - Support dependencies on base-4.13 (ghc-8.8) and Cabal-3.0.
+- Bump upper bounds to proto-lens-0.6.
 
 ## v0.4.0.2
 - Bump upper bounds to support `proto-lens-0.5.*`.

--- a/proto-lens-setup/package.yaml
+++ b/proto-lens-setup/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-setup
-version: '0.4.0.2'
+version: '0.4.0.3'
 synopsis: 'Cabal support for codegen with proto-lens.'
 description: |
   This package provides Cabal support for the @proto-lens@ package.
@@ -61,7 +61,7 @@ library:
     # Depend transitively on the binary.
     # TODO: once there's sufficient support from Stack and Cabal,
     # make this a build-tool dependency.
-    - proto-lens-protoc >= 0.4 && < 0.6
+    - proto-lens-protoc >= 0.4 && < 0.7
     - temporary >= 1.2 && < 1.4
     - text == 1.2.*
   exposed-modules:

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -1,12 +1,12 @@
 # Changelog for `proto-lens`
 
-## Pending
+## v0.6.0.0
 
 ### Breaking Changes
 - Bump lower bounds to base-4.10 (ghc-8.2).
 
 ### Backwards-Compatible Changes
-- Bump upper bound to allo profunctors-5.5.
+- Bump upper bound to allow profunctors-5.5.
 - Support dependencies on base-4.13 (ghc-8.8) and lens-family-2.0.
 
 ## v0.5.1.0

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens
-version: "0.5.1.0"
+version: "0.6.0.0"
 synopsis: A lens-based implementation of protocol buffers in Haskell.
 description: >
   The proto-lens library provides an API for protocol buffers using modern

--- a/travis-cabal.sh
+++ b/travis-cabal.sh
@@ -19,8 +19,8 @@ chmod +x $HOME/.local/bin/hpack
 PACKAGES_TO_INSTALL="
     discrimination-ieee754
     proto-lens
-    proto-lens-protoc
     proto-lens-runtime
+    proto-lens-protoc
     proto-lens-setup
     proto-lens-protobuf-types
     proto-lens-arbitrary


### PR DESCRIPTION
Packages like proto-lens-optparse and proto-lens-arbitrary that
are compatible with the older versions only get a minor bump.