### PR TITLE
Fix transitivity property test of message Sorts.  (#364)

### DIFF
--- a/proto-lens-discrimination/package.yaml
+++ b/proto-lens-discrimination/package.yaml
@@ -46,6 +46,7 @@ tests:
     source-dirs: tests
     dependencies:
       - HUnit >= 1.3 && < 1.7
+      - QuickCheck >= 2.8 && < 2.14
       - proto-lens-arbitrary >= 0.1 && < 0.2
       - proto-lens-discrimination
       - proto-lens-runtime >= 0.6 && < 0.8

--- a/proto-lens-discrimination/tests/disc_test.hs
+++ b/proto-lens-discrimination/tests/disc_test.hs
@@ -12,6 +12,7 @@ import Test.Framework (testGroup, defaultMain)
 import Test.Framework.Providers.API (Test)
 import Test.Framework.Providers.HUnit (testCase)
 import Test.Framework.Providers.QuickCheck2 (testProperty)
+import Test.QuickCheck ((===), (.||.))
 
 import qualified Data.Map as M
 
@@ -120,13 +121,13 @@ messageSortTest = testGroup "Message"
         (defMessage & bar .~ BAR5 & barDefaulted .~ BAR3) $ s
     , testProperty "symmetry" $
         \(ArbitraryMessage msg1) (ArbitraryMessage msg2) ->
-            (LT == sortCompare s msg1 msg2) ==
+            (LT == sortCompare s msg1 msg2) ===
             (GT == sortCompare s msg2 msg1)
     , testProperty "transitivity" $
         \(ArbitraryMessage m1) (ArbitraryMessage m2) (ArbitraryMessage m3) ->
-            let [low, _, high] =
-                    sortBy (sortCompare s) [m1, m2, m3]
-            in LT == sortCompare s low high
+            let [low, mid, high] = sortBy (sortCompare s) [m1, m2, m3]
+            in  LT === sortCompare s low high .||.
+                (EQ, EQ) === (sortCompare s low mid, sortCompare s mid high)
     ]
   where
     -- This fixes the types of all the ArbitraryMessages and defs above.


### PR DESCRIPTION
If all three messages are equal, they'll get sorted into some arbitrary order, and the least won't be less than the greatest.  So, assert that either the least is less than the greatest, or all three are equal.

Note: I wasn't able to convince proto-lens to build in a few tens of minutes (all the .proto files in submodules were missing), so I gave up and decided to let the CI deal with it.  So, this might not even type-check yet.