### PR TITLE
Add Data.ProtoLens.Descriptor to proto-lens-protobuf-types.

### DIFF
--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -39,6 +39,7 @@ library:
   source-dirs: src
   exposed-modules:
     - Data.ProtoLens.Any
+    - Data.ProtoLens.Descriptor
   generated-exposed-modules:
     - Proto.Google.Protobuf.Any
     - Proto.Google.Protobuf.Any_Fields

--- a/proto-lens-protobuf-types/src/Data/ProtoLens/Descriptor.hs
+++ b/proto-lens-protobuf-types/src/Data/ProtoLens/Descriptor.hs
@@ -1,0 +1,17 @@
+-- | Functions for interacting with message descriptors.
+module Data.ProtoLens.Descriptor
+    ( DescriptorProto
+    , messageDescriptor
+    ) where
+
+import Data.ProtoLens
+import Data.Proxy (Proxy)
+import Proto.Google.Protobuf.Descriptor
+
+-- | The protocol buffer message descriptor for this type.
+messageDescriptor :: Message a => Proxy a -> DescriptorProto
+-- Note: technically decodeMessageOrDie can fail.  However, it's
+-- unlikely in practice since we encode the message ourselves
+-- in proto-lens-protoc; and furthermore proto decoding is robust
+-- to unknown/missing fields.
+messageDescriptor = decodeMessageOrDie . packedMessageDescriptor

--- a/proto-lens-protobuf-types/src/Data/ProtoLens/Descriptor.hs
+++ b/proto-lens-protobuf-types/src/Data/ProtoLens/Descriptor.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 -- | Functions for interacting with message descriptors.
 module Data.ProtoLens.Descriptor
     ( DescriptorProto
@@ -5,13 +8,17 @@ module Data.ProtoLens.Descriptor
     ) where
 
 import Data.ProtoLens
-import Data.Proxy (Proxy)
+import Data.Proxy (Proxy(..))
 import Proto.Google.Protobuf.Descriptor
 
--- | The protocol buffer message descriptor for this type.
-messageDescriptor :: Message a => Proxy a -> DescriptorProto
+-- | The protocol buffer message descriptor for a given type.
+--
+-- This function should be used with @TypeApplications@, e.g.:
+--
+-- > messageDescriptor @SomeProtoType
+messageDescriptor :: forall a . Message a => DescriptorProto
 -- Note: technically decodeMessageOrDie can fail.  However, it's
 -- unlikely in practice since we encode the message ourselves
 -- in proto-lens-protoc; and furthermore proto decoding is robust
 -- to unknown/missing fields.
-messageDescriptor = decodeMessageOrDie . packedMessageDescriptor
+messageDescriptor = decodeMessageOrDie $ packedMessageDescriptor (Proxy @a)

--- a/proto-lens-tests/tests/descriptor_test.hs
+++ b/proto-lens-tests/tests/descriptor_test.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Data.ProtoLens (Message(..), decodeMessageOrDie)
 import Data.ProtoLens.Labels ()
 import Lens.Family2 (view, toListOf)
 import Test.Tasty.HUnit (testCase)
@@ -11,7 +10,7 @@ import Test.HUnit ((@=?))
 import Data.Proxy (Proxy(..))
 import Data.ProtoLens.TestUtil (TestTree, testMain)
 import qualified Proto.Descriptor as PB
-import qualified Proto.Google.Protobuf.Descriptor as Descriptor
+import Data.ProtoLens.Descriptor
 
 main :: IO ()
 main = testMain
@@ -24,5 +23,4 @@ testDescriptor = testCase "testDescriptor" $ do
   ["a_string", "some_ints", "inner"] @=? toListOf (#field . traverse . #name) d
 
   where
-    d :: Descriptor.DescriptorProto
-    d = (decodeMessageOrDie . packedMessageDescriptor) (Proxy :: Proxy PB.DescriptorTest)
+    d = messageDescriptor (Proxy :: Proxy PB.DescriptorTest)

--- a/proto-lens-tests/tests/descriptor_test.hs
+++ b/proto-lens-tests/tests/descriptor_test.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
 module Main where
 
 import Data.ProtoLens.Labels ()
@@ -7,7 +8,6 @@ import Lens.Family2 (view, toListOf)
 import Test.Tasty.HUnit (testCase)
 import Test.HUnit ((@=?))
 
-import Data.Proxy (Proxy(..))
 import Data.ProtoLens.TestUtil (TestTree, testMain)
 import qualified Proto.Descriptor as PB
 import Data.ProtoLens.Descriptor
@@ -23,4 +23,4 @@ testDescriptor = testCase "testDescriptor" $ do
   ["a_string", "some_ints", "inner"] @=? toListOf (#field . traverse . #name) d
 
   where
-    d = messageDescriptor (Proxy :: Proxy PB.DescriptorTest)
+    d = messageDescriptor @PB.DescriptorTest

--- a/proto-lens/src/Data/ProtoLens/Message.hs
+++ b/proto-lens/src/Data/ProtoLens/Message.hs
@@ -76,6 +76,10 @@ class Message msg where
     messageName :: Proxy msg -> T.Text
 
     -- | The serialized protobuffer message descriptor for this type.
+    --
+    -- For a friendlier version which returns the actual descriptor type,
+    -- use @Data.ProtoLens.Descriptor.messageDescriptor@
+    -- from the @proto-lens-protobuf-types@ package.
     packedMessageDescriptor :: Proxy msg -> B.ByteString
 
     -- | A message with all fields set to their default values.


### PR DESCRIPTION
It contains the function `messageDescriptor` which is a nicer
API than `Data.ProtoLens.Message.packedMessageDescriptor`.
(We can't return a `DescriptorProto` directly in `Data.ProtoLens.Message`
because the `proto-lens` package doesn't have access to that type
yet (it's now exposed from proto-lens-protobuf-types).