### PR TITLE
Update versions and changelogs for packagedMessageDescriptor

### DIFF
--- a/proto-lens-arbitrary/package.yaml
+++ b/proto-lens-arbitrary/package.yaml
@@ -14,7 +14,7 @@ extra-source-files:
   - Changelog.md
 
 dependencies:
-  - proto-lens >= 0.4 && < 0.7
+  - proto-lens >= 0.4 && < 0.8
   - base >= 4.10 && < 4.14
   - bytestring == 0.10.*
   - containers >= 0.5 && < 0.7

--- a/proto-lens-discrimination/package.yaml
+++ b/proto-lens-discrimination/package.yaml
@@ -29,8 +29,7 @@ dependencies:
   - discrimination >= 0.3 && < 0.5
   - discrimination-ieee754 == 0.1.*
   - lens-family == 1.2.*
-  - proto-lens == 0.6.*
-  - proto-lens-runtime == 0.6.*
+  - proto-lens >= 0.6 && < 0.8
   - text == 1.2.*
 
 library:
@@ -49,6 +48,7 @@ tests:
       - HUnit >= 1.3 && < 1.7
       - proto-lens-arbitrary >= 0.1 && < 0.2
       - proto-lens-discrimination
+      - proto-lens-runtime >= 0.6 && < 0.8
       - test-framework == 0.8.*
       - test-framework-hunit == 0.3.*
       - test-framework-quickcheck2 == 0.3.*

--- a/proto-lens-optparse/package.yaml
+++ b/proto-lens-optparse/package.yaml
@@ -15,7 +15,7 @@ extra-source-files:
   - Changelog.md
 
 dependencies:
-  - proto-lens >= 0.1 && < 0.7
+  - proto-lens >= 0.1 && < 0.8
   - base >= 4.10 && < 4.14
   - optparse-applicative >= 0.13 && < 0.16
   - text == 1.2.*

--- a/proto-lens-protobuf-types/Changelog.md
+++ b/proto-lens-protobuf-types/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog for `proto-lens-protobuf-types`
 
+## v0.7.0.0
+- Add the module `Data.ProtoLens.Descriptor`.  It exposes `messageDescriptor`,
+  which makes it easier to get the descriptor proto for a given message type.
+
 ## v0.6.0.0
 - Bump lower bounds to base-4.10 (ghc-8.2).
 - Support dependencies on base-4.13 (ghc-8.8) and lens-family-2.0.

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-protobuf-types
-version: '0.6.0.0'
+version: '0.7.0.0'
 synopsis: Basic protocol buffer message types.
 description: >
   This package provides bindings standard protocol message types,
@@ -31,8 +31,8 @@ build-tools: proto-lens-protoc:proto-lens-protoc
 dependencies:
   - base >= 4.10 && < 4.14
   - lens-family >= 1.2 && < 2.1
-  - proto-lens == 0.6.*
-  - proto-lens-runtime == 0.6.*
+  - proto-lens == 0.7.*
+  - proto-lens-runtime == 0.7.*
   - text == 1.2.*
 
 library:

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -1,6 +1,7 @@
 # Changelog for `proto-lens-protoc`
 
-## v0.6.0.0
+## v0.7.0.0
+- Support `proto-lens` changes for the new method `packedMessageDescriptor`.
 
 ### Breaking Changes
 - Reexport transitive definitions from modules generated for `.proto` files

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-protoc
-version: '0.6.0.0'
+version: '0.7.0.0'
 synopsis: Protocol buffer compiler for the proto-lens library.
 description: >
   Turn protocol buffer files (.proto) into Haskell files (.hs) which
@@ -37,7 +37,7 @@ executables:
       - ghc-source-gen == 0.3.*
       - lens-family >= 1.2 && < 2.1
       - pretty == 1.1.*
-      - proto-lens == 0.6.*
+      - proto-lens == 0.7.*
       - proto-lens-protoc
-      - proto-lens-runtime == 0.6.*
+      - proto-lens-runtime == 0.7.*
       - text == 1.2.*

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-runtime
-version: '0.6.0.0'
+version: '0.7.0.0'
 author: Judah Jacobson
 maintainer: proto-lens@googlegroups.com
 github: google/proto-lens/proto-lens-runtime
@@ -22,7 +22,7 @@ library:
     - deepseq == 1.4.*
     - filepath >= 1.4 && < 1.6
     - lens-family >= 1.2 && < 2.1
-    - proto-lens == 0.6.*
+    - proto-lens == 0.7.*
     - text == 1.2.*
     - vector >= 0.11 && < 0.13
 

--- a/proto-lens-setup/package.yaml
+++ b/proto-lens-setup/package.yaml
@@ -61,7 +61,7 @@ library:
     # Depend transitively on the binary.
     # TODO: once there's sufficient support from Stack and Cabal,
     # make this a build-tool dependency.
-    - proto-lens-protoc >= 0.4 && < 0.7
+    - proto-lens-protoc >= 0.4 && < 0.8
     - temporary >= 1.2 && < 1.4
     - text == 1.2.*
   exposed-modules:

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -1,5 +1,10 @@
 # Changelog for `proto-lens`
 
+## v0.7.0.0
+- Add a method to `Data.ProtoLens.Message` for getting the `DescriptorProto`
+  of a given message.  For a simpler API, see `Data.ProtoLens.Descriptor`
+  from `proto-lens-protobuf-types`.
+
 ## v0.6.0.0
 
 ### Breaking Changes

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens
-version: "0.6.0.0"
+version: "0.7.0.0"
 synopsis: A lens-based implementation of protocol buffers in Haskell.
 description: >
   The proto-lens library provides an API for protocol buffers using modern


### PR DESCRIPTION
The new method `packedMessageDescriptor` is a breaking change
from the 0.6.* API.

I avoided doing the minor version bumps for other libraries;
we can do that when we do our next release (probably not for a bit).

Note: this is diffbased onto #362.