### PR TITLE
Fix "cabal check" on proto-lens-protobuf-types.

### DIFF
--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -54,3 +54,9 @@ library:
     - Proto.Google.Protobuf.Wrappers_Fields
     - Proto.Google.Protobuf.Timestamp
     - Proto.Google.Protobuf.Timestamp_Fields
+  # Prevent hpack from putting Paths_* in the other-modules.
+  # Otherwise, "cabal check" complains (preventing upload to Hackage)
+  # because it expects it to be listed in autogen-modules.
+  # For details, see https://github.com/sol/hpack/issues/303.
+  verbatim:
+    other-modules:


### PR DESCRIPTION
This was preventing us from uploading the package to Hackage.
It was caused by #353 which (as expected) bumped the .cabal
file to require version 2.  Unfortunately, this ran afoul
of an hpack issue:
https://github.com/sol/hpack/issues/303

Specifically: (a) hpack auto-adds a `Paths_*`
module, and (b) Cabal v2 expects that to be listed explicitly
in `autogen-modules`, which hpack does not do.

Work around this by following a suggestion from the above thread:
include an explicit `verbatim`/`other-modules` clause,
which prevents hpack from auto-adding the `Paths_*` module.