### PR TITLE
Add FileDescriptorProto to generated protos.

### DIFF
--- a/proto-lens-protobuf-types/src/Data/ProtoLens/Descriptor.hs
+++ b/proto-lens-protobuf-types/src/Data/ProtoLens/Descriptor.hs
@@ -5,6 +5,7 @@
 module Data.ProtoLens.Descriptor
     ( DescriptorProto
     , messageDescriptor
+    , fileDescriptor
     ) where
 
 import Data.ProtoLens
@@ -22,3 +23,11 @@ messageDescriptor :: forall a . Message a => DescriptorProto
 -- in proto-lens-protoc; and furthermore proto decoding is robust
 -- to unknown/missing fields.
 messageDescriptor = decodeMessageOrDie $ packedMessageDescriptor (Proxy @a)
+
+-- | The protocol buffer file descriptor containing a given type.
+--
+-- This function should be used with @TypeApplications@, e.g.:
+--
+-- > fileDescriptor @SomeProtoType
+fileDescriptor :: forall a . Message a => FileDescriptorProto
+fileDescriptor = decodeMessageOrDie $ packedFileDescriptor (Proxy @a)

--- a/proto-lens-protoc/app/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens-protoc/app/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -127,6 +127,7 @@ instance Data.ProtoLens.Message CodeGeneratorRequest where
       \\n\
       \proto_file\CAN\SI \ETX(\v2$.google.protobuf.FileDescriptorProtoR\tprotoFile\DC2L\n\
       \\DLEcompiler_version\CAN\ETX \SOH(\v2!.google.protobuf.compiler.VersionR\SIcompilerVersion"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         fileToGenerate__field_descriptor
@@ -425,6 +426,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
       \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2'\n\
       \\SIinsertion_point\CAN\STX \SOH(\tR\SOinsertionPoint\DC2\CAN\n\
       \\acontent\CAN\SI \SOH(\tR\acontent"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         error__field_descriptor
@@ -638,6 +640,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
       \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2'\n\
       \\SIinsertion_point\CAN\STX \SOH(\tR\SOinsertionPoint\DC2\CAN\n\
       \\acontent\CAN\SI \SOH(\tR\acontent"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         name__field_descriptor
@@ -894,6 +897,7 @@ instance Data.ProtoLens.Message Version where
       \\ENQminor\CAN\STX \SOH(\ENQR\ENQminor\DC2\DC4\n\
       \\ENQpatch\CAN\ETX \SOH(\ENQR\ENQpatch\DC2\SYN\n\
       \\ACKsuffix\CAN\EOT \SOH(\tR\ACKsuffix"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         major__field_descriptor
@@ -1067,3 +1071,332 @@ instance Control.DeepSeq.NFData Version where
                    (Control.DeepSeq.deepseq
                       (_Version'patch x__)
                       (Control.DeepSeq.deepseq (_Version'suffix x__) ()))))
+{- | FileDescriptorProto for protos defined in Proto.Google.Protobuf.Compiler.Plugin -}
+packedFileDescriptor :: Data.ByteString.ByteString
+packedFileDescriptor
+  = "\n\
+    \%google/protobuf/compiler/plugin.proto\DC2\CANgoogle.protobuf.compiler\SUB google/protobuf/descriptor.proto\"c\n\
+    \\aVersion\DC2\DC4\n\
+    \\ENQmajor\CAN\SOH \SOH(\ENQR\ENQmajor\DC2\DC4\n\
+    \\ENQminor\CAN\STX \SOH(\ENQR\ENQminor\DC2\DC4\n\
+    \\ENQpatch\CAN\ETX \SOH(\ENQR\ENQpatch\DC2\SYN\n\
+    \\ACKsuffix\CAN\EOT \SOH(\tR\ACKsuffix\"\241\SOH\n\
+    \\DC4CodeGeneratorRequest\DC2(\n\
+    \\DLEfile_to_generate\CAN\SOH \ETX(\tR\SOfileToGenerate\DC2\FS\n\
+    \\tparameter\CAN\STX \SOH(\tR\tparameter\DC2C\n\
+    \\n\
+    \proto_file\CAN\SI \ETX(\v2$.google.protobuf.FileDescriptorProtoR\tprotoFile\DC2L\n\
+    \\DLEcompiler_version\CAN\ETX \SOH(\v2!.google.protobuf.compiler.VersionR\SIcompilerVersion\"\214\SOH\n\
+    \\NAKCodeGeneratorResponse\DC2\DC4\n\
+    \\ENQerror\CAN\SOH \SOH(\tR\ENQerror\DC2H\n\
+    \\EOTfile\CAN\SI \ETX(\v24.google.protobuf.compiler.CodeGeneratorResponse.FileR\EOTfile\SUB]\n\
+    \\EOTFile\DC2\DC2\n\
+    \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2'\n\
+    \\SIinsertion_point\CAN\STX \SOH(\tR\SOinsertionPoint\DC2\CAN\n\
+    \\acontent\CAN\SI \SOH(\tR\acontentBg\n\
+    \\FScom.google.protobuf.compilerB\fPluginProtosZ9github.com/golang/protobuf/protoc-gen-go/plugin;plugin_goJ\239>\n\
+    \\a\DC2\ENQ.\NUL\166\SOH\SOH\n\
+    \\202\DC1\n\
+    \\SOH\f\DC2\ETX.\NUL\DC22\193\f Protocol Buffers - Google's data interchange format\n\
+    \ Copyright 2008 Google Inc.  All rights reserved.\n\
+    \ https://developers.google.com/protocol-buffers/\n\
+    \\n\
+    \ Redistribution and use in source and binary forms, with or without\n\
+    \ modification, are permitted provided that the following conditions are\n\
+    \ met:\n\
+    \\n\
+    \     * Redistributions of source code must retain the above copyright\n\
+    \ notice, this list of conditions and the following disclaimer.\n\
+    \     * Redistributions in binary form must reproduce the above\n\
+    \ copyright notice, this list of conditions and the following disclaimer\n\
+    \ in the documentation and/or other materials provided with the\n\
+    \ distribution.\n\
+    \     * Neither the name of Google Inc. nor the names of its\n\
+    \ contributors may be used to endorse or promote products derived from\n\
+    \ this software without specific prior written permission.\n\
+    \\n\
+    \ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\
+    \ \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\n\
+    \ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\n\
+    \ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\n\
+    \ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\n\
+    \ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\n\
+    \ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n\
+    \ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n\
+    \ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n\
+    \ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n\
+    \ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\
+    \2\251\EOT Author: kenton@google.com (Kenton Varda)\n\
+    \\n\
+    \ WARNING:  The plugin interface is currently EXPERIMENTAL and is subject to\n\
+    \   change.\n\
+    \\n\
+    \ protoc (aka the Protocol Compiler) can be extended via plugins.  A plugin is\n\
+    \ just a program that reads a CodeGeneratorRequest from stdin and writes a\n\
+    \ CodeGeneratorResponse to stdout.\n\
+    \\n\
+    \ Plugins written using C++ can use google/protobuf/compiler/plugin.h instead\n\
+    \ of dealing with the raw protocol defined here.\n\
+    \\n\
+    \ A plugin executable needs only to be placed somewhere in the path.  The\n\
+    \ plugin should be named \"protoc-gen-$NAME\", and will then be used when the\n\
+    \ flag \"--${NAME}_out\" is passed to protoc.\n\
+    \\n\
+    \\b\n\
+    \\SOH\STX\DC2\ETX/\NUL!\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX0\NUL5\n\
+    \\t\n\
+    \\STX\b\SOH\DC2\ETX0\NUL5\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX1\NUL-\n\
+    \\t\n\
+    \\STX\b\b\DC2\ETX1\NUL-\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX3\NULP\n\
+    \\t\n\
+    \\STX\b\v\DC2\ETX3\NULP\n\
+    \\t\n\
+    \\STX\ETX\NUL\DC2\ETX5\NUL*\n\
+    \6\n\
+    \\STX\EOT\NUL\DC2\EOT8\NUL?\SOH\SUB* The version number of protocol compiler.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\NUL\SOH\DC2\ETX8\b\SI\n\
+    \\v\n\
+    \\EOT\EOT\NUL\STX\NUL\DC2\ETX9\STX\ESC\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\EOT\DC2\ETX9\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\ENQ\DC2\ETX9\v\DLE\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\SOH\DC2\ETX9\DC1\SYN\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\ETX\DC2\ETX9\EM\SUB\n\
+    \\v\n\
+    \\EOT\EOT\NUL\STX\SOH\DC2\ETX:\STX\ESC\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\SOH\EOT\DC2\ETX:\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\SOH\ENQ\DC2\ETX:\v\DLE\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\SOH\SOH\DC2\ETX:\DC1\SYN\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\SOH\ETX\DC2\ETX:\EM\SUB\n\
+    \\v\n\
+    \\EOT\EOT\NUL\STX\STX\DC2\ETX;\STX\ESC\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\STX\EOT\DC2\ETX;\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\STX\ENQ\DC2\ETX;\v\DLE\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\STX\SOH\DC2\ETX;\DC1\SYN\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\STX\ETX\DC2\ETX;\EM\SUB\n\
+    \\128\SOH\n\
+    \\EOT\EOT\NUL\STX\ETX\DC2\ETX>\STX\GS\SUBs A suffix for alpha, beta or rc release, e.g., \"alpha-1\", \"rc2\". It should\n\
+    \ be empty for mainline stable releases.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ETX\EOT\DC2\ETX>\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ETX\ENQ\DC2\ETX>\v\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ETX\SOH\DC2\ETX>\DC2\CAN\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\ETX\ETX\DC2\ETX>\ESC\FS\n\
+    \O\n\
+    \\STX\EOT\SOH\DC2\EOTB\NUL^\SOH\SUBC An encoded CodeGeneratorRequest is written to the plugin's stdin.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\SOH\SOH\DC2\ETXB\b\FS\n\
+    \\209\SOH\n\
+    \\EOT\EOT\SOH\STX\NUL\DC2\ETXF\STX'\SUB\195\SOH The .proto files that were explicitly listed on the command-line.  The\n\
+    \ code generator should generate code only for these files.  Each file's\n\
+    \ descriptor will be included in proto_file, below.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\EOT\DC2\ETXF\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\ENQ\DC2\ETXF\v\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\SOH\DC2\ETXF\DC2\"\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\ETX\DC2\ETXF%&\n\
+    \B\n\
+    \\EOT\EOT\SOH\STX\SOH\DC2\ETXI\STX \SUB5 The generator parameter passed on the command-line.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\EOT\DC2\ETXI\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\ENQ\DC2\ETXI\v\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\SOH\DC2\ETXI\DC2\ESC\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\ETX\DC2\ETXI\RS\US\n\
+    \\135\ACK\n\
+    \\EOT\EOT\SOH\STX\STX\DC2\ETXY\STX/\SUB\249\ENQ FileDescriptorProtos for all files in files_to_generate and everything\n\
+    \ they import.  The files will appear in topological order, so each file\n\
+    \ appears before any file that imports it.\n\
+    \\n\
+    \ protoc guarantees that all proto_files will be written after\n\
+    \ the fields above, even though this is not technically guaranteed by the\n\
+    \ protobuf wire format.  This theoretically could allow a plugin to stream\n\
+    \ in the FileDescriptorProtos and handle them one by one rather than read\n\
+    \ the entire set into memory at once.  However, as of this writing, this\n\
+    \ is not similarly optimized on protoc's end -- it will store all fields in\n\
+    \ memory at once before sending them to the plugin.\n\
+    \\n\
+    \ Type names of fields and extensions in the FileDescriptorProto are always\n\
+    \ fully qualified.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\STX\EOT\DC2\ETXY\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\STX\ACK\DC2\ETXY\v\RS\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\STX\SOH\DC2\ETXY\US)\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\STX\ETX\DC2\ETXY,.\n\
+    \7\n\
+    \\EOT\EOT\SOH\STX\ETX\DC2\ETX\\\STX(\SUB* The version number of protocol compiler.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ETX\EOT\DC2\ETX\\\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ETX\ACK\DC2\ETX\\\v\DC2\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ETX\SOH\DC2\ETX\\\DC3#\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ETX\ETX\DC2\ETX\\&'\n\
+    \L\n\
+    \\STX\EOT\STX\DC2\ENQa\NUL\166\SOH\SOH\SUB? The plugin writes an encoded CodeGeneratorResponse to stdout.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\STX\SOH\DC2\ETXa\b\GS\n\
+    \\237\ETX\n\
+    \\EOT\EOT\STX\STX\NUL\DC2\ETXj\STX\FS\SUB\223\ETX Error message.  If non-empty, code generation failed.  The plugin process\n\
+    \ should exit with status code zero even if it reports an error in this way.\n\
+    \\n\
+    \ This should be used to indicate errors in .proto files which prevent the\n\
+    \ code generator from generating correct code.  Errors which indicate a\n\
+    \ problem in protoc itself -- such as the input CodeGeneratorRequest being\n\
+    \ unparseable -- should be reported by writing a message to stderr and\n\
+    \ exiting with a non-zero status code.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\EOT\DC2\ETXj\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\ENQ\DC2\ETXj\v\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\SOH\DC2\ETXj\DC2\ETB\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\ETX\DC2\ETXj\SUB\ESC\n\
+    \4\n\
+    \\EOT\EOT\STX\ETX\NUL\DC2\ENQm\STX\164\SOH\ETX\SUB% Represents a single generated file.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\ETX\NUL\SOH\DC2\ETXm\n\
+    \\SO\n\
+    \\173\ENQ\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\NUL\DC2\ETXy\EOT\GS\SUB\157\ENQ The file name, relative to the output directory.  The name must not\n\
+    \ contain \".\" or \"..\" components and must be relative, not be absolute (so,\n\
+    \ the file cannot lie outside the output directory).  \"/\" must be used as\n\
+    \ the path separator, not \"\\\".\n\
+    \\n\
+    \ If the name is omitted, the content will be appended to the previous\n\
+    \ file.  This allows the generator to break large files into small chunks,\n\
+    \ and allows the generated text to be streamed back to protoc so that large\n\
+    \ files need not reside completely in memory at one time.  Note that as of\n\
+    \ this writing protoc does not optimize for this -- it will read the entire\n\
+    \ CodeGeneratorResponse before writing files to disk.\n\
+    \\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\EOT\DC2\ETXy\EOT\f\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\ENQ\DC2\ETXy\r\DC3\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\SOH\DC2\ETXy\DC4\CAN\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\ETX\DC2\ETXy\ESC\FS\n\
+    \\174\DLE\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\SOH\DC2\EOT\160\SOH\EOT(\SUB\157\DLE If non-empty, indicates that the named file should already exist, and the\n\
+    \ content here is to be inserted into that file at a defined insertion\n\
+    \ point.  This feature allows a code generator to extend the output\n\
+    \ produced by another code generator.  The original generator may provide\n\
+    \ insertion points by placing special annotations in the file that look\n\
+    \ like:\n\
+    \   @@protoc_insertion_point(NAME)\n\
+    \ The annotation can have arbitrary text before and after it on the line,\n\
+    \ which allows it to be placed in a comment.  NAME should be replaced with\n\
+    \ an identifier naming the point -- this is what other generators will use\n\
+    \ as the insertion_point.  Code inserted at this point will be placed\n\
+    \ immediately above the line containing the insertion point (thus multiple\n\
+    \ insertions to the same point will come out in the order they were added).\n\
+    \ The double-@ is intended to make it unlikely that the generated code\n\
+    \ could contain things that look like insertion points by accident.\n\
+    \\n\
+    \ For example, the C++ code generator places the following line in the\n\
+    \ .pb.h files that it generates:\n\
+    \   // @@protoc_insertion_point(namespace_scope)\n\
+    \ This line appears within the scope of the file's package namespace, but\n\
+    \ outside of any particular class.  Another plugin can then specify the\n\
+    \ insertion_point \"namespace_scope\" to generate additional classes or\n\
+    \ other declarations that should be placed in this scope.\n\
+    \\n\
+    \ Note that if the line containing the insertion point begins with\n\
+    \ whitespace, the same whitespace will be added to every line of the\n\
+    \ inserted text.  This is useful for languages like Python, where\n\
+    \ indentation matters.  In these languages, the insertion point comment\n\
+    \ should be indented the same amount as any inserted code will need to be\n\
+    \ in order to work correctly in that context.\n\
+    \\n\
+    \ The code generator that generates the initial file and the one which\n\
+    \ inserts into it must both run as part of a single invocation of protoc.\n\
+    \ Code generators are executed in the order in which they appear on the\n\
+    \ command line.\n\
+    \\n\
+    \ If |insertion_point| is present, |name| must also be present.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\EOT\DC2\EOT\160\SOH\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\ENQ\DC2\EOT\160\SOH\r\DC3\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\SOH\DC2\EOT\160\SOH\DC4#\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\ETX\DC2\EOT\160\SOH&'\n\
+    \$\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\STX\DC2\EOT\163\SOH\EOT!\SUB\DC4 The file contents.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\EOT\DC2\EOT\163\SOH\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\ENQ\DC2\EOT\163\SOH\r\DC3\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\SOH\DC2\EOT\163\SOH\DC4\ESC\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\ETX\DC2\EOT\163\SOH\RS \n\
+    \\f\n\
+    \\EOT\EOT\STX\STX\SOH\DC2\EOT\165\SOH\STX\SUB\n\
+    \\r\n\
+    \\ENQ\EOT\STX\STX\SOH\EOT\DC2\EOT\165\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\STX\STX\SOH\ACK\DC2\EOT\165\SOH\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\STX\STX\SOH\SOH\DC2\EOT\165\SOH\DLE\DC4\n\
+    \\r\n\
+    \\ENQ\EOT\STX\STX\SOH\ETX\DC2\EOT\165\SOH\ETB\EM"

--- a/proto-lens-protoc/app/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens-protoc/app/Proto/Google/Protobuf/Descriptor.hs
@@ -270,6 +270,7 @@ instance Data.ProtoLens.Message DescriptorProto where
       \\rReservedRange\DC2\DC4\n\
       \\ENQstart\CAN\SOH \SOH(\ENQR\ENQstart\DC2\DLE\n\
       \\ETXend\CAN\STX \SOH(\ENQR\ETXend"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         name__field_descriptor
@@ -977,6 +978,7 @@ instance Data.ProtoLens.Message DescriptorProto'ExtensionRange where
       \\ENQstart\CAN\SOH \SOH(\ENQR\ENQstart\DC2\DLE\n\
       \\ETXend\CAN\STX \SOH(\ENQR\ETXend\DC2@\n\
       \\aoptions\CAN\ETX \SOH(\v2&.google.protobuf.ExtensionRangeOptionsR\aoptions"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         start__field_descriptor
@@ -1175,6 +1177,7 @@ instance Data.ProtoLens.Message DescriptorProto'ReservedRange where
       \\rReservedRange\DC2\DC4\n\
       \\ENQstart\CAN\SOH \SOH(\ENQR\ENQstart\DC2\DLE\n\
       \\ETXend\CAN\STX \SOH(\ENQR\ETXend"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         start__field_descriptor
@@ -1401,6 +1404,7 @@ instance Data.ProtoLens.Message EnumDescriptorProto where
       \\DC1EnumReservedRange\DC2\DC4\n\
       \\ENQstart\CAN\SOH \SOH(\ENQR\ENQstart\DC2\DLE\n\
       \\ETXend\CAN\STX \SOH(\ENQR\ETXend"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         name__field_descriptor
@@ -1747,6 +1751,7 @@ instance Data.ProtoLens.Message EnumDescriptorProto'EnumReservedRange where
       \\DC1EnumReservedRange\DC2\DC4\n\
       \\ENQstart\CAN\SOH \SOH(\ENQR\ENQstart\DC2\DLE\n\
       \\ETXend\CAN\STX \SOH(\ENQR\ETXend"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         start__field_descriptor
@@ -1933,6 +1938,7 @@ instance Data.ProtoLens.Message EnumOptions where
       \deprecated\CAN\ETX \SOH(\b:\ENQfalseR\n\
       \deprecated\DC2X\n\
       \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STXJ\EOT\b\ENQ\DLE\ACK"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         allowAlias__field_descriptor
@@ -2174,6 +2180,7 @@ instance Data.ProtoLens.Message EnumValueDescriptorProto where
       \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2\SYN\n\
       \\ACKnumber\CAN\STX \SOH(\ENQR\ACKnumber\DC2;\n\
       \\aoptions\CAN\ETX \SOH(\v2!.google.protobuf.EnumValueOptionsR\aoptions"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         name__field_descriptor
@@ -2386,6 +2393,7 @@ instance Data.ProtoLens.Message EnumValueOptions where
       \deprecated\CAN\SOH \SOH(\b:\ENQfalseR\n\
       \deprecated\DC2X\n\
       \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STX"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         deprecated__field_descriptor
@@ -2561,6 +2569,7 @@ instance Data.ProtoLens.Message ExtensionRangeOptions where
     = "\n\
       \\NAKExtensionRangeOptions\DC2X\n\
       \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STX"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         uninterpretedOption__field_descriptor
@@ -2893,6 +2902,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
       \\SOLABEL_OPTIONAL\DLE\SOH\DC2\DC2\n\
       \\SOLABEL_REQUIRED\DLE\STX\DC2\DC2\n\
       \\SOLABEL_REPEATED\DLE\ETX"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         name__field_descriptor
@@ -3741,6 +3751,7 @@ instance Data.ProtoLens.Message FieldOptions where
       \\tJS_NORMAL\DLE\NUL\DC2\r\n\
       \\tJS_STRING\DLE\SOH\DC2\r\n\
       \\tJS_NUMBER\DLE\STX*\t\b\232\a\DLE\128\128\128\128\STXJ\EOT\b\EOT\DLE\ENQ"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         ctype__field_descriptor
@@ -4399,6 +4410,7 @@ instance Data.ProtoLens.Message FileDescriptorProto where
       \\aoptions\CAN\b \SOH(\v2\FS.google.protobuf.FileOptionsR\aoptions\DC2I\n\
       \\DLEsource_code_info\CAN\t \SOH(\v2\US.google.protobuf.SourceCodeInfoR\SOsourceCodeInfo\DC2\SYN\n\
       \\ACKsyntax\CAN\f \SOH(\tR\ACKsyntax"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         name__field_descriptor
@@ -5203,6 +5215,7 @@ instance Data.ProtoLens.Message FileDescriptorSet where
     = "\n\
       \\DC1FileDescriptorSet\DC28\n\
       \\EOTfile\CAN\SOH \ETX(\v2$.google.protobuf.FileDescriptorProtoR\EOTfile"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         file__field_descriptor
@@ -5703,6 +5716,7 @@ instance Data.ProtoLens.Message FileOptions where
       \\ENQSPEED\DLE\SOH\DC2\r\n\
       \\tCODE_SIZE\DLE\STX\DC2\DLE\n\
       \\fLITE_RUNTIME\DLE\ETX*\t\b\232\a\DLE\128\128\128\128\STXJ\EOT\b&\DLE'"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         javaPackage__field_descriptor
@@ -6756,6 +6770,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo where
       \sourceFile\DC2\DC4\n\
       \\ENQbegin\CAN\ETX \SOH(\ENQR\ENQbegin\DC2\DLE\n\
       \\ETXend\CAN\EOT \SOH(\ENQR\ETXend"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         annotation__field_descriptor
@@ -6953,6 +6968,7 @@ instance Data.ProtoLens.Message GeneratedCodeInfo'Annotation where
       \sourceFile\DC2\DC4\n\
       \\ENQbegin\CAN\ETX \SOH(\ENQR\ENQbegin\DC2\DLE\n\
       \\ETXend\CAN\EOT \SOH(\ENQR\ETXend"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         path__field_descriptor
@@ -7294,6 +7310,7 @@ instance Data.ProtoLens.Message MessageOptions where
       \deprecated\DC2\ESC\n\
       \\tmap_entry\CAN\a \SOH(\bR\bmapEntry\DC2X\n\
       \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STXJ\EOT\b\b\DLE\tJ\EOT\b\t\DLE\n"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         messageSetWireFormat__field_descriptor
@@ -7663,6 +7680,7 @@ instance Data.ProtoLens.Message MethodDescriptorProto where
       \\aoptions\CAN\EOT \SOH(\v2\RS.google.protobuf.MethodOptionsR\aoptions\DC20\n\
       \\DLEclient_streaming\CAN\ENQ \SOH(\b:\ENQfalseR\SIclientStreaming\DC20\n\
       \\DLEserver_streaming\CAN\ACK \SOH(\b:\ENQfalseR\SIserverStreaming"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         name__field_descriptor
@@ -8019,6 +8037,7 @@ instance Data.ProtoLens.Message MethodOptions where
       \\SINO_SIDE_EFFECTS\DLE\SOH\DC2\SO\n\
       \\n\
       \IDEMPOTENT\DLE\STX*\t\b\232\a\DLE\128\128\128\128\STX"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         deprecated__field_descriptor
@@ -8304,6 +8323,7 @@ instance Data.ProtoLens.Message OneofDescriptorProto where
       \\DC4OneofDescriptorProto\DC2\DC2\n\
       \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC27\n\
       \\aoptions\CAN\STX \SOH(\v2\GS.google.protobuf.OneofOptionsR\aoptions"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         name__field_descriptor
@@ -8466,6 +8486,7 @@ instance Data.ProtoLens.Message OneofOptions where
     = "\n\
       \\fOneofOptions\DC2X\n\
       \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STX"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         uninterpretedOption__field_descriptor
@@ -8643,6 +8664,7 @@ instance Data.ProtoLens.Message ServiceDescriptorProto where
       \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2>\n\
       \\ACKmethod\CAN\STX \ETX(\v2&.google.protobuf.MethodDescriptorProtoR\ACKmethod\DC29\n\
       \\aoptions\CAN\ETX \SOH(\v2\US.google.protobuf.ServiceOptionsR\aoptions"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         name__field_descriptor
@@ -8877,6 +8899,7 @@ instance Data.ProtoLens.Message ServiceOptions where
       \deprecated\CAN! \SOH(\b:\ENQfalseR\n\
       \deprecated\DC2X\n\
       \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STX"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         deprecated__field_descriptor
@@ -9056,6 +9079,7 @@ instance Data.ProtoLens.Message SourceCodeInfo where
       \\DLEleading_comments\CAN\ETX \SOH(\tR\SIleadingComments\DC2+\n\
       \\DC1trailing_comments\CAN\EOT \SOH(\tR\DLEtrailingComments\DC2:\n\
       \\EMleading_detached_comments\CAN\ACK \ETX(\tR\ETBleadingDetachedComments"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         location__field_descriptor
@@ -9275,6 +9299,7 @@ instance Data.ProtoLens.Message SourceCodeInfo'Location where
       \\DLEleading_comments\CAN\ETX \SOH(\tR\SIleadingComments\DC2+\n\
       \\DC1trailing_comments\CAN\EOT \SOH(\tR\DLEtrailingComments\DC2:\n\
       \\EMleading_detached_comments\CAN\ACK \ETX(\tR\ETBleadingDetachedComments"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         path__field_descriptor
@@ -9767,6 +9792,7 @@ instance Data.ProtoLens.Message UninterpretedOption where
       \\bNamePart\DC2\ESC\n\
       \\tname_part\CAN\SOH \STX(\tR\bnamePart\DC2!\n\
       \\fis_extension\CAN\STX \STX(\bR\visExtension"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         name__field_descriptor
@@ -10125,6 +10151,7 @@ instance Data.ProtoLens.Message UninterpretedOption'NamePart where
       \\bNamePart\DC2\ESC\n\
       \\tname_part\CAN\SOH \STX(\tR\bnamePart\DC2!\n\
       \\fis_extension\CAN\STX \STX(\bR\visExtension"
+  packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
         namePart__field_descriptor
@@ -10255,3 +10282,2867 @@ instance Control.DeepSeq.NFData UninterpretedOption'NamePart where
                 (_UninterpretedOption'NamePart'namePart x__)
                 (Control.DeepSeq.deepseq
                    (_UninterpretedOption'NamePart'isExtension x__) ()))
+{- | FileDescriptorProto for protos defined in Proto.Google.Protobuf.Descriptor -}
+packedFileDescriptor :: Data.ByteString.ByteString
+packedFileDescriptor
+  = "\n\
+    \ google/protobuf/descriptor.proto\DC2\SIgoogle.protobuf\"M\n\
+    \\DC1FileDescriptorSet\DC28\n\
+    \\EOTfile\CAN\SOH \ETX(\v2$.google.protobuf.FileDescriptorProtoR\EOTfile\"\228\EOT\n\
+    \\DC3FileDescriptorProto\DC2\DC2\n\
+    \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2\CAN\n\
+    \\apackage\CAN\STX \SOH(\tR\apackage\DC2\RS\n\
+    \\n\
+    \dependency\CAN\ETX \ETX(\tR\n\
+    \dependency\DC2+\n\
+    \\DC1public_dependency\CAN\n\
+    \ \ETX(\ENQR\DLEpublicDependency\DC2'\n\
+    \\SIweak_dependency\CAN\v \ETX(\ENQR\SOweakDependency\DC2C\n\
+    \\fmessage_type\CAN\EOT \ETX(\v2 .google.protobuf.DescriptorProtoR\vmessageType\DC2A\n\
+    \\tenum_type\CAN\ENQ \ETX(\v2$.google.protobuf.EnumDescriptorProtoR\benumType\DC2A\n\
+    \\aservice\CAN\ACK \ETX(\v2'.google.protobuf.ServiceDescriptorProtoR\aservice\DC2C\n\
+    \\textension\CAN\a \ETX(\v2%.google.protobuf.FieldDescriptorProtoR\textension\DC26\n\
+    \\aoptions\CAN\b \SOH(\v2\FS.google.protobuf.FileOptionsR\aoptions\DC2I\n\
+    \\DLEsource_code_info\CAN\t \SOH(\v2\US.google.protobuf.SourceCodeInfoR\SOsourceCodeInfo\DC2\SYN\n\
+    \\ACKsyntax\CAN\f \SOH(\tR\ACKsyntax\"\185\ACK\n\
+    \\SIDescriptorProto\DC2\DC2\n\
+    \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2;\n\
+    \\ENQfield\CAN\STX \ETX(\v2%.google.protobuf.FieldDescriptorProtoR\ENQfield\DC2C\n\
+    \\textension\CAN\ACK \ETX(\v2%.google.protobuf.FieldDescriptorProtoR\textension\DC2A\n\
+    \\vnested_type\CAN\ETX \ETX(\v2 .google.protobuf.DescriptorProtoR\n\
+    \nestedType\DC2A\n\
+    \\tenum_type\CAN\EOT \ETX(\v2$.google.protobuf.EnumDescriptorProtoR\benumType\DC2X\n\
+    \\SIextension_range\CAN\ENQ \ETX(\v2/.google.protobuf.DescriptorProto.ExtensionRangeR\SOextensionRange\DC2D\n\
+    \\n\
+    \oneof_decl\CAN\b \ETX(\v2%.google.protobuf.OneofDescriptorProtoR\toneofDecl\DC29\n\
+    \\aoptions\CAN\a \SOH(\v2\US.google.protobuf.MessageOptionsR\aoptions\DC2U\n\
+    \\SOreserved_range\CAN\t \ETX(\v2..google.protobuf.DescriptorProto.ReservedRangeR\rreservedRange\DC2#\n\
+    \\rreserved_name\CAN\n\
+    \ \ETX(\tR\freservedName\SUBz\n\
+    \\SOExtensionRange\DC2\DC4\n\
+    \\ENQstart\CAN\SOH \SOH(\ENQR\ENQstart\DC2\DLE\n\
+    \\ETXend\CAN\STX \SOH(\ENQR\ETXend\DC2@\n\
+    \\aoptions\CAN\ETX \SOH(\v2&.google.protobuf.ExtensionRangeOptionsR\aoptions\SUB7\n\
+    \\rReservedRange\DC2\DC4\n\
+    \\ENQstart\CAN\SOH \SOH(\ENQR\ENQstart\DC2\DLE\n\
+    \\ETXend\CAN\STX \SOH(\ENQR\ETXend\"|\n\
+    \\NAKExtensionRangeOptions\DC2X\n\
+    \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STX\"\152\ACK\n\
+    \\DC4FieldDescriptorProto\DC2\DC2\n\
+    \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2\SYN\n\
+    \\ACKnumber\CAN\ETX \SOH(\ENQR\ACKnumber\DC2A\n\
+    \\ENQlabel\CAN\EOT \SOH(\SO2+.google.protobuf.FieldDescriptorProto.LabelR\ENQlabel\DC2>\n\
+    \\EOTtype\CAN\ENQ \SOH(\SO2*.google.protobuf.FieldDescriptorProto.TypeR\EOTtype\DC2\ESC\n\
+    \\ttype_name\CAN\ACK \SOH(\tR\btypeName\DC2\SUB\n\
+    \\bextendee\CAN\STX \SOH(\tR\bextendee\DC2#\n\
+    \\rdefault_value\CAN\a \SOH(\tR\fdefaultValue\DC2\US\n\
+    \\voneof_index\CAN\t \SOH(\ENQR\n\
+    \oneofIndex\DC2\ESC\n\
+    \\tjson_name\CAN\n\
+    \ \SOH(\tR\bjsonName\DC27\n\
+    \\aoptions\CAN\b \SOH(\v2\GS.google.protobuf.FieldOptionsR\aoptions\"\182\STX\n\
+    \\EOTType\DC2\SI\n\
+    \\vTYPE_DOUBLE\DLE\SOH\DC2\SO\n\
+    \\n\
+    \TYPE_FLOAT\DLE\STX\DC2\SO\n\
+    \\n\
+    \TYPE_INT64\DLE\ETX\DC2\SI\n\
+    \\vTYPE_UINT64\DLE\EOT\DC2\SO\n\
+    \\n\
+    \TYPE_INT32\DLE\ENQ\DC2\DLE\n\
+    \\fTYPE_FIXED64\DLE\ACK\DC2\DLE\n\
+    \\fTYPE_FIXED32\DLE\a\DC2\r\n\
+    \\tTYPE_BOOL\DLE\b\DC2\SI\n\
+    \\vTYPE_STRING\DLE\t\DC2\SO\n\
+    \\n\
+    \TYPE_GROUP\DLE\n\
+    \\DC2\DLE\n\
+    \\fTYPE_MESSAGE\DLE\v\DC2\SO\n\
+    \\n\
+    \TYPE_BYTES\DLE\f\DC2\SI\n\
+    \\vTYPE_UINT32\DLE\r\DC2\r\n\
+    \\tTYPE_ENUM\DLE\SO\DC2\DC1\n\
+    \\rTYPE_SFIXED32\DLE\SI\DC2\DC1\n\
+    \\rTYPE_SFIXED64\DLE\DLE\DC2\SI\n\
+    \\vTYPE_SINT32\DLE\DC1\DC2\SI\n\
+    \\vTYPE_SINT64\DLE\DC2\"C\n\
+    \\ENQLabel\DC2\DC2\n\
+    \\SOLABEL_OPTIONAL\DLE\SOH\DC2\DC2\n\
+    \\SOLABEL_REQUIRED\DLE\STX\DC2\DC2\n\
+    \\SOLABEL_REPEATED\DLE\ETX\"c\n\
+    \\DC4OneofDescriptorProto\DC2\DC2\n\
+    \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC27\n\
+    \\aoptions\CAN\STX \SOH(\v2\GS.google.protobuf.OneofOptionsR\aoptions\"\227\STX\n\
+    \\DC3EnumDescriptorProto\DC2\DC2\n\
+    \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2?\n\
+    \\ENQvalue\CAN\STX \ETX(\v2).google.protobuf.EnumValueDescriptorProtoR\ENQvalue\DC26\n\
+    \\aoptions\CAN\ETX \SOH(\v2\FS.google.protobuf.EnumOptionsR\aoptions\DC2]\n\
+    \\SOreserved_range\CAN\EOT \ETX(\v26.google.protobuf.EnumDescriptorProto.EnumReservedRangeR\rreservedRange\DC2#\n\
+    \\rreserved_name\CAN\ENQ \ETX(\tR\freservedName\SUB;\n\
+    \\DC1EnumReservedRange\DC2\DC4\n\
+    \\ENQstart\CAN\SOH \SOH(\ENQR\ENQstart\DC2\DLE\n\
+    \\ETXend\CAN\STX \SOH(\ENQR\ETXend\"\131\SOH\n\
+    \\CANEnumValueDescriptorProto\DC2\DC2\n\
+    \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2\SYN\n\
+    \\ACKnumber\CAN\STX \SOH(\ENQR\ACKnumber\DC2;\n\
+    \\aoptions\CAN\ETX \SOH(\v2!.google.protobuf.EnumValueOptionsR\aoptions\"\167\SOH\n\
+    \\SYNServiceDescriptorProto\DC2\DC2\n\
+    \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2>\n\
+    \\ACKmethod\CAN\STX \ETX(\v2&.google.protobuf.MethodDescriptorProtoR\ACKmethod\DC29\n\
+    \\aoptions\CAN\ETX \SOH(\v2\US.google.protobuf.ServiceOptionsR\aoptions\"\137\STX\n\
+    \\NAKMethodDescriptorProto\DC2\DC2\n\
+    \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2\GS\n\
+    \\n\
+    \input_type\CAN\STX \SOH(\tR\tinputType\DC2\US\n\
+    \\voutput_type\CAN\ETX \SOH(\tR\n\
+    \outputType\DC28\n\
+    \\aoptions\CAN\EOT \SOH(\v2\RS.google.protobuf.MethodOptionsR\aoptions\DC20\n\
+    \\DLEclient_streaming\CAN\ENQ \SOH(\b:\ENQfalseR\SIclientStreaming\DC20\n\
+    \\DLEserver_streaming\CAN\ACK \SOH(\b:\ENQfalseR\SIserverStreaming\"\146\t\n\
+    \\vFileOptions\DC2!\n\
+    \\fjava_package\CAN\SOH \SOH(\tR\vjavaPackage\DC20\n\
+    \\DC4java_outer_classname\CAN\b \SOH(\tR\DC2javaOuterClassname\DC25\n\
+    \\DC3java_multiple_files\CAN\n\
+    \ \SOH(\b:\ENQfalseR\DC1javaMultipleFiles\DC2D\n\
+    \\GSjava_generate_equals_and_hash\CAN\DC4 \SOH(\bR\EMjavaGenerateEqualsAndHashB\STX\CAN\SOH\DC2:\n\
+    \\SYNjava_string_check_utf8\CAN\ESC \SOH(\b:\ENQfalseR\DC3javaStringCheckUtf8\DC2S\n\
+    \\foptimize_for\CAN\t \SOH(\SO2).google.protobuf.FileOptions.OptimizeMode:\ENQSPEEDR\voptimizeFor\DC2\GS\n\
+    \\n\
+    \go_package\CAN\v \SOH(\tR\tgoPackage\DC25\n\
+    \\DC3cc_generic_services\CAN\DLE \SOH(\b:\ENQfalseR\DC1ccGenericServices\DC29\n\
+    \\NAKjava_generic_services\CAN\DC1 \SOH(\b:\ENQfalseR\DC3javaGenericServices\DC25\n\
+    \\DC3py_generic_services\CAN\DC2 \SOH(\b:\ENQfalseR\DC1pyGenericServices\DC27\n\
+    \\DC4php_generic_services\CAN* \SOH(\b:\ENQfalseR\DC2phpGenericServices\DC2%\n\
+    \\n\
+    \deprecated\CAN\ETB \SOH(\b:\ENQfalseR\n\
+    \deprecated\DC2/\n\
+    \\DLEcc_enable_arenas\CAN\US \SOH(\b:\ENQfalseR\SOccEnableArenas\DC2*\n\
+    \\DC1objc_class_prefix\CAN$ \SOH(\tR\SIobjcClassPrefix\DC2)\n\
+    \\DLEcsharp_namespace\CAN% \SOH(\tR\SIcsharpNamespace\DC2!\n\
+    \\fswift_prefix\CAN' \SOH(\tR\vswiftPrefix\DC2(\n\
+    \\DLEphp_class_prefix\CAN( \SOH(\tR\SOphpClassPrefix\DC2#\n\
+    \\rphp_namespace\CAN) \SOH(\tR\fphpNamespace\DC24\n\
+    \\SYNphp_metadata_namespace\CAN, \SOH(\tR\DC4phpMetadataNamespace\DC2!\n\
+    \\fruby_package\CAN- \SOH(\tR\vrubyPackage\DC2X\n\
+    \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption\":\n\
+    \\fOptimizeMode\DC2\t\n\
+    \\ENQSPEED\DLE\SOH\DC2\r\n\
+    \\tCODE_SIZE\DLE\STX\DC2\DLE\n\
+    \\fLITE_RUNTIME\DLE\ETX*\t\b\232\a\DLE\128\128\128\128\STXJ\EOT\b&\DLE'\"\209\STX\n\
+    \\SOMessageOptions\DC2<\n\
+    \\ETBmessage_set_wire_format\CAN\SOH \SOH(\b:\ENQfalseR\DC4messageSetWireFormat\DC2L\n\
+    \\USno_standard_descriptor_accessor\CAN\STX \SOH(\b:\ENQfalseR\FSnoStandardDescriptorAccessor\DC2%\n\
+    \\n\
+    \deprecated\CAN\ETX \SOH(\b:\ENQfalseR\n\
+    \deprecated\DC2\ESC\n\
+    \\tmap_entry\CAN\a \SOH(\bR\bmapEntry\DC2X\n\
+    \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STXJ\EOT\b\b\DLE\tJ\EOT\b\t\DLE\n\
+    \\"\226\ETX\n\
+    \\fFieldOptions\DC2A\n\
+    \\ENQctype\CAN\SOH \SOH(\SO2#.google.protobuf.FieldOptions.CType:\ACKSTRINGR\ENQctype\DC2\SYN\n\
+    \\ACKpacked\CAN\STX \SOH(\bR\ACKpacked\DC2G\n\
+    \\ACKjstype\CAN\ACK \SOH(\SO2$.google.protobuf.FieldOptions.JSType:\tJS_NORMALR\ACKjstype\DC2\EM\n\
+    \\EOTlazy\CAN\ENQ \SOH(\b:\ENQfalseR\EOTlazy\DC2%\n\
+    \\n\
+    \deprecated\CAN\ETX \SOH(\b:\ENQfalseR\n\
+    \deprecated\DC2\EM\n\
+    \\EOTweak\CAN\n\
+    \ \SOH(\b:\ENQfalseR\EOTweak\DC2X\n\
+    \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption\"/\n\
+    \\ENQCType\DC2\n\
+    \\n\
+    \\ACKSTRING\DLE\NUL\DC2\b\n\
+    \\EOTCORD\DLE\SOH\DC2\DLE\n\
+    \\fSTRING_PIECE\DLE\STX\"5\n\
+    \\ACKJSType\DC2\r\n\
+    \\tJS_NORMAL\DLE\NUL\DC2\r\n\
+    \\tJS_STRING\DLE\SOH\DC2\r\n\
+    \\tJS_NUMBER\DLE\STX*\t\b\232\a\DLE\128\128\128\128\STXJ\EOT\b\EOT\DLE\ENQ\"s\n\
+    \\fOneofOptions\DC2X\n\
+    \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STX\"\192\SOH\n\
+    \\vEnumOptions\DC2\US\n\
+    \\vallow_alias\CAN\STX \SOH(\bR\n\
+    \allowAlias\DC2%\n\
+    \\n\
+    \deprecated\CAN\ETX \SOH(\b:\ENQfalseR\n\
+    \deprecated\DC2X\n\
+    \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STXJ\EOT\b\ENQ\DLE\ACK\"\158\SOH\n\
+    \\DLEEnumValueOptions\DC2%\n\
+    \\n\
+    \deprecated\CAN\SOH \SOH(\b:\ENQfalseR\n\
+    \deprecated\DC2X\n\
+    \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STX\"\156\SOH\n\
+    \\SOServiceOptions\DC2%\n\
+    \\n\
+    \deprecated\CAN! \SOH(\b:\ENQfalseR\n\
+    \deprecated\DC2X\n\
+    \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STX\"\224\STX\n\
+    \\rMethodOptions\DC2%\n\
+    \\n\
+    \deprecated\CAN! \SOH(\b:\ENQfalseR\n\
+    \deprecated\DC2q\n\
+    \\DC1idempotency_level\CAN\" \SOH(\SO2/.google.protobuf.MethodOptions.IdempotencyLevel:\DC3IDEMPOTENCY_UNKNOWNR\DLEidempotencyLevel\DC2X\n\
+    \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption\"P\n\
+    \\DLEIdempotencyLevel\DC2\ETB\n\
+    \\DC3IDEMPOTENCY_UNKNOWN\DLE\NUL\DC2\DC3\n\
+    \\SINO_SIDE_EFFECTS\DLE\SOH\DC2\SO\n\
+    \\n\
+    \IDEMPOTENT\DLE\STX*\t\b\232\a\DLE\128\128\128\128\STX\"\154\ETX\n\
+    \\DC3UninterpretedOption\DC2A\n\
+    \\EOTname\CAN\STX \ETX(\v2-.google.protobuf.UninterpretedOption.NamePartR\EOTname\DC2)\n\
+    \\DLEidentifier_value\CAN\ETX \SOH(\tR\SIidentifierValue\DC2,\n\
+    \\DC2positive_int_value\CAN\EOT \SOH(\EOTR\DLEpositiveIntValue\DC2,\n\
+    \\DC2negative_int_value\CAN\ENQ \SOH(\ETXR\DLEnegativeIntValue\DC2!\n\
+    \\fdouble_value\CAN\ACK \SOH(\SOHR\vdoubleValue\DC2!\n\
+    \\fstring_value\CAN\a \SOH(\fR\vstringValue\DC2'\n\
+    \\SIaggregate_value\CAN\b \SOH(\tR\SOaggregateValue\SUBJ\n\
+    \\bNamePart\DC2\ESC\n\
+    \\tname_part\CAN\SOH \STX(\tR\bnamePart\DC2!\n\
+    \\fis_extension\CAN\STX \STX(\bR\visExtension\"\167\STX\n\
+    \\SOSourceCodeInfo\DC2D\n\
+    \\blocation\CAN\SOH \ETX(\v2(.google.protobuf.SourceCodeInfo.LocationR\blocation\SUB\206\SOH\n\
+    \\bLocation\DC2\SYN\n\
+    \\EOTpath\CAN\SOH \ETX(\ENQR\EOTpathB\STX\DLE\SOH\DC2\SYN\n\
+    \\EOTspan\CAN\STX \ETX(\ENQR\EOTspanB\STX\DLE\SOH\DC2)\n\
+    \\DLEleading_comments\CAN\ETX \SOH(\tR\SIleadingComments\DC2+\n\
+    \\DC1trailing_comments\CAN\EOT \SOH(\tR\DLEtrailingComments\DC2:\n\
+    \\EMleading_detached_comments\CAN\ACK \ETX(\tR\ETBleadingDetachedComments\"\209\SOH\n\
+    \\DC1GeneratedCodeInfo\DC2M\n\
+    \\n\
+    \annotation\CAN\SOH \ETX(\v2-.google.protobuf.GeneratedCodeInfo.AnnotationR\n\
+    \annotation\SUBm\n\
+    \\n\
+    \Annotation\DC2\SYN\n\
+    \\EOTpath\CAN\SOH \ETX(\ENQR\EOTpathB\STX\DLE\SOH\DC2\US\n\
+    \\vsource_file\CAN\STX \SOH(\tR\n\
+    \sourceFile\DC2\DC4\n\
+    \\ENQbegin\CAN\ETX \SOH(\ENQR\ENQbegin\DC2\DLE\n\
+    \\ETXend\CAN\EOT \SOH(\ENQR\ETXendB\143\SOH\n\
+    \\DC3com.google.protobufB\DLEDescriptorProtosH\SOHZ>github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor\248\SOH\SOH\162\STX\ETXGPB\170\STX\SUBGoogle.Protobuf.ReflectionJ\172\190\STX\n\
+    \\a\DC2\ENQ'\NUL\242\ACK\SOH\n\
+    \\170\SI\n\
+    \\SOH\f\DC2\ETX'\NUL\DC22\193\f Protocol Buffers - Google's data interchange format\n\
+    \ Copyright 2008 Google Inc.  All rights reserved.\n\
+    \ https://developers.google.com/protocol-buffers/\n\
+    \\n\
+    \ Redistribution and use in source and binary forms, with or without\n\
+    \ modification, are permitted provided that the following conditions are\n\
+    \ met:\n\
+    \\n\
+    \     * Redistributions of source code must retain the above copyright\n\
+    \ notice, this list of conditions and the following disclaimer.\n\
+    \     * Redistributions in binary form must reproduce the above\n\
+    \ copyright notice, this list of conditions and the following disclaimer\n\
+    \ in the documentation and/or other materials provided with the\n\
+    \ distribution.\n\
+    \     * Neither the name of Google Inc. nor the names of its\n\
+    \ contributors may be used to endorse or promote products derived from\n\
+    \ this software without specific prior written permission.\n\
+    \\n\
+    \ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS\n\
+    \ \"AS IS\" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT\n\
+    \ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\n\
+    \ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT\n\
+    \ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,\n\
+    \ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT\n\
+    \ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n\
+    \ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n\
+    \ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n\
+    \ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n\
+    \ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n\
+    \2\219\STX Author: kenton@google.com (Kenton Varda)\n\
+    \  Based on original Protocol Buffers design by\n\
+    \  Sanjay Ghemawat, Jeff Dean, and others.\n\
+    \\n\
+    \ The messages in this file describe the definitions found in .proto files.\n\
+    \ A valid .proto file can be translated directly to a FileDescriptorProto\n\
+    \ without any other information (e.g. without reading its imports).\n\
+    \\n\
+    \\b\n\
+    \\SOH\STX\DC2\ETX)\NUL\CAN\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX*\NULU\n\
+    \\t\n\
+    \\STX\b\v\DC2\ETX*\NULU\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX+\NUL,\n\
+    \\t\n\
+    \\STX\b\SOH\DC2\ETX+\NUL,\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX,\NUL1\n\
+    \\t\n\
+    \\STX\b\b\DC2\ETX,\NUL1\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX-\NUL7\n\
+    \\t\n\
+    \\STX\b%\DC2\ETX-\NUL7\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX.\NUL!\n\
+    \\t\n\
+    \\STX\b$\DC2\ETX.\NUL!\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX/\NUL\US\n\
+    \\t\n\
+    \\STX\b\US\DC2\ETX/\NUL\US\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX3\NUL\FS\n\
+    \\DEL\n\
+    \\STX\b\t\DC2\ETX3\NUL\FS\SUBt descriptor.proto must be optimized for speed because reflection-based\n\
+    \ algorithms don't work during bootstrapping.\n\
+    \\n\
+    \j\n\
+    \\STX\EOT\NUL\DC2\EOT7\NUL9\SOH\SUB^ The protocol compiler can output a FileDescriptorSet containing the .proto\n\
+    \ files it parses.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\NUL\SOH\DC2\ETX7\b\EM\n\
+    \\v\n\
+    \\EOT\EOT\NUL\STX\NUL\DC2\ETX8\STX(\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\EOT\DC2\ETX8\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\ACK\DC2\ETX8\v\RS\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\SOH\DC2\ETX8\US#\n\
+    \\f\n\
+    \\ENQ\EOT\NUL\STX\NUL\ETX\DC2\ETX8&'\n\
+    \/\n\
+    \\STX\EOT\SOH\DC2\EOT<\NULY\SOH\SUB# Describes a complete .proto file.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\SOH\SOH\DC2\ETX<\b\ESC\n\
+    \9\n\
+    \\EOT\EOT\SOH\STX\NUL\DC2\ETX=\STX\ESC\", file name, relative to root of source tree\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\EOT\DC2\ETX=\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\ENQ\DC2\ETX=\v\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\SOH\DC2\ETX=\DC2\SYN\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\NUL\ETX\DC2\ETX=\EM\SUB\n\
+    \*\n\
+    \\EOT\EOT\SOH\STX\SOH\DC2\ETX>\STX\RS\"\GS e.g. \"foo\", \"foo.bar\", etc.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\EOT\DC2\ETX>\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\ENQ\DC2\ETX>\v\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\SOH\DC2\ETX>\DC2\EM\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\SOH\ETX\DC2\ETX>\FS\GS\n\
+    \4\n\
+    \\EOT\EOT\SOH\STX\STX\DC2\ETXA\STX!\SUB' Names of files imported by this file.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\STX\EOT\DC2\ETXA\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\STX\ENQ\DC2\ETXA\v\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\STX\SOH\DC2\ETXA\DC2\FS\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\STX\ETX\DC2\ETXA\US \n\
+    \Q\n\
+    \\EOT\EOT\SOH\STX\ETX\DC2\ETXC\STX(\SUBD Indexes of the public imported files in the dependency list above.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ETX\EOT\DC2\ETXC\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ETX\ENQ\DC2\ETXC\v\DLE\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ETX\SOH\DC2\ETXC\DC1\"\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ETX\ETX\DC2\ETXC%'\n\
+    \z\n\
+    \\EOT\EOT\SOH\STX\EOT\DC2\ETXF\STX&\SUBm Indexes of the weak imported files in the dependency list.\n\
+    \ For Google-internal migration only. Do not use.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\EOT\EOT\DC2\ETXF\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\EOT\ENQ\DC2\ETXF\v\DLE\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\EOT\SOH\DC2\ETXF\DC1 \n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\EOT\ETX\DC2\ETXF#%\n\
+    \6\n\
+    \\EOT\EOT\SOH\STX\ENQ\DC2\ETXI\STX,\SUB) All top-level definitions in this file.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ENQ\EOT\DC2\ETXI\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ENQ\ACK\DC2\ETXI\v\SUB\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ENQ\SOH\DC2\ETXI\ESC'\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ENQ\ETX\DC2\ETXI*+\n\
+    \\v\n\
+    \\EOT\EOT\SOH\STX\ACK\DC2\ETXJ\STX-\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ACK\EOT\DC2\ETXJ\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ACK\ACK\DC2\ETXJ\v\RS\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ACK\SOH\DC2\ETXJ\US(\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\ACK\ETX\DC2\ETXJ+,\n\
+    \\v\n\
+    \\EOT\EOT\SOH\STX\a\DC2\ETXK\STX.\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\a\EOT\DC2\ETXK\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\a\ACK\DC2\ETXK\v!\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\a\SOH\DC2\ETXK\")\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\a\ETX\DC2\ETXK,-\n\
+    \\v\n\
+    \\EOT\EOT\SOH\STX\b\DC2\ETXL\STX.\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\b\EOT\DC2\ETXL\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\b\ACK\DC2\ETXL\v\US\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\b\SOH\DC2\ETXL )\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\b\ETX\DC2\ETXL,-\n\
+    \\v\n\
+    \\EOT\EOT\SOH\STX\t\DC2\ETXN\STX#\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\t\EOT\DC2\ETXN\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\t\ACK\DC2\ETXN\v\SYN\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\t\SOH\DC2\ETXN\ETB\RS\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\t\ETX\DC2\ETXN!\"\n\
+    \\244\SOH\n\
+    \\EOT\EOT\SOH\STX\n\
+    \\DC2\ETXT\STX/\SUB\230\SOH This field contains optional information about the original source code.\n\
+    \ You may safely remove this entire field without harming runtime\n\
+    \ functionality of the descriptors -- the information is needed only by\n\
+    \ development tools.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\n\
+    \\EOT\DC2\ETXT\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\n\
+    \\ACK\DC2\ETXT\v\EM\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\n\
+    \\SOH\DC2\ETXT\SUB*\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\n\
+    \\ETX\DC2\ETXT-.\n\
+    \]\n\
+    \\EOT\EOT\SOH\STX\v\DC2\ETXX\STX\RS\SUBP The syntax of the proto file.\n\
+    \ The supported values are \"proto2\" and \"proto3\".\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\v\EOT\DC2\ETXX\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\v\ENQ\DC2\ETXX\v\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\v\SOH\DC2\ETXX\DC2\CAN\n\
+    \\f\n\
+    \\ENQ\EOT\SOH\STX\v\ETX\DC2\ETXX\ESC\GS\n\
+    \'\n\
+    \\STX\EOT\STX\DC2\EOT\\\NUL|\SOH\SUB\ESC Describes a message type.\n\
+    \\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\STX\SOH\DC2\ETX\\\b\ETB\n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\NUL\DC2\ETX]\STX\ESC\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\EOT\DC2\ETX]\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\ENQ\DC2\ETX]\v\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\SOH\DC2\ETX]\DC2\SYN\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\NUL\ETX\DC2\ETX]\EM\SUB\n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\SOH\DC2\ETX_\STX*\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\EOT\DC2\ETX_\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\ACK\DC2\ETX_\v\US\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\SOH\DC2\ETX_ %\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\ETX\DC2\ETX_()\n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\STX\DC2\ETX`\STX.\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\STX\EOT\DC2\ETX`\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\STX\ACK\DC2\ETX`\v\US\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\STX\SOH\DC2\ETX` )\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\STX\ETX\DC2\ETX`,-\n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\ETX\DC2\ETXb\STX+\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ETX\EOT\DC2\ETXb\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ETX\ACK\DC2\ETXb\v\SUB\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ETX\SOH\DC2\ETXb\ESC&\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ETX\ETX\DC2\ETXb)*\n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\EOT\DC2\ETXc\STX-\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\EOT\EOT\DC2\ETXc\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\EOT\ACK\DC2\ETXc\v\RS\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\EOT\SOH\DC2\ETXc\US(\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\EOT\ETX\DC2\ETXc+,\n\
+    \\f\n\
+    \\EOT\EOT\STX\ETX\NUL\DC2\EOTe\STXj\ETX\n\
+    \\f\n\
+    \\ENQ\EOT\STX\ETX\NUL\SOH\DC2\ETXe\n\
+    \\CAN\n\
+    \\r\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\NUL\DC2\ETXf\EOT\GS\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\EOT\DC2\ETXf\EOT\f\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\ENQ\DC2\ETXf\r\DC2\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\SOH\DC2\ETXf\DC3\CAN\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\ETX\DC2\ETXf\ESC\FS\n\
+    \\r\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\SOH\DC2\ETXg\EOT\ESC\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\EOT\DC2\ETXg\EOT\f\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\ENQ\DC2\ETXg\r\DC2\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\SOH\DC2\ETXg\DC3\SYN\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\ETX\DC2\ETXg\EM\SUB\n\
+    \\r\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\STX\DC2\ETXi\EOT/\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\EOT\DC2\ETXi\EOT\f\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\ACK\DC2\ETXi\r\"\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\SOH\DC2\ETXi#*\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\ETX\DC2\ETXi-.\n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\ENQ\DC2\ETXk\STX.\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ENQ\EOT\DC2\ETXk\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ENQ\ACK\DC2\ETXk\v\EM\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ENQ\SOH\DC2\ETXk\SUB)\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ENQ\ETX\DC2\ETXk,-\n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\ACK\DC2\ETXm\STX/\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ACK\EOT\DC2\ETXm\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ACK\ACK\DC2\ETXm\v\US\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ACK\SOH\DC2\ETXm *\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\ACK\ETX\DC2\ETXm-.\n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\a\DC2\ETXo\STX&\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\a\EOT\DC2\ETXo\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\a\ACK\DC2\ETXo\v\EM\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\a\SOH\DC2\ETXo\SUB!\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\a\ETX\DC2\ETXo$%\n\
+    \\170\SOH\n\
+    \\EOT\EOT\STX\ETX\SOH\DC2\EOTt\STXw\ETX\SUB\155\SOH Range of reserved tag numbers. Reserved tag numbers may not be used by\n\
+    \ fields or extension ranges in the same message. Reserved ranges may\n\
+    \ not overlap.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\ETX\SOH\SOH\DC2\ETXt\n\
+    \\ETB\n\
+    \\ESC\n\
+    \\ACK\EOT\STX\ETX\SOH\STX\NUL\DC2\ETXu\EOT\GS\"\f Inclusive.\n\
+    \\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\SOH\STX\NUL\EOT\DC2\ETXu\EOT\f\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\SOH\STX\NUL\ENQ\DC2\ETXu\r\DC2\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\SOH\STX\NUL\SOH\DC2\ETXu\DC3\CAN\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\SOH\STX\NUL\ETX\DC2\ETXu\ESC\FS\n\
+    \\ESC\n\
+    \\ACK\EOT\STX\ETX\SOH\STX\SOH\DC2\ETXv\EOT\ESC\"\f Exclusive.\n\
+    \\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\SOH\STX\SOH\EOT\DC2\ETXv\EOT\f\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\SOH\STX\SOH\ENQ\DC2\ETXv\r\DC2\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\SOH\STX\SOH\SOH\DC2\ETXv\DC3\SYN\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\SOH\STX\SOH\ETX\DC2\ETXv\EM\SUB\n\
+    \\v\n\
+    \\EOT\EOT\STX\STX\b\DC2\ETXx\STX,\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\b\EOT\DC2\ETXx\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\b\ACK\DC2\ETXx\v\CAN\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\b\SOH\DC2\ETXx\EM'\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\b\ETX\DC2\ETXx*+\n\
+    \\130\SOH\n\
+    \\EOT\EOT\STX\STX\t\DC2\ETX{\STX%\SUBu Reserved field names, which may not be used by fields in the same message.\n\
+    \ A given name may only be reserved once.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\t\EOT\DC2\ETX{\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\t\ENQ\DC2\ETX{\v\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\t\SOH\DC2\ETX{\DC2\US\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\t\ETX\DC2\ETX{\"$\n\
+    \\v\n\
+    \\STX\EOT\ETX\DC2\ENQ~\NUL\132\SOH\SOH\n\
+    \\n\
+    \\n\
+    \\ETX\EOT\ETX\SOH\DC2\ETX~\b\GS\n\
+    \O\n\
+    \\EOT\EOT\ETX\STX\NUL\DC2\EOT\128\SOH\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ETX\STX\NUL\EOT\DC2\EOT\128\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ETX\STX\NUL\ACK\DC2\EOT\128\SOH\v\RS\n\
+    \\r\n\
+    \\ENQ\EOT\ETX\STX\NUL\SOH\DC2\EOT\128\SOH\US3\n\
+    \\r\n\
+    \\ENQ\EOT\ETX\STX\NUL\ETX\DC2\EOT\128\SOH69\n\
+    \Z\n\
+    \\ETX\EOT\ETX\ENQ\DC2\EOT\131\SOH\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\ETX\ENQ\NUL\DC2\EOT\131\SOH\r\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\ETX\ENQ\NUL\SOH\DC2\EOT\131\SOH\r\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\ETX\ENQ\NUL\STX\DC2\EOT\131\SOH\NAK\CAN\n\
+    \3\n\
+    \\STX\EOT\EOT\DC2\ACK\135\SOH\NUL\213\SOH\SOH\SUB% Describes a field within a message.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\EOT\SOH\DC2\EOT\135\SOH\b\FS\n\
+    \\SO\n\
+    \\EOT\EOT\EOT\EOT\NUL\DC2\ACK\136\SOH\STX\167\SOH\ETX\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\EOT\NUL\SOH\DC2\EOT\136\SOH\a\v\n\
+    \S\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\NUL\DC2\EOT\139\SOH\EOT\FS\SUBC 0 is reserved for errors.\n\
+    \ Order is weird for historical reasons.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\NUL\SOH\DC2\EOT\139\SOH\EOT\SI\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\NUL\STX\DC2\EOT\139\SOH\SUB\ESC\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\SOH\DC2\EOT\140\SOH\EOT\FS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SOH\SOH\DC2\EOT\140\SOH\EOT\SO\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SOH\STX\DC2\EOT\140\SOH\SUB\ESC\n\
+    \w\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\STX\DC2\EOT\143\SOH\EOT\FS\SUBg Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if\n\
+    \ negative values are likely.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\STX\SOH\DC2\EOT\143\SOH\EOT\SO\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\STX\STX\DC2\EOT\143\SOH\SUB\ESC\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\ETX\DC2\EOT\144\SOH\EOT\FS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ETX\SOH\DC2\EOT\144\SOH\EOT\SI\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ETX\STX\DC2\EOT\144\SOH\SUB\ESC\n\
+    \w\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\EOT\DC2\EOT\147\SOH\EOT\FS\SUBg Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if\n\
+    \ negative values are likely.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\EOT\SOH\DC2\EOT\147\SOH\EOT\SO\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\EOT\STX\DC2\EOT\147\SOH\SUB\ESC\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\ENQ\DC2\EOT\148\SOH\EOT\FS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ENQ\SOH\DC2\EOT\148\SOH\EOT\DLE\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ENQ\STX\DC2\EOT\148\SOH\SUB\ESC\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\ACK\DC2\EOT\149\SOH\EOT\FS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ACK\SOH\DC2\EOT\149\SOH\EOT\DLE\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ACK\STX\DC2\EOT\149\SOH\SUB\ESC\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\a\DC2\EOT\150\SOH\EOT\FS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\a\SOH\DC2\EOT\150\SOH\EOT\r\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\a\STX\DC2\EOT\150\SOH\SUB\ESC\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\b\DC2\EOT\151\SOH\EOT\FS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\b\SOH\DC2\EOT\151\SOH\EOT\SI\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\b\STX\DC2\EOT\151\SOH\SUB\ESC\n\
+    \\226\SOH\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\t\DC2\EOT\156\SOH\EOT\GS\SUB\209\SOH Tag-delimited aggregate.\n\
+    \ Group type is deprecated and not supported in proto3. However, Proto3\n\
+    \ implementations should still be able to parse the group wire format and\n\
+    \ treat group fields as unknown fields.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\t\SOH\DC2\EOT\156\SOH\EOT\SO\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\t\STX\DC2\EOT\156\SOH\SUB\FS\n\
+    \-\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\n\
+    \\DC2\EOT\157\SOH\EOT\GS\"\GS Length-delimited aggregate.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\n\
+    \\SOH\DC2\EOT\157\SOH\EOT\DLE\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\n\
+    \\STX\DC2\EOT\157\SOH\SUB\FS\n\
+    \#\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\v\DC2\EOT\160\SOH\EOT\GS\SUB\DC3 New in version 2.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\v\SOH\DC2\EOT\160\SOH\EOT\SO\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\v\STX\DC2\EOT\160\SOH\SUB\FS\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\f\DC2\EOT\161\SOH\EOT\GS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\f\SOH\DC2\EOT\161\SOH\EOT\SI\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\f\STX\DC2\EOT\161\SOH\SUB\FS\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\r\DC2\EOT\162\SOH\EOT\GS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\r\SOH\DC2\EOT\162\SOH\EOT\r\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\r\STX\DC2\EOT\162\SOH\SUB\FS\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\SO\DC2\EOT\163\SOH\EOT\GS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SO\SOH\DC2\EOT\163\SOH\EOT\DC1\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SO\STX\DC2\EOT\163\SOH\SUB\FS\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\SI\DC2\EOT\164\SOH\EOT\GS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SI\SOH\DC2\EOT\164\SOH\EOT\DC1\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SI\STX\DC2\EOT\164\SOH\SUB\FS\n\
+    \'\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\DLE\DC2\EOT\165\SOH\EOT\GS\"\ETB Uses ZigZag encoding.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\DLE\SOH\DC2\EOT\165\SOH\EOT\SI\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\DLE\STX\DC2\EOT\165\SOH\SUB\FS\n\
+    \'\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\DC1\DC2\EOT\166\SOH\EOT\GS\"\ETB Uses ZigZag encoding.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\DC1\SOH\DC2\EOT\166\SOH\EOT\SI\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\DC1\STX\DC2\EOT\166\SOH\SUB\FS\n\
+    \\SO\n\
+    \\EOT\EOT\EOT\EOT\SOH\DC2\ACK\169\SOH\STX\174\SOH\ETX\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\EOT\SOH\SOH\DC2\EOT\169\SOH\a\f\n\
+    \*\n\
+    \\ACK\EOT\EOT\EOT\SOH\STX\NUL\DC2\EOT\171\SOH\EOT\FS\SUB\SUB 0 is reserved for errors\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\SOH\STX\NUL\SOH\DC2\EOT\171\SOH\EOT\DC2\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\SOH\STX\NUL\STX\DC2\EOT\171\SOH\SUB\ESC\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\SOH\STX\SOH\DC2\EOT\172\SOH\EOT\FS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\SOH\STX\SOH\SOH\DC2\EOT\172\SOH\EOT\DC2\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\SOH\STX\SOH\STX\DC2\EOT\172\SOH\SUB\ESC\n\
+    \\SO\n\
+    \\ACK\EOT\EOT\EOT\SOH\STX\STX\DC2\EOT\173\SOH\EOT\FS\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\SOH\STX\STX\SOH\DC2\EOT\173\SOH\EOT\DC2\n\
+    \\SI\n\
+    \\a\EOT\EOT\EOT\SOH\STX\STX\STX\DC2\EOT\173\SOH\SUB\ESC\n\
+    \\f\n\
+    \\EOT\EOT\EOT\STX\NUL\DC2\EOT\176\SOH\STX\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\NUL\EOT\DC2\EOT\176\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\NUL\ENQ\DC2\EOT\176\SOH\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\NUL\SOH\DC2\EOT\176\SOH\DC2\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\NUL\ETX\DC2\EOT\176\SOH\EM\SUB\n\
+    \\f\n\
+    \\EOT\EOT\EOT\STX\SOH\DC2\EOT\177\SOH\STX\FS\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\SOH\EOT\DC2\EOT\177\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\SOH\ENQ\DC2\EOT\177\SOH\v\DLE\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\SOH\SOH\DC2\EOT\177\SOH\DC1\ETB\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\SOH\ETX\DC2\EOT\177\SOH\SUB\ESC\n\
+    \\f\n\
+    \\EOT\EOT\EOT\STX\STX\DC2\EOT\178\SOH\STX\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\STX\EOT\DC2\EOT\178\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\STX\ACK\DC2\EOT\178\SOH\v\DLE\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\STX\SOH\DC2\EOT\178\SOH\DC1\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\STX\ETX\DC2\EOT\178\SOH\EM\SUB\n\
+    \\156\SOH\n\
+    \\EOT\EOT\EOT\STX\ETX\DC2\EOT\182\SOH\STX\EM\SUB\141\SOH If type_name is set, this need not be set.  If both this and type_name\n\
+    \ are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ETX\EOT\DC2\EOT\182\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ETX\ACK\DC2\EOT\182\SOH\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ETX\SOH\DC2\EOT\182\SOH\DLE\DC4\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ETX\ETX\DC2\EOT\182\SOH\ETB\CAN\n\
+    \\183\STX\n\
+    \\EOT\EOT\EOT\STX\EOT\DC2\EOT\189\SOH\STX \SUB\168\STX For message and enum types, this is the name of the type.  If the name\n\
+    \ starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping\n\
+    \ rules are used to find the type (i.e. first the nested types within this\n\
+    \ message are searched, then within the parent, on up to the root\n\
+    \ namespace).\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\EOT\EOT\DC2\EOT\189\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\EOT\ENQ\DC2\EOT\189\SOH\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\EOT\SOH\DC2\EOT\189\SOH\DC2\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\EOT\ETX\DC2\EOT\189\SOH\RS\US\n\
+    \~\n\
+    \\EOT\EOT\EOT\STX\ENQ\DC2\EOT\193\SOH\STX\US\SUBp For extensions, this is the name of the type being extended.  It is\n\
+    \ resolved in the same manner as type_name.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ENQ\EOT\DC2\EOT\193\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ENQ\ENQ\DC2\EOT\193\SOH\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ENQ\SOH\DC2\EOT\193\SOH\DC2\SUB\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ENQ\ETX\DC2\EOT\193\SOH\GS\RS\n\
+    \\177\STX\n\
+    \\EOT\EOT\EOT\STX\ACK\DC2\EOT\200\SOH\STX$\SUB\162\STX For numeric types, contains the original text representation of the value.\n\
+    \ For booleans, \"true\" or \"false\".\n\
+    \ For strings, contains the default text contents (not escaped in any way).\n\
+    \ For bytes, contains the C escaped value.  All bytes >= 128 are escaped.\n\
+    \ TODO(kenton):  Base-64 encode?\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ACK\EOT\DC2\EOT\200\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ACK\ENQ\DC2\EOT\200\SOH\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ACK\SOH\DC2\EOT\200\SOH\DC2\US\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\ACK\ETX\DC2\EOT\200\SOH\"#\n\
+    \\132\SOH\n\
+    \\EOT\EOT\EOT\STX\a\DC2\EOT\204\SOH\STX!\SUBv If set, gives the index of a oneof in the containing type's oneof_decl\n\
+    \ list.  This field is a member of that oneof.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\a\EOT\DC2\EOT\204\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\a\ENQ\DC2\EOT\204\SOH\v\DLE\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\a\SOH\DC2\EOT\204\SOH\DC1\FS\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\a\ETX\DC2\EOT\204\SOH\US \n\
+    \\250\SOH\n\
+    \\EOT\EOT\EOT\STX\b\DC2\EOT\210\SOH\STX!\SUB\235\SOH JSON name of this field. The value is set by protocol compiler. If the\n\
+    \ user has set a \"json_name\" option on this field, that option's value\n\
+    \ will be used. Otherwise, it's deduced from the field's name by converting\n\
+    \ it to camelCase.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\b\EOT\DC2\EOT\210\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\b\ENQ\DC2\EOT\210\SOH\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\b\SOH\DC2\EOT\210\SOH\DC2\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\b\ETX\DC2\EOT\210\SOH\RS \n\
+    \\f\n\
+    \\EOT\EOT\EOT\STX\t\DC2\EOT\212\SOH\STX$\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\t\EOT\DC2\EOT\212\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\t\ACK\DC2\EOT\212\SOH\v\ETB\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\t\SOH\DC2\EOT\212\SOH\CAN\US\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\t\ETX\DC2\EOT\212\SOH\"#\n\
+    \\"\n\
+    \\STX\EOT\ENQ\DC2\ACK\216\SOH\NUL\219\SOH\SOH\SUB\DC4 Describes a oneof.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\ENQ\SOH\DC2\EOT\216\SOH\b\FS\n\
+    \\f\n\
+    \\EOT\EOT\ENQ\STX\NUL\DC2\EOT\217\SOH\STX\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\NUL\EOT\DC2\EOT\217\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\NUL\ENQ\DC2\EOT\217\SOH\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\NUL\SOH\DC2\EOT\217\SOH\DC2\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\NUL\ETX\DC2\EOT\217\SOH\EM\SUB\n\
+    \\f\n\
+    \\EOT\EOT\ENQ\STX\SOH\DC2\EOT\218\SOH\STX$\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\SOH\EOT\DC2\EOT\218\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\SOH\ACK\DC2\EOT\218\SOH\v\ETB\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\SOH\SOH\DC2\EOT\218\SOH\CAN\US\n\
+    \\r\n\
+    \\ENQ\EOT\ENQ\STX\SOH\ETX\DC2\EOT\218\SOH\"#\n\
+    \'\n\
+    \\STX\EOT\ACK\DC2\ACK\222\SOH\NUL\248\SOH\SOH\SUB\EM Describes an enum type.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\ACK\SOH\DC2\EOT\222\SOH\b\ESC\n\
+    \\f\n\
+    \\EOT\EOT\ACK\STX\NUL\DC2\EOT\223\SOH\STX\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\NUL\EOT\DC2\EOT\223\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\NUL\ENQ\DC2\EOT\223\SOH\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\NUL\SOH\DC2\EOT\223\SOH\DC2\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\NUL\ETX\DC2\EOT\223\SOH\EM\SUB\n\
+    \\f\n\
+    \\EOT\EOT\ACK\STX\SOH\DC2\EOT\225\SOH\STX.\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\SOH\EOT\DC2\EOT\225\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\SOH\ACK\DC2\EOT\225\SOH\v#\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\SOH\SOH\DC2\EOT\225\SOH$)\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\SOH\ETX\DC2\EOT\225\SOH,-\n\
+    \\f\n\
+    \\EOT\EOT\ACK\STX\STX\DC2\EOT\227\SOH\STX#\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\STX\EOT\DC2\EOT\227\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\STX\ACK\DC2\EOT\227\SOH\v\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\STX\SOH\DC2\EOT\227\SOH\ETB\RS\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\STX\ETX\DC2\EOT\227\SOH!\"\n\
+    \\175\STX\n\
+    \\EOT\EOT\ACK\ETX\NUL\DC2\ACK\235\SOH\STX\238\SOH\ETX\SUB\158\STX Range of reserved numeric values. Reserved values may not be used by\n\
+    \ entries in the same enum. Reserved ranges may not overlap.\n\
+    \\n\
+    \ Note that this is distinct from DescriptorProto.ReservedRange in that it\n\
+    \ is inclusive such that it can appropriately represent the entire int32\n\
+    \ domain.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\ETX\NUL\SOH\DC2\EOT\235\SOH\n\
+    \\ESC\n\
+    \\FS\n\
+    \\ACK\EOT\ACK\ETX\NUL\STX\NUL\DC2\EOT\236\SOH\EOT\GS\"\f Inclusive.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\ACK\ETX\NUL\STX\NUL\EOT\DC2\EOT\236\SOH\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\ACK\ETX\NUL\STX\NUL\ENQ\DC2\EOT\236\SOH\r\DC2\n\
+    \\SI\n\
+    \\a\EOT\ACK\ETX\NUL\STX\NUL\SOH\DC2\EOT\236\SOH\DC3\CAN\n\
+    \\SI\n\
+    \\a\EOT\ACK\ETX\NUL\STX\NUL\ETX\DC2\EOT\236\SOH\ESC\FS\n\
+    \\FS\n\
+    \\ACK\EOT\ACK\ETX\NUL\STX\SOH\DC2\EOT\237\SOH\EOT\ESC\"\f Inclusive.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\ACK\ETX\NUL\STX\SOH\EOT\DC2\EOT\237\SOH\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\ACK\ETX\NUL\STX\SOH\ENQ\DC2\EOT\237\SOH\r\DC2\n\
+    \\SI\n\
+    \\a\EOT\ACK\ETX\NUL\STX\SOH\SOH\DC2\EOT\237\SOH\DC3\SYN\n\
+    \\SI\n\
+    \\a\EOT\ACK\ETX\NUL\STX\SOH\ETX\DC2\EOT\237\SOH\EM\SUB\n\
+    \\170\SOH\n\
+    \\EOT\EOT\ACK\STX\ETX\DC2\EOT\243\SOH\STX0\SUB\155\SOH Range of reserved numeric values. Reserved numeric values may not be used\n\
+    \ by enum values in the same enum declaration. Reserved ranges may not\n\
+    \ overlap.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\ETX\EOT\DC2\EOT\243\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\ETX\ACK\DC2\EOT\243\SOH\v\FS\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\ETX\SOH\DC2\EOT\243\SOH\GS+\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\ETX\ETX\DC2\EOT\243\SOH./\n\
+    \l\n\
+    \\EOT\EOT\ACK\STX\EOT\DC2\EOT\247\SOH\STX$\SUB^ Reserved enum value names, which may not be reused. A given name may only\n\
+    \ be reserved once.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\EOT\EOT\DC2\EOT\247\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\EOT\ENQ\DC2\EOT\247\SOH\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\EOT\SOH\DC2\EOT\247\SOH\DC2\US\n\
+    \\r\n\
+    \\ENQ\EOT\ACK\STX\EOT\ETX\DC2\EOT\247\SOH\"#\n\
+    \1\n\
+    \\STX\EOT\a\DC2\ACK\251\SOH\NUL\128\STX\SOH\SUB# Describes a value within an enum.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\a\SOH\DC2\EOT\251\SOH\b \n\
+    \\f\n\
+    \\EOT\EOT\a\STX\NUL\DC2\EOT\252\SOH\STX\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\NUL\EOT\DC2\EOT\252\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\NUL\ENQ\DC2\EOT\252\SOH\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\NUL\SOH\DC2\EOT\252\SOH\DC2\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\NUL\ETX\DC2\EOT\252\SOH\EM\SUB\n\
+    \\f\n\
+    \\EOT\EOT\a\STX\SOH\DC2\EOT\253\SOH\STX\FS\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\SOH\EOT\DC2\EOT\253\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\SOH\ENQ\DC2\EOT\253\SOH\v\DLE\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\SOH\SOH\DC2\EOT\253\SOH\DC1\ETB\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\SOH\ETX\DC2\EOT\253\SOH\SUB\ESC\n\
+    \\f\n\
+    \\EOT\EOT\a\STX\STX\DC2\EOT\255\SOH\STX(\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\STX\EOT\DC2\EOT\255\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\STX\ACK\DC2\EOT\255\SOH\v\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\STX\SOH\DC2\EOT\255\SOH\FS#\n\
+    \\r\n\
+    \\ENQ\EOT\a\STX\STX\ETX\DC2\EOT\255\SOH&'\n\
+    \$\n\
+    \\STX\EOT\b\DC2\ACK\131\STX\NUL\136\STX\SOH\SUB\SYN Describes a service.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\b\SOH\DC2\EOT\131\STX\b\RS\n\
+    \\f\n\
+    \\EOT\EOT\b\STX\NUL\DC2\EOT\132\STX\STX\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\NUL\EOT\DC2\EOT\132\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\NUL\ENQ\DC2\EOT\132\STX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\NUL\SOH\DC2\EOT\132\STX\DC2\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\NUL\ETX\DC2\EOT\132\STX\EM\SUB\n\
+    \\f\n\
+    \\EOT\EOT\b\STX\SOH\DC2\EOT\133\STX\STX,\n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\SOH\EOT\DC2\EOT\133\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\SOH\ACK\DC2\EOT\133\STX\v \n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\SOH\SOH\DC2\EOT\133\STX!'\n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\SOH\ETX\DC2\EOT\133\STX*+\n\
+    \\f\n\
+    \\EOT\EOT\b\STX\STX\DC2\EOT\135\STX\STX&\n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\STX\EOT\DC2\EOT\135\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\STX\ACK\DC2\EOT\135\STX\v\EM\n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\STX\SOH\DC2\EOT\135\STX\SUB!\n\
+    \\r\n\
+    \\ENQ\EOT\b\STX\STX\ETX\DC2\EOT\135\STX$%\n\
+    \0\n\
+    \\STX\EOT\t\DC2\ACK\139\STX\NUL\153\STX\SOH\SUB\" Describes a method of a service.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\t\SOH\DC2\EOT\139\STX\b\GS\n\
+    \\f\n\
+    \\EOT\EOT\t\STX\NUL\DC2\EOT\140\STX\STX\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\NUL\EOT\DC2\EOT\140\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\NUL\ENQ\DC2\EOT\140\STX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\NUL\SOH\DC2\EOT\140\STX\DC2\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\NUL\ETX\DC2\EOT\140\STX\EM\SUB\n\
+    \\151\SOH\n\
+    \\EOT\EOT\t\STX\SOH\DC2\EOT\144\STX\STX!\SUB\136\SOH Input and output type names.  These are resolved in the same way as\n\
+    \ FieldDescriptorProto.type_name, but must refer to a message type.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\SOH\EOT\DC2\EOT\144\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\SOH\ENQ\DC2\EOT\144\STX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\SOH\SOH\DC2\EOT\144\STX\DC2\FS\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\SOH\ETX\DC2\EOT\144\STX\US \n\
+    \\f\n\
+    \\EOT\EOT\t\STX\STX\DC2\EOT\145\STX\STX\"\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\STX\EOT\DC2\EOT\145\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\STX\ENQ\DC2\EOT\145\STX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\STX\SOH\DC2\EOT\145\STX\DC2\GS\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\STX\ETX\DC2\EOT\145\STX !\n\
+    \\f\n\
+    \\EOT\EOT\t\STX\ETX\DC2\EOT\147\STX\STX%\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\ETX\EOT\DC2\EOT\147\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\ETX\ACK\DC2\EOT\147\STX\v\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\ETX\SOH\DC2\EOT\147\STX\EM \n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\ETX\ETX\DC2\EOT\147\STX#$\n\
+    \E\n\
+    \\EOT\EOT\t\STX\EOT\DC2\EOT\150\STX\STX5\SUB7 Identifies if client streams multiple client messages\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\EOT\EOT\DC2\EOT\150\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\EOT\ENQ\DC2\EOT\150\STX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\EOT\SOH\DC2\EOT\150\STX\DLE \n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\EOT\ETX\DC2\EOT\150\STX#$\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\EOT\b\DC2\EOT\150\STX%4\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\EOT\a\DC2\EOT\150\STX.3\n\
+    \E\n\
+    \\EOT\EOT\t\STX\ENQ\DC2\EOT\152\STX\STX5\SUB7 Identifies if server streams multiple server messages\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\ENQ\EOT\DC2\EOT\152\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\ENQ\ENQ\DC2\EOT\152\STX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\ENQ\SOH\DC2\EOT\152\STX\DLE \n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\ENQ\ETX\DC2\EOT\152\STX#$\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\ENQ\b\DC2\EOT\152\STX%4\n\
+    \\r\n\
+    \\ENQ\EOT\t\STX\ENQ\a\DC2\EOT\152\STX.3\n\
+    \\175\SO\n\
+    \\STX\EOT\n\
+    \\DC2\ACK\189\STX\NUL\183\ETX\SOH2N ===================================================================\n\
+    \ Options\n\
+    \2\208\r Each of the definitions above may have \"options\" attached.  These are\n\
+    \ just annotations which may cause code to be generated slightly differently\n\
+    \ or may contain hints for code that manipulates protocol messages.\n\
+    \\n\
+    \ Clients may define custom options as extensions of the *Options messages.\n\
+    \ These extensions may not yet be known at parsing time, so the parser cannot\n\
+    \ store the values in them.  Instead it stores them in a field in the *Options\n\
+    \ message called uninterpreted_option. This field must have the same name\n\
+    \ across all *Options messages. We then use this field to populate the\n\
+    \ extensions when we build a descriptor, at which point all protos have been\n\
+    \ parsed and so all extensions are known.\n\
+    \\n\
+    \ Extension numbers for custom options may be chosen as follows:\n\
+    \ * For options which will only be used within a single application or\n\
+    \   organization, or for experimental options, use field numbers 50000\n\
+    \   through 99999.  It is up to you to ensure that you do not use the\n\
+    \   same number for multiple options.\n\
+    \ * For options which will be published and used publicly by multiple\n\
+    \   independent entities, e-mail protobuf-global-extension-registry@google.com\n\
+    \   to reserve extension numbers. Simply provide your project name (e.g.\n\
+    \   Objective-C plugin) and your project website (if available) -- there's no\n\
+    \   need to explain how you intend to use them. Usually you only need one\n\
+    \   extension number. You can declare multiple options with only one extension\n\
+    \   number by putting them in a sub-message. See the Custom Options section of\n\
+    \   the docs for examples:\n\
+    \   https://developers.google.com/protocol-buffers/docs/proto#options\n\
+    \   If this turns out to be popular, a web service will be set up\n\
+    \   to automatically assign option numbers.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\n\
+    \\SOH\DC2\EOT\189\STX\b\DC3\n\
+    \\244\SOH\n\
+    \\EOT\EOT\n\
+    \\STX\NUL\DC2\EOT\195\STX\STX#\SUB\229\SOH Sets the Java package where classes generated from this .proto will be\n\
+    \ placed.  By default, the proto package is used, but this is often\n\
+    \ inappropriate because proto packages do not normally start with backwards\n\
+    \ domain names.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\NUL\EOT\DC2\EOT\195\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\NUL\ENQ\DC2\EOT\195\STX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\NUL\SOH\DC2\EOT\195\STX\DC2\RS\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\NUL\ETX\DC2\EOT\195\STX!\"\n\
+    \\191\STX\n\
+    \\EOT\EOT\n\
+    \\STX\SOH\DC2\EOT\203\STX\STX+\SUB\176\STX If set, all the classes from the .proto file are wrapped in a single\n\
+    \ outer class with the given name.  This applies to both Proto1\n\
+    \ (equivalent to the old \"--one_java_file\" option) and Proto2 (where\n\
+    \ a .proto always translates to a single class, but you may want to\n\
+    \ explicitly choose the class name).\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SOH\EOT\DC2\EOT\203\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SOH\ENQ\DC2\EOT\203\STX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SOH\SOH\DC2\EOT\203\STX\DC2&\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SOH\ETX\DC2\EOT\203\STX)*\n\
+    \\163\ETX\n\
+    \\EOT\EOT\n\
+    \\STX\STX\DC2\EOT\211\STX\STX9\SUB\148\ETX If set true, then the Java code generator will generate a separate .java\n\
+    \ file for each top-level message, enum, and service defined in the .proto\n\
+    \ file.  Thus, these types will *not* be nested inside the outer class\n\
+    \ named by java_outer_classname.  However, the outer class will still be\n\
+    \ generated to contain the file's getDescriptor() method as well as any\n\
+    \ top-level extensions defined in the file.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\STX\EOT\DC2\EOT\211\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\STX\ENQ\DC2\EOT\211\STX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\STX\SOH\DC2\EOT\211\STX\DLE#\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\STX\ETX\DC2\EOT\211\STX&(\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\STX\b\DC2\EOT\211\STX)8\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\STX\a\DC2\EOT\211\STX27\n\
+    \)\n\
+    \\EOT\EOT\n\
+    \\STX\ETX\DC2\EOT\214\STX\STXE\SUB\ESC This option does nothing.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ETX\EOT\DC2\EOT\214\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ETX\ENQ\DC2\EOT\214\STX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ETX\SOH\DC2\EOT\214\STX\DLE-\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ETX\ETX\DC2\EOT\214\STX02\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ETX\b\DC2\EOT\214\STX3D\n\
+    \\SO\n\
+    \\ACK\EOT\n\
+    \\STX\ETX\b\ETX\DC2\EOT\214\STX4C\n\
+    \\230\STX\n\
+    \\EOT\EOT\n\
+    \\STX\EOT\DC2\EOT\222\STX\STX<\SUB\215\STX If set true, then the Java2 code generator will generate code that\n\
+    \ throws an exception whenever an attempt is made to assign a non-UTF-8\n\
+    \ byte sequence to a string field.\n\
+    \ Message reflection will do the same.\n\
+    \ However, an extension field still accepts non-UTF-8 byte sequences.\n\
+    \ This option has no effect on when used with the lite runtime.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\EOT\EOT\DC2\EOT\222\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\EOT\ENQ\DC2\EOT\222\STX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\EOT\SOH\DC2\EOT\222\STX\DLE&\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\EOT\ETX\DC2\EOT\222\STX)+\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\EOT\b\DC2\EOT\222\STX,;\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\EOT\a\DC2\EOT\222\STX5:\n\
+    \L\n\
+    \\EOT\EOT\n\
+    \\EOT\NUL\DC2\ACK\226\STX\STX\231\STX\ETX\SUB< Generated classes can be optimized for speed or code size.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\EOT\NUL\SOH\DC2\EOT\226\STX\a\DC3\n\
+    \D\n\
+    \\ACK\EOT\n\
+    \\EOT\NUL\STX\NUL\DC2\EOT\227\STX\EOT\SO\"4 Generate complete code for parsing, serialization,\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\n\
+    \\EOT\NUL\STX\NUL\SOH\DC2\EOT\227\STX\EOT\t\n\
+    \\SI\n\
+    \\a\EOT\n\
+    \\EOT\NUL\STX\NUL\STX\DC2\EOT\227\STX\f\r\n\
+    \G\n\
+    \\ACK\EOT\n\
+    \\EOT\NUL\STX\SOH\DC2\EOT\229\STX\EOT\DC2\SUB\ACK etc.\n\
+    \\"/ Use ReflectionOps to implement these methods.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\n\
+    \\EOT\NUL\STX\SOH\SOH\DC2\EOT\229\STX\EOT\r\n\
+    \\SI\n\
+    \\a\EOT\n\
+    \\EOT\NUL\STX\SOH\STX\DC2\EOT\229\STX\DLE\DC1\n\
+    \G\n\
+    \\ACK\EOT\n\
+    \\EOT\NUL\STX\STX\DC2\EOT\230\STX\EOT\NAK\"7 Generate code using MessageLite and the lite runtime.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\n\
+    \\EOT\NUL\STX\STX\SOH\DC2\EOT\230\STX\EOT\DLE\n\
+    \\SI\n\
+    \\a\EOT\n\
+    \\EOT\NUL\STX\STX\STX\DC2\EOT\230\STX\DC3\DC4\n\
+    \\f\n\
+    \\EOT\EOT\n\
+    \\STX\ENQ\DC2\EOT\232\STX\STX9\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ENQ\EOT\DC2\EOT\232\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ENQ\ACK\DC2\EOT\232\STX\v\ETB\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ENQ\SOH\DC2\EOT\232\STX\CAN$\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ENQ\ETX\DC2\EOT\232\STX'(\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ENQ\b\DC2\EOT\232\STX)8\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ENQ\a\DC2\EOT\232\STX27\n\
+    \\226\STX\n\
+    \\EOT\EOT\n\
+    \\STX\ACK\DC2\EOT\239\STX\STX\"\SUB\211\STX Sets the Go package where structs generated from this .proto will be\n\
+    \ placed. If omitted, the Go package will be derived from the following:\n\
+    \   - The basename of the package import path, if provided.\n\
+    \   - Otherwise, the package statement in the .proto file, if present.\n\
+    \   - Otherwise, the basename of the .proto file, without extension.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ACK\EOT\DC2\EOT\239\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ACK\ENQ\DC2\EOT\239\STX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ACK\SOH\DC2\EOT\239\STX\DC2\FS\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\ACK\ETX\DC2\EOT\239\STX\US!\n\
+    \\212\EOT\n\
+    \\EOT\EOT\n\
+    \\STX\a\DC2\EOT\253\STX\STX9\SUB\197\EOT Should generic services be generated in each language?  \"Generic\" services\n\
+    \ are not specific to any particular RPC system.  They are generated by the\n\
+    \ main code generators in each language (without additional plugins).\n\
+    \ Generic services were the only kind of service generation supported by\n\
+    \ early versions of google.protobuf.\n\
+    \\n\
+    \ Generic services are now considered deprecated in favor of using plugins\n\
+    \ that generate code specific to your particular RPC system.  Therefore,\n\
+    \ these default to false.  Old code which depends on generic services should\n\
+    \ explicitly set them to true.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\a\EOT\DC2\EOT\253\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\a\ENQ\DC2\EOT\253\STX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\a\SOH\DC2\EOT\253\STX\DLE#\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\a\ETX\DC2\EOT\253\STX&(\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\a\b\DC2\EOT\253\STX)8\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\a\a\DC2\EOT\253\STX27\n\
+    \\f\n\
+    \\EOT\EOT\n\
+    \\STX\b\DC2\EOT\254\STX\STX;\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\b\EOT\DC2\EOT\254\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\b\ENQ\DC2\EOT\254\STX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\b\SOH\DC2\EOT\254\STX\DLE%\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\b\ETX\DC2\EOT\254\STX(*\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\b\b\DC2\EOT\254\STX+:\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\b\a\DC2\EOT\254\STX49\n\
+    \\f\n\
+    \\EOT\EOT\n\
+    \\STX\t\DC2\EOT\255\STX\STX9\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\t\EOT\DC2\EOT\255\STX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\t\ENQ\DC2\EOT\255\STX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\t\SOH\DC2\EOT\255\STX\DLE#\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\t\ETX\DC2\EOT\255\STX&(\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\t\b\DC2\EOT\255\STX)8\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\t\a\DC2\EOT\255\STX27\n\
+    \\f\n\
+    \\EOT\EOT\n\
+    \\STX\n\
+    \\DC2\EOT\128\ETX\STX:\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\n\
+    \\EOT\DC2\EOT\128\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\n\
+    \\ENQ\DC2\EOT\128\ETX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\n\
+    \\SOH\DC2\EOT\128\ETX\DLE$\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\n\
+    \\ETX\DC2\EOT\128\ETX')\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\n\
+    \\b\DC2\EOT\128\ETX*9\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\n\
+    \\a\DC2\EOT\128\ETX38\n\
+    \\243\SOH\n\
+    \\EOT\EOT\n\
+    \\STX\v\DC2\EOT\134\ETX\STX0\SUB\228\SOH Is this file deprecated?\n\
+    \ Depending on the target platform, this can emit Deprecated annotations\n\
+    \ for everything in the file, or it will be completely ignored; in the very\n\
+    \ least, this is a formalization for deprecating files.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\v\EOT\DC2\EOT\134\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\v\ENQ\DC2\EOT\134\ETX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\v\SOH\DC2\EOT\134\ETX\DLE\SUB\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\v\ETX\DC2\EOT\134\ETX\GS\US\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\v\b\DC2\EOT\134\ETX /\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\v\a\DC2\EOT\134\ETX).\n\
+    \\DEL\n\
+    \\EOT\EOT\n\
+    \\STX\f\DC2\EOT\138\ETX\STX6\SUBq Enables the use of arenas for the proto messages in this file. This applies\n\
+    \ only to generated classes for C++.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\f\EOT\DC2\EOT\138\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\f\ENQ\DC2\EOT\138\ETX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\f\SOH\DC2\EOT\138\ETX\DLE \n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\f\ETX\DC2\EOT\138\ETX#%\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\f\b\DC2\EOT\138\ETX&5\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\f\a\DC2\EOT\138\ETX/4\n\
+    \\146\SOH\n\
+    \\EOT\EOT\n\
+    \\STX\r\DC2\EOT\143\ETX\STX)\SUB\131\SOH Sets the objective c class prefix which is prepended to all objective c\n\
+    \ generated classes from this .proto. There is no default.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\r\EOT\DC2\EOT\143\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\r\ENQ\DC2\EOT\143\ETX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\r\SOH\DC2\EOT\143\ETX\DC2#\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\r\ETX\DC2\EOT\143\ETX&(\n\
+    \I\n\
+    \\EOT\EOT\n\
+    \\STX\SO\DC2\EOT\146\ETX\STX(\SUB; Namespace for generated classes; defaults to the package.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SO\EOT\DC2\EOT\146\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SO\ENQ\DC2\EOT\146\ETX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SO\SOH\DC2\EOT\146\ETX\DC2\"\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SO\ETX\DC2\EOT\146\ETX%'\n\
+    \\145\STX\n\
+    \\EOT\EOT\n\
+    \\STX\SI\DC2\EOT\152\ETX\STX$\SUB\130\STX By default Swift generators will take the proto package and CamelCase it\n\
+    \ replacing '.' with underscore and use that to prefix the types/symbols\n\
+    \ defined. When this options is provided, they will use this value instead\n\
+    \ to prefix the types/symbols defined.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SI\EOT\DC2\EOT\152\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SI\ENQ\DC2\EOT\152\ETX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SI\SOH\DC2\EOT\152\ETX\DC2\RS\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\SI\ETX\DC2\EOT\152\ETX!#\n\
+    \~\n\
+    \\EOT\EOT\n\
+    \\STX\DLE\DC2\EOT\156\ETX\STX(\SUBp Sets the php class prefix which is prepended to all php generated classes\n\
+    \ from this .proto. Default is empty.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DLE\EOT\DC2\EOT\156\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DLE\ENQ\DC2\EOT\156\ETX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DLE\SOH\DC2\EOT\156\ETX\DC2\"\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DLE\ETX\DC2\EOT\156\ETX%'\n\
+    \\190\SOH\n\
+    \\EOT\EOT\n\
+    \\STX\DC1\DC2\EOT\161\ETX\STX%\SUB\175\SOH Use this option to change the namespace of php generated classes. Default\n\
+    \ is empty. When this option is empty, the package name will be used for\n\
+    \ determining the namespace.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC1\EOT\DC2\EOT\161\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC1\ENQ\DC2\EOT\161\ETX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC1\SOH\DC2\EOT\161\ETX\DC2\US\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC1\ETX\DC2\EOT\161\ETX\"$\n\
+    \\202\SOH\n\
+    \\EOT\EOT\n\
+    \\STX\DC2\DC2\EOT\167\ETX\STX.\SUB\187\SOH Use this option to change the namespace of php generated metadata classes.\n\
+    \ Default is empty. When this option is empty, the proto file name will be used\n\
+    \ for determining the namespace.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC2\EOT\DC2\EOT\167\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC2\ENQ\DC2\EOT\167\ETX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC2\SOH\DC2\EOT\167\ETX\DC2(\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC2\ETX\DC2\EOT\167\ETX+-\n\
+    \\194\SOH\n\
+    \\EOT\EOT\n\
+    \\STX\DC3\DC2\EOT\172\ETX\STX$\SUB\179\SOH Use this option to change the package of ruby generated classes. Default\n\
+    \ is empty. When this option is not set, the package name will be used for\n\
+    \ determining the ruby package.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC3\EOT\DC2\EOT\172\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC3\ENQ\DC2\EOT\172\ETX\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC3\SOH\DC2\EOT\172\ETX\DC2\RS\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC3\ETX\DC2\EOT\172\ETX!#\n\
+    \|\n\
+    \\EOT\EOT\n\
+    \\STX\DC4\DC2\EOT\176\ETX\STX:\SUBn The parser stores options it doesn't recognize here.\n\
+    \ See the documentation for the \"Options\" section above.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC4\EOT\DC2\EOT\176\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC4\ACK\DC2\EOT\176\ETX\v\RS\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC4\SOH\DC2\EOT\176\ETX\US3\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\STX\DC4\ETX\DC2\EOT\176\ETX69\n\
+    \\135\SOH\n\
+    \\ETX\EOT\n\
+    \\ENQ\DC2\EOT\180\ETX\STX\EM\SUBz Clients can define custom options in extensions of this message.\n\
+    \ See the documentation for the \"Options\" section above.\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\n\
+    \\ENQ\NUL\DC2\EOT\180\ETX\r\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\ENQ\NUL\SOH\DC2\EOT\180\ETX\r\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\ENQ\NUL\STX\DC2\EOT\180\ETX\NAK\CAN\n\
+    \\v\n\
+    \\ETX\EOT\n\
+    \\t\DC2\EOT\182\ETX\STX\SO\n\
+    \\f\n\
+    \\EOT\EOT\n\
+    \\t\NUL\DC2\EOT\182\ETX\v\r\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\t\NUL\SOH\DC2\EOT\182\ETX\v\r\n\
+    \\r\n\
+    \\ENQ\EOT\n\
+    \\t\NUL\STX\DC2\EOT\182\ETX\v\r\n\
+    \\f\n\
+    \\STX\EOT\v\DC2\ACK\185\ETX\NUL\248\ETX\SOH\n\
+    \\v\n\
+    \\ETX\EOT\v\SOH\DC2\EOT\185\ETX\b\SYN\n\
+    \\216\ENQ\n\
+    \\EOT\EOT\v\STX\NUL\DC2\EOT\204\ETX\STX<\SUB\201\ENQ Set true to use the old proto1 MessageSet wire format for extensions.\n\
+    \ This is provided for backwards-compatibility with the MessageSet wire\n\
+    \ format.  You should not use this for any other reason:  It's less\n\
+    \ efficient, has fewer features, and is more complicated.\n\
+    \\n\
+    \ The message must be defined exactly as follows:\n\
+    \   message Foo {\n\
+    \     option message_set_wire_format = true;\n\
+    \     extensions 4 to max;\n\
+    \   }\n\
+    \ Note that the message cannot have any defined fields; MessageSets only\n\
+    \ have extensions.\n\
+    \\n\
+    \ All extensions of your type must be singular messages; e.g. they cannot\n\
+    \ be int32s, enums, or repeated messages.\n\
+    \\n\
+    \ Because this is an option, the above two restrictions are not enforced by\n\
+    \ the protocol compiler.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\NUL\EOT\DC2\EOT\204\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\NUL\ENQ\DC2\EOT\204\ETX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\NUL\SOH\DC2\EOT\204\ETX\DLE'\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\NUL\ETX\DC2\EOT\204\ETX*+\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\NUL\b\DC2\EOT\204\ETX,;\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\NUL\a\DC2\EOT\204\ETX5:\n\
+    \\235\SOH\n\
+    \\EOT\EOT\v\STX\SOH\DC2\EOT\209\ETX\STXD\SUB\220\SOH Disables the generation of the standard \"descriptor()\" accessor, which can\n\
+    \ conflict with a field of the same name.  This is meant to make migration\n\
+    \ from proto1 easier; new code should avoid fields named \"descriptor\".\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\SOH\EOT\DC2\EOT\209\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\SOH\ENQ\DC2\EOT\209\ETX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\SOH\SOH\DC2\EOT\209\ETX\DLE/\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\SOH\ETX\DC2\EOT\209\ETX23\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\SOH\b\DC2\EOT\209\ETX4C\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\SOH\a\DC2\EOT\209\ETX=B\n\
+    \\238\SOH\n\
+    \\EOT\EOT\v\STX\STX\DC2\EOT\215\ETX\STX/\SUB\223\SOH Is this message deprecated?\n\
+    \ Depending on the target platform, this can emit Deprecated annotations\n\
+    \ for the message, or it will be completely ignored; in the very least,\n\
+    \ this is a formalization for deprecating messages.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\STX\EOT\DC2\EOT\215\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\STX\ENQ\DC2\EOT\215\ETX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\STX\SOH\DC2\EOT\215\ETX\DLE\SUB\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\STX\ETX\DC2\EOT\215\ETX\GS\RS\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\STX\b\DC2\EOT\215\ETX\US.\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\STX\a\DC2\EOT\215\ETX(-\n\
+    \\158\ACK\n\
+    \\EOT\EOT\v\STX\ETX\DC2\EOT\238\ETX\STX\RS\SUB\143\ACK Whether the message is an automatically generated map entry type for the\n\
+    \ maps field.\n\
+    \\n\
+    \ For maps fields:\n\
+    \     map<KeyType, ValueType> map_field = 1;\n\
+    \ The parsed descriptor looks like:\n\
+    \     message MapFieldEntry {\n\
+    \         option map_entry = true;\n\
+    \         optional KeyType key = 1;\n\
+    \         optional ValueType value = 2;\n\
+    \     }\n\
+    \     repeated MapFieldEntry map_field = 1;\n\
+    \\n\
+    \ Implementations may choose not to generate the map_entry=true message, but\n\
+    \ use a native map in the target language to hold the keys and values.\n\
+    \ The reflection APIs in such implementions still need to work as\n\
+    \ if the field is a repeated message field.\n\
+    \\n\
+    \ NOTE: Do not set the option in .proto files. Always use the maps syntax\n\
+    \ instead. The option should only be implicitly set by the proto compiler\n\
+    \ parser.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\ETX\EOT\DC2\EOT\238\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\ETX\ENQ\DC2\EOT\238\ETX\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\ETX\SOH\DC2\EOT\238\ETX\DLE\EM\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\ETX\ETX\DC2\EOT\238\ETX\FS\GS\n\
+    \$\n\
+    \\ETX\EOT\v\t\DC2\EOT\240\ETX\STX\r\"\ETB javalite_serializable\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\v\t\NUL\DC2\EOT\240\ETX\v\f\n\
+    \\r\n\
+    \\ENQ\EOT\v\t\NUL\SOH\DC2\EOT\240\ETX\v\f\n\
+    \\r\n\
+    \\ENQ\EOT\v\t\NUL\STX\DC2\EOT\240\ETX\v\f\n\
+    \\US\n\
+    \\ETX\EOT\v\t\DC2\EOT\241\ETX\STX\r\"\DC2 javanano_as_lite\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\v\t\SOH\DC2\EOT\241\ETX\v\f\n\
+    \\r\n\
+    \\ENQ\EOT\v\t\SOH\SOH\DC2\EOT\241\ETX\v\f\n\
+    \\r\n\
+    \\ENQ\EOT\v\t\SOH\STX\DC2\EOT\241\ETX\v\f\n\
+    \O\n\
+    \\EOT\EOT\v\STX\EOT\DC2\EOT\244\ETX\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\EOT\EOT\DC2\EOT\244\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\EOT\ACK\DC2\EOT\244\ETX\v\RS\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\EOT\SOH\DC2\EOT\244\ETX\US3\n\
+    \\r\n\
+    \\ENQ\EOT\v\STX\EOT\ETX\DC2\EOT\244\ETX69\n\
+    \Z\n\
+    \\ETX\EOT\v\ENQ\DC2\EOT\247\ETX\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\v\ENQ\NUL\DC2\EOT\247\ETX\r\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\v\ENQ\NUL\SOH\DC2\EOT\247\ETX\r\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\v\ENQ\NUL\STX\DC2\EOT\247\ETX\NAK\CAN\n\
+    \\f\n\
+    \\STX\EOT\f\DC2\ACK\250\ETX\NUL\213\EOT\SOH\n\
+    \\v\n\
+    \\ETX\EOT\f\SOH\DC2\EOT\250\ETX\b\DC4\n\
+    \\163\STX\n\
+    \\EOT\EOT\f\STX\NUL\DC2\EOT\255\ETX\STX.\SUB\148\STX The ctype option instructs the C++ code generator to use a different\n\
+    \ representation of the field than it normally would.  See the specific\n\
+    \ options below.  This option is not yet implemented in the open source\n\
+    \ release -- sorry, we'll try to include it in a future version!\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\NUL\EOT\DC2\EOT\255\ETX\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\NUL\ACK\DC2\EOT\255\ETX\v\DLE\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\NUL\SOH\DC2\EOT\255\ETX\DC1\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\NUL\ETX\DC2\EOT\255\ETX\EM\SUB\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\NUL\b\DC2\EOT\255\ETX\ESC-\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\NUL\a\DC2\EOT\255\ETX&,\n\
+    \\SO\n\
+    \\EOT\EOT\f\EOT\NUL\DC2\ACK\128\EOT\STX\135\EOT\ETX\n\
+    \\r\n\
+    \\ENQ\EOT\f\EOT\NUL\SOH\DC2\EOT\128\EOT\a\f\n\
+    \\US\n\
+    \\ACK\EOT\f\EOT\NUL\STX\NUL\DC2\EOT\130\EOT\EOT\SI\SUB\SI Default mode.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\NUL\STX\NUL\SOH\DC2\EOT\130\EOT\EOT\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\NUL\STX\NUL\STX\DC2\EOT\130\EOT\r\SO\n\
+    \\SO\n\
+    \\ACK\EOT\f\EOT\NUL\STX\SOH\DC2\EOT\132\EOT\EOT\r\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\NUL\STX\SOH\SOH\DC2\EOT\132\EOT\EOT\b\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\NUL\STX\SOH\STX\DC2\EOT\132\EOT\v\f\n\
+    \\SO\n\
+    \\ACK\EOT\f\EOT\NUL\STX\STX\DC2\EOT\134\EOT\EOT\NAK\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\NUL\STX\STX\SOH\DC2\EOT\134\EOT\EOT\DLE\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\NUL\STX\STX\STX\DC2\EOT\134\EOT\DC3\DC4\n\
+    \\218\STX\n\
+    \\EOT\EOT\f\STX\SOH\DC2\EOT\141\EOT\STX\ESC\SUB\203\STX The packed option can be enabled for repeated primitive fields to enable\n\
+    \ a more efficient representation on the wire. Rather than repeatedly\n\
+    \ writing the tag and type for each element, the entire array is encoded as\n\
+    \ a single length-delimited blob. In proto3, only explicit setting it to\n\
+    \ false will avoid using packed encoding.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\SOH\EOT\DC2\EOT\141\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\SOH\ENQ\DC2\EOT\141\EOT\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\SOH\SOH\DC2\EOT\141\EOT\DLE\SYN\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\SOH\ETX\DC2\EOT\141\EOT\EM\SUB\n\
+    \\154\ENQ\n\
+    \\EOT\EOT\f\STX\STX\DC2\EOT\154\EOT\STX3\SUB\139\ENQ The jstype option determines the JavaScript type used for values of the\n\
+    \ field.  The option is permitted only for 64 bit integral and fixed types\n\
+    \ (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING\n\
+    \ is represented as JavaScript string, which avoids loss of precision that\n\
+    \ can happen when a large value is converted to a floating point JavaScript.\n\
+    \ Specifying JS_NUMBER for the jstype causes the generated JavaScript code to\n\
+    \ use the JavaScript \"number\" type.  The behavior of the default option\n\
+    \ JS_NORMAL is implementation dependent.\n\
+    \\n\
+    \ This option is an enum to permit additional types to be added, e.g.\n\
+    \ goog.math.Integer.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\STX\EOT\DC2\EOT\154\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\STX\ACK\DC2\EOT\154\EOT\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\STX\SOH\DC2\EOT\154\EOT\DC2\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\STX\ETX\DC2\EOT\154\EOT\ESC\FS\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\STX\b\DC2\EOT\154\EOT\GS2\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\STX\a\DC2\EOT\154\EOT(1\n\
+    \\SO\n\
+    \\EOT\EOT\f\EOT\SOH\DC2\ACK\155\EOT\STX\164\EOT\ETX\n\
+    \\r\n\
+    \\ENQ\EOT\f\EOT\SOH\SOH\DC2\EOT\155\EOT\a\r\n\
+    \'\n\
+    \\ACK\EOT\f\EOT\SOH\STX\NUL\DC2\EOT\157\EOT\EOT\DC2\SUB\ETB Use the default type.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\SOH\STX\NUL\SOH\DC2\EOT\157\EOT\EOT\r\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\SOH\STX\NUL\STX\DC2\EOT\157\EOT\DLE\DC1\n\
+    \)\n\
+    \\ACK\EOT\f\EOT\SOH\STX\SOH\DC2\EOT\160\EOT\EOT\DC2\SUB\EM Use JavaScript strings.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\SOH\STX\SOH\SOH\DC2\EOT\160\EOT\EOT\r\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\SOH\STX\SOH\STX\DC2\EOT\160\EOT\DLE\DC1\n\
+    \)\n\
+    \\ACK\EOT\f\EOT\SOH\STX\STX\DC2\EOT\163\EOT\EOT\DC2\SUB\EM Use JavaScript numbers.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\SOH\STX\STX\SOH\DC2\EOT\163\EOT\EOT\r\n\
+    \\SI\n\
+    \\a\EOT\f\EOT\SOH\STX\STX\STX\DC2\EOT\163\EOT\DLE\DC1\n\
+    \\239\f\n\
+    \\EOT\EOT\f\STX\ETX\DC2\EOT\194\EOT\STX)\SUB\224\f Should this field be parsed lazily?  Lazy applies only to message-type\n\
+    \ fields.  It means that when the outer message is initially parsed, the\n\
+    \ inner message's contents will not be parsed but instead stored in encoded\n\
+    \ form.  The inner message will actually be parsed when it is first accessed.\n\
+    \\n\
+    \ This is only a hint.  Implementations are free to choose whether to use\n\
+    \ eager or lazy parsing regardless of the value of this option.  However,\n\
+    \ setting this option true suggests that the protocol author believes that\n\
+    \ using lazy parsing on this field is worth the additional bookkeeping\n\
+    \ overhead typically needed to implement it.\n\
+    \\n\
+    \ This option does not affect the public interface of any generated code;\n\
+    \ all method signatures remain the same.  Furthermore, thread-safety of the\n\
+    \ interface is not affected by this option; const methods remain safe to\n\
+    \ call from multiple threads concurrently, while non-const methods continue\n\
+    \ to require exclusive access.\n\
+    \\n\
+    \\n\
+    \ Note that implementations may choose not to check required fields within\n\
+    \ a lazy sub-message.  That is, calling IsInitialized() on the outer message\n\
+    \ may return true even if the inner message has missing required fields.\n\
+    \ This is necessary because otherwise the inner message would have to be\n\
+    \ parsed in order to perform the check, defeating the purpose of lazy\n\
+    \ parsing.  An implementation which chooses not to check required fields\n\
+    \ must be consistent about it.  That is, for any particular sub-message, the\n\
+    \ implementation must either *always* check its required fields, or *never*\n\
+    \ check its required fields, regardless of whether or not the message has\n\
+    \ been parsed.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ETX\EOT\DC2\EOT\194\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ETX\ENQ\DC2\EOT\194\EOT\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ETX\SOH\DC2\EOT\194\EOT\DLE\DC4\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ETX\ETX\DC2\EOT\194\EOT\ETB\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ETX\b\DC2\EOT\194\EOT\EM(\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ETX\a\DC2\EOT\194\EOT\"'\n\
+    \\232\SOH\n\
+    \\EOT\EOT\f\STX\EOT\DC2\EOT\200\EOT\STX/\SUB\217\SOH Is this field deprecated?\n\
+    \ Depending on the target platform, this can emit Deprecated annotations\n\
+    \ for accessors, or it will be completely ignored; in the very least, this\n\
+    \ is a formalization for deprecating fields.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\EOT\EOT\DC2\EOT\200\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\EOT\ENQ\DC2\EOT\200\EOT\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\EOT\SOH\DC2\EOT\200\EOT\DLE\SUB\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\EOT\ETX\DC2\EOT\200\EOT\GS\RS\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\EOT\b\DC2\EOT\200\EOT\US.\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\EOT\a\DC2\EOT\200\EOT(-\n\
+    \?\n\
+    \\EOT\EOT\f\STX\ENQ\DC2\EOT\203\EOT\STX*\SUB1 For Google-internal migration only. Do not use.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ENQ\EOT\DC2\EOT\203\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ENQ\ENQ\DC2\EOT\203\EOT\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ENQ\SOH\DC2\EOT\203\EOT\DLE\DC4\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ENQ\ETX\DC2\EOT\203\EOT\ETB\EM\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ENQ\b\DC2\EOT\203\EOT\SUB)\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ENQ\a\DC2\EOT\203\EOT#(\n\
+    \O\n\
+    \\EOT\EOT\f\STX\ACK\DC2\EOT\207\EOT\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ACK\EOT\DC2\EOT\207\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ACK\ACK\DC2\EOT\207\EOT\v\RS\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ACK\SOH\DC2\EOT\207\EOT\US3\n\
+    \\r\n\
+    \\ENQ\EOT\f\STX\ACK\ETX\DC2\EOT\207\EOT69\n\
+    \Z\n\
+    \\ETX\EOT\f\ENQ\DC2\EOT\210\EOT\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\f\ENQ\NUL\DC2\EOT\210\EOT\r\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\f\ENQ\NUL\SOH\DC2\EOT\210\EOT\r\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\f\ENQ\NUL\STX\DC2\EOT\210\EOT\NAK\CAN\n\
+    \\FS\n\
+    \\ETX\EOT\f\t\DC2\EOT\212\EOT\STX\r\"\SI removed jtype\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\f\t\NUL\DC2\EOT\212\EOT\v\f\n\
+    \\r\n\
+    \\ENQ\EOT\f\t\NUL\SOH\DC2\EOT\212\EOT\v\f\n\
+    \\r\n\
+    \\ENQ\EOT\f\t\NUL\STX\DC2\EOT\212\EOT\v\f\n\
+    \\f\n\
+    \\STX\EOT\r\DC2\ACK\215\EOT\NUL\221\EOT\SOH\n\
+    \\v\n\
+    \\ETX\EOT\r\SOH\DC2\EOT\215\EOT\b\DC4\n\
+    \O\n\
+    \\EOT\EOT\r\STX\NUL\DC2\EOT\217\EOT\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\r\STX\NUL\EOT\DC2\EOT\217\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\r\STX\NUL\ACK\DC2\EOT\217\EOT\v\RS\n\
+    \\r\n\
+    \\ENQ\EOT\r\STX\NUL\SOH\DC2\EOT\217\EOT\US3\n\
+    \\r\n\
+    \\ENQ\EOT\r\STX\NUL\ETX\DC2\EOT\217\EOT69\n\
+    \Z\n\
+    \\ETX\EOT\r\ENQ\DC2\EOT\220\EOT\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\r\ENQ\NUL\DC2\EOT\220\EOT\r\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\r\ENQ\NUL\SOH\DC2\EOT\220\EOT\r\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\r\ENQ\NUL\STX\DC2\EOT\220\EOT\NAK\CAN\n\
+    \\f\n\
+    \\STX\EOT\SO\DC2\ACK\223\EOT\NUL\242\EOT\SOH\n\
+    \\v\n\
+    \\ETX\EOT\SO\SOH\DC2\EOT\223\EOT\b\DC3\n\
+    \`\n\
+    \\EOT\EOT\SO\STX\NUL\DC2\EOT\227\EOT\STX \SUBR Set this option to true to allow mapping different tag names to the same\n\
+    \ value.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\NUL\EOT\DC2\EOT\227\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\NUL\ENQ\DC2\EOT\227\EOT\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\NUL\SOH\DC2\EOT\227\EOT\DLE\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\NUL\ETX\DC2\EOT\227\EOT\RS\US\n\
+    \\229\SOH\n\
+    \\EOT\EOT\SO\STX\SOH\DC2\EOT\233\EOT\STX/\SUB\214\SOH Is this enum deprecated?\n\
+    \ Depending on the target platform, this can emit Deprecated annotations\n\
+    \ for the enum, or it will be completely ignored; in the very least, this\n\
+    \ is a formalization for deprecating enums.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\SOH\EOT\DC2\EOT\233\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\SOH\ENQ\DC2\EOT\233\EOT\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\SOH\SOH\DC2\EOT\233\EOT\DLE\SUB\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\SOH\ETX\DC2\EOT\233\EOT\GS\RS\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\SOH\b\DC2\EOT\233\EOT\US.\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\SOH\a\DC2\EOT\233\EOT(-\n\
+    \\US\n\
+    \\ETX\EOT\SO\t\DC2\EOT\235\EOT\STX\r\"\DC2 javanano_as_lite\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\SO\t\NUL\DC2\EOT\235\EOT\v\f\n\
+    \\r\n\
+    \\ENQ\EOT\SO\t\NUL\SOH\DC2\EOT\235\EOT\v\f\n\
+    \\r\n\
+    \\ENQ\EOT\SO\t\NUL\STX\DC2\EOT\235\EOT\v\f\n\
+    \O\n\
+    \\EOT\EOT\SO\STX\STX\DC2\EOT\238\EOT\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\STX\EOT\DC2\EOT\238\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\STX\ACK\DC2\EOT\238\EOT\v\RS\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\STX\SOH\DC2\EOT\238\EOT\US3\n\
+    \\r\n\
+    \\ENQ\EOT\SO\STX\STX\ETX\DC2\EOT\238\EOT69\n\
+    \Z\n\
+    \\ETX\EOT\SO\ENQ\DC2\EOT\241\EOT\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\SO\ENQ\NUL\DC2\EOT\241\EOT\r\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\SO\ENQ\NUL\SOH\DC2\EOT\241\EOT\r\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\SO\ENQ\NUL\STX\DC2\EOT\241\EOT\NAK\CAN\n\
+    \\f\n\
+    \\STX\EOT\SI\DC2\ACK\244\EOT\NUL\128\ENQ\SOH\n\
+    \\v\n\
+    \\ETX\EOT\SI\SOH\DC2\EOT\244\EOT\b\CAN\n\
+    \\247\SOH\n\
+    \\EOT\EOT\SI\STX\NUL\DC2\EOT\249\EOT\STX/\SUB\232\SOH Is this enum value deprecated?\n\
+    \ Depending on the target platform, this can emit Deprecated annotations\n\
+    \ for the enum value, or it will be completely ignored; in the very least,\n\
+    \ this is a formalization for deprecating enum values.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\SI\STX\NUL\EOT\DC2\EOT\249\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\SI\STX\NUL\ENQ\DC2\EOT\249\EOT\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\SI\STX\NUL\SOH\DC2\EOT\249\EOT\DLE\SUB\n\
+    \\r\n\
+    \\ENQ\EOT\SI\STX\NUL\ETX\DC2\EOT\249\EOT\GS\RS\n\
+    \\r\n\
+    \\ENQ\EOT\SI\STX\NUL\b\DC2\EOT\249\EOT\US.\n\
+    \\r\n\
+    \\ENQ\EOT\SI\STX\NUL\a\DC2\EOT\249\EOT(-\n\
+    \O\n\
+    \\EOT\EOT\SI\STX\SOH\DC2\EOT\252\EOT\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\SI\STX\SOH\EOT\DC2\EOT\252\EOT\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\SI\STX\SOH\ACK\DC2\EOT\252\EOT\v\RS\n\
+    \\r\n\
+    \\ENQ\EOT\SI\STX\SOH\SOH\DC2\EOT\252\EOT\US3\n\
+    \\r\n\
+    \\ENQ\EOT\SI\STX\SOH\ETX\DC2\EOT\252\EOT69\n\
+    \Z\n\
+    \\ETX\EOT\SI\ENQ\DC2\EOT\255\EOT\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\SI\ENQ\NUL\DC2\EOT\255\EOT\r\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\SI\ENQ\NUL\SOH\DC2\EOT\255\EOT\r\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\SI\ENQ\NUL\STX\DC2\EOT\255\EOT\NAK\CAN\n\
+    \\f\n\
+    \\STX\EOT\DLE\DC2\ACK\130\ENQ\NUL\148\ENQ\SOH\n\
+    \\v\n\
+    \\ETX\EOT\DLE\SOH\DC2\EOT\130\ENQ\b\SYN\n\
+    \\217\ETX\n\
+    \\EOT\EOT\DLE\STX\NUL\DC2\EOT\141\ENQ\STX0\SUB\223\SOH Is this service deprecated?\n\
+    \ Depending on the target platform, this can emit Deprecated annotations\n\
+    \ for the service, or it will be completely ignored; in the very least,\n\
+    \ this is a formalization for deprecating services.\n\
+    \2\232\SOH Note:  Field numbers 1 through 32 are reserved for Google's internal RPC\n\
+    \   framework.  We apologize for hoarding these numbers to ourselves, but\n\
+    \   we were already using them long before we decided to release Protocol\n\
+    \   Buffers.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\STX\NUL\EOT\DC2\EOT\141\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\STX\NUL\ENQ\DC2\EOT\141\ENQ\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\STX\NUL\SOH\DC2\EOT\141\ENQ\DLE\SUB\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\STX\NUL\ETX\DC2\EOT\141\ENQ\GS\US\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\STX\NUL\b\DC2\EOT\141\ENQ /\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\STX\NUL\a\DC2\EOT\141\ENQ).\n\
+    \O\n\
+    \\EOT\EOT\DLE\STX\SOH\DC2\EOT\144\ENQ\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\STX\SOH\EOT\DC2\EOT\144\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\STX\SOH\ACK\DC2\EOT\144\ENQ\v\RS\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\STX\SOH\SOH\DC2\EOT\144\ENQ\US3\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\STX\SOH\ETX\DC2\EOT\144\ENQ69\n\
+    \Z\n\
+    \\ETX\EOT\DLE\ENQ\DC2\EOT\147\ENQ\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\DLE\ENQ\NUL\DC2\EOT\147\ENQ\r\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\ENQ\NUL\SOH\DC2\EOT\147\ENQ\r\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\DLE\ENQ\NUL\STX\DC2\EOT\147\ENQ\NAK\CAN\n\
+    \\f\n\
+    \\STX\EOT\DC1\DC2\ACK\150\ENQ\NUL\179\ENQ\SOH\n\
+    \\v\n\
+    \\ETX\EOT\DC1\SOH\DC2\EOT\150\ENQ\b\NAK\n\
+    \\214\ETX\n\
+    \\EOT\EOT\DC1\STX\NUL\DC2\EOT\161\ENQ\STX0\SUB\220\SOH Is this method deprecated?\n\
+    \ Depending on the target platform, this can emit Deprecated annotations\n\
+    \ for the method, or it will be completely ignored; in the very least,\n\
+    \ this is a formalization for deprecating methods.\n\
+    \2\232\SOH Note:  Field numbers 1 through 32 are reserved for Google's internal RPC\n\
+    \   framework.  We apologize for hoarding these numbers to ourselves, but\n\
+    \   we were already using them long before we decided to release Protocol\n\
+    \   Buffers.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\NUL\EOT\DC2\EOT\161\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\NUL\ENQ\DC2\EOT\161\ENQ\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\NUL\SOH\DC2\EOT\161\ENQ\DLE\SUB\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\NUL\ETX\DC2\EOT\161\ENQ\GS\US\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\NUL\b\DC2\EOT\161\ENQ /\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\NUL\a\DC2\EOT\161\ENQ).\n\
+    \\240\SOH\n\
+    \\EOT\EOT\DC1\EOT\NUL\DC2\ACK\166\ENQ\STX\170\ENQ\ETX\SUB\223\SOH Is this method side-effect-free (or safe in HTTP parlance), or idempotent,\n\
+    \ or neither? HTTP based RPC implementation may choose GET verb for safe\n\
+    \ methods, and PUT verb for idempotent methods instead of the default POST.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\EOT\NUL\SOH\DC2\EOT\166\ENQ\a\ETB\n\
+    \\SO\n\
+    \\ACK\EOT\DC1\EOT\NUL\STX\NUL\DC2\EOT\167\ENQ\EOT\FS\n\
+    \\SI\n\
+    \\a\EOT\DC1\EOT\NUL\STX\NUL\SOH\DC2\EOT\167\ENQ\EOT\ETB\n\
+    \\SI\n\
+    \\a\EOT\DC1\EOT\NUL\STX\NUL\STX\DC2\EOT\167\ENQ\SUB\ESC\n\
+    \$\n\
+    \\ACK\EOT\DC1\EOT\NUL\STX\SOH\DC2\EOT\168\ENQ\EOT\FS\"\DC4 implies idempotent\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\DC1\EOT\NUL\STX\SOH\SOH\DC2\EOT\168\ENQ\EOT\DC3\n\
+    \\SI\n\
+    \\a\EOT\DC1\EOT\NUL\STX\SOH\STX\DC2\EOT\168\ENQ\SUB\ESC\n\
+    \7\n\
+    \\ACK\EOT\DC1\EOT\NUL\STX\STX\DC2\EOT\169\ENQ\EOT\FS\"' idempotent, but may have side effects\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\DC1\EOT\NUL\STX\STX\SOH\DC2\EOT\169\ENQ\EOT\SO\n\
+    \\SI\n\
+    \\a\EOT\DC1\EOT\NUL\STX\STX\STX\DC2\EOT\169\ENQ\SUB\ESC\n\
+    \\SO\n\
+    \\EOT\EOT\DC1\STX\SOH\DC2\ACK\171\ENQ\STX\172\ENQ'\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\SOH\EOT\DC2\EOT\171\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\SOH\ACK\DC2\EOT\171\ENQ\v\ESC\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\SOH\SOH\DC2\EOT\171\ENQ\FS-\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\SOH\ETX\DC2\EOT\172\ENQ\ACK\b\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\SOH\b\DC2\EOT\172\ENQ\t&\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\SOH\a\DC2\EOT\172\ENQ\DC2%\n\
+    \O\n\
+    \\EOT\EOT\DC1\STX\STX\DC2\EOT\175\ENQ\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\STX\EOT\DC2\EOT\175\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\STX\ACK\DC2\EOT\175\ENQ\v\RS\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\STX\SOH\DC2\EOT\175\ENQ\US3\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\STX\STX\ETX\DC2\EOT\175\ENQ69\n\
+    \Z\n\
+    \\ETX\EOT\DC1\ENQ\DC2\EOT\178\ENQ\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\n\
+    \\f\n\
+    \\EOT\EOT\DC1\ENQ\NUL\DC2\EOT\178\ENQ\r\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\ENQ\NUL\SOH\DC2\EOT\178\ENQ\r\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\DC1\ENQ\NUL\STX\DC2\EOT\178\ENQ\NAK\CAN\n\
+    \\139\ETX\n\
+    \\STX\EOT\DC2\DC2\ACK\188\ENQ\NUL\208\ENQ\SOH\SUB\252\STX A message representing a option the parser does not recognize. This only\n\
+    \ appears in options protos created by the compiler::Parser class.\n\
+    \ DescriptorPool resolves these when building Descriptor objects. Therefore,\n\
+    \ options protos in descriptor objects (e.g. returned by Descriptor::options(),\n\
+    \ or produced by Descriptor::CopyTo()) will never have UninterpretedOptions\n\
+    \ in them.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\DC2\SOH\DC2\EOT\188\ENQ\b\ESC\n\
+    \\203\STX\n\
+    \\EOT\EOT\DC2\ETX\NUL\DC2\ACK\194\ENQ\STX\197\ENQ\ETX\SUB\186\STX The name of the uninterpreted option.  Each string represents a segment in\n\
+    \ a dot-separated name.  is_extension is true iff a segment represents an\n\
+    \ extension (denoted with parentheses in options specs in .proto files).\n\
+    \ E.g.,{ [\"foo\", false], [\"bar.baz\", true], [\"qux\", false] } represents\n\
+    \ \"foo.(bar.baz).qux\".\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\ETX\NUL\SOH\DC2\EOT\194\ENQ\n\
+    \\DC2\n\
+    \\SO\n\
+    \\ACK\EOT\DC2\ETX\NUL\STX\NUL\DC2\EOT\195\ENQ\EOT\"\n\
+    \\SI\n\
+    \\a\EOT\DC2\ETX\NUL\STX\NUL\EOT\DC2\EOT\195\ENQ\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\DC2\ETX\NUL\STX\NUL\ENQ\DC2\EOT\195\ENQ\r\DC3\n\
+    \\SI\n\
+    \\a\EOT\DC2\ETX\NUL\STX\NUL\SOH\DC2\EOT\195\ENQ\DC4\GS\n\
+    \\SI\n\
+    \\a\EOT\DC2\ETX\NUL\STX\NUL\ETX\DC2\EOT\195\ENQ !\n\
+    \\SO\n\
+    \\ACK\EOT\DC2\ETX\NUL\STX\SOH\DC2\EOT\196\ENQ\EOT#\n\
+    \\SI\n\
+    \\a\EOT\DC2\ETX\NUL\STX\SOH\EOT\DC2\EOT\196\ENQ\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\DC2\ETX\NUL\STX\SOH\ENQ\DC2\EOT\196\ENQ\r\DC1\n\
+    \\SI\n\
+    \\a\EOT\DC2\ETX\NUL\STX\SOH\SOH\DC2\EOT\196\ENQ\DC2\RS\n\
+    \\SI\n\
+    \\a\EOT\DC2\ETX\NUL\STX\SOH\ETX\DC2\EOT\196\ENQ!\"\n\
+    \\f\n\
+    \\EOT\EOT\DC2\STX\NUL\DC2\EOT\198\ENQ\STX\GS\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\NUL\EOT\DC2\EOT\198\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\NUL\ACK\DC2\EOT\198\ENQ\v\DC3\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\NUL\SOH\DC2\EOT\198\ENQ\DC4\CAN\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\NUL\ETX\DC2\EOT\198\ENQ\ESC\FS\n\
+    \\156\SOH\n\
+    \\EOT\EOT\DC2\STX\SOH\DC2\EOT\202\ENQ\STX'\SUB\141\SOH The value of the uninterpreted option, in whatever type the tokenizer\n\
+    \ identified it as during parsing. Exactly one of these should be set.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\SOH\EOT\DC2\EOT\202\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\SOH\ENQ\DC2\EOT\202\ENQ\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\SOH\SOH\DC2\EOT\202\ENQ\DC2\"\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\SOH\ETX\DC2\EOT\202\ENQ%&\n\
+    \\f\n\
+    \\EOT\EOT\DC2\STX\STX\DC2\EOT\203\ENQ\STX)\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\STX\EOT\DC2\EOT\203\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\STX\ENQ\DC2\EOT\203\ENQ\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\STX\SOH\DC2\EOT\203\ENQ\DC2$\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\STX\ETX\DC2\EOT\203\ENQ'(\n\
+    \\f\n\
+    \\EOT\EOT\DC2\STX\ETX\DC2\EOT\204\ENQ\STX(\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ETX\EOT\DC2\EOT\204\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ETX\ENQ\DC2\EOT\204\ENQ\v\DLE\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ETX\SOH\DC2\EOT\204\ENQ\DC1#\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ETX\ETX\DC2\EOT\204\ENQ&'\n\
+    \\f\n\
+    \\EOT\EOT\DC2\STX\EOT\DC2\EOT\205\ENQ\STX#\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\EOT\EOT\DC2\EOT\205\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\EOT\ENQ\DC2\EOT\205\ENQ\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\EOT\SOH\DC2\EOT\205\ENQ\DC2\RS\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\EOT\ETX\DC2\EOT\205\ENQ!\"\n\
+    \\f\n\
+    \\EOT\EOT\DC2\STX\ENQ\DC2\EOT\206\ENQ\STX\"\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ENQ\EOT\DC2\EOT\206\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ENQ\ENQ\DC2\EOT\206\ENQ\v\DLE\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ENQ\SOH\DC2\EOT\206\ENQ\DC1\GS\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ENQ\ETX\DC2\EOT\206\ENQ !\n\
+    \\f\n\
+    \\EOT\EOT\DC2\STX\ACK\DC2\EOT\207\ENQ\STX&\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ACK\EOT\DC2\EOT\207\ENQ\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ACK\ENQ\DC2\EOT\207\ENQ\v\DC1\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ACK\SOH\DC2\EOT\207\ENQ\DC2!\n\
+    \\r\n\
+    \\ENQ\EOT\DC2\STX\ACK\ETX\DC2\EOT\207\ENQ$%\n\
+    \\218\SOH\n\
+    \\STX\EOT\DC3\DC2\ACK\215\ENQ\NUL\216\ACK\SOH\SUBj Encapsulates information about the original source file from which a\n\
+    \ FileDescriptorProto was generated.\n\
+    \2` ===================================================================\n\
+    \ Optional source code info\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\DC3\SOH\DC2\EOT\215\ENQ\b\SYN\n\
+    \\130\DC1\n\
+    \\EOT\EOT\DC3\STX\NUL\DC2\EOT\131\ACK\STX!\SUB\243\DLE A Location identifies a piece of source code in a .proto file which\n\
+    \ corresponds to a particular definition.  This information is intended\n\
+    \ to be useful to IDEs, code indexers, documentation generators, and similar\n\
+    \ tools.\n\
+    \\n\
+    \ For example, say we have a file like:\n\
+    \   message Foo {\n\
+    \     optional string foo = 1;\n\
+    \   }\n\
+    \ Let's look at just the field definition:\n\
+    \   optional string foo = 1;\n\
+    \   ^       ^^     ^^  ^  ^^^\n\
+    \   a       bc     de  f  ghi\n\
+    \ We have the following locations:\n\
+    \   span   path               represents\n\
+    \   [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.\n\
+    \   [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).\n\
+    \   [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).\n\
+    \   [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).\n\
+    \   [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).\n\
+    \\n\
+    \ Notes:\n\
+    \ - A location may refer to a repeated field itself (i.e. not to any\n\
+    \   particular index within it).  This is used whenever a set of elements are\n\
+    \   logically enclosed in a single code segment.  For example, an entire\n\
+    \   extend block (possibly containing multiple extension definitions) will\n\
+    \   have an outer location whose path refers to the \"extensions\" repeated\n\
+    \   field without an index.\n\
+    \ - Multiple locations may have the same path.  This happens when a single\n\
+    \   logical declaration is spread out across multiple places.  The most\n\
+    \   obvious example is the \"extend\" block again -- there may be multiple\n\
+    \   extend blocks in the same scope, each of which will have the same path.\n\
+    \ - A location's span is not always a subset of its parent's span.  For\n\
+    \   example, the \"extendee\" of an extension declaration appears at the\n\
+    \   beginning of the \"extend\" block and is shared by all extensions within\n\
+    \   the block.\n\
+    \ - Just because a location's span is a subset of some other location's span\n\
+    \   does not mean that it is a descendent.  For example, a \"group\" defines\n\
+    \   both a type and a field in a single declaration.  Thus, the locations\n\
+    \   corresponding to the type and field and their components will overlap.\n\
+    \ - Code which tries to interpret locations should probably be designed to\n\
+    \   ignore those that it doesn't understand, as more types of locations could\n\
+    \   be recorded in the future.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC3\STX\NUL\EOT\DC2\EOT\131\ACK\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC3\STX\NUL\ACK\DC2\EOT\131\ACK\v\DC3\n\
+    \\r\n\
+    \\ENQ\EOT\DC3\STX\NUL\SOH\DC2\EOT\131\ACK\DC4\FS\n\
+    \\r\n\
+    \\ENQ\EOT\DC3\STX\NUL\ETX\DC2\EOT\131\ACK\US \n\
+    \\SO\n\
+    \\EOT\EOT\DC3\ETX\NUL\DC2\ACK\132\ACK\STX\215\ACK\ETX\n\
+    \\r\n\
+    \\ENQ\EOT\DC3\ETX\NUL\SOH\DC2\EOT\132\ACK\n\
+    \\DC2\n\
+    \\131\a\n\
+    \\ACK\EOT\DC3\ETX\NUL\STX\NUL\DC2\EOT\156\ACK\EOT*\SUB\242\ACK Identifies which part of the FileDescriptorProto was defined at this\n\
+    \ location.\n\
+    \\n\
+    \ Each element is a field number or an index.  They form a path from\n\
+    \ the root FileDescriptorProto to the place where the definition.  For\n\
+    \ example, this path:\n\
+    \   [ 4, 3, 2, 7, 1 ]\n\
+    \ refers to:\n\
+    \   file.message_type(3)  // 4, 3\n\
+    \       .field(7)         // 2, 7\n\
+    \       .name()           // 1\n\
+    \ This is because FileDescriptorProto.message_type has field number 4:\n\
+    \   repeated DescriptorProto message_type = 4;\n\
+    \ and DescriptorProto.field has field number 2:\n\
+    \   repeated FieldDescriptorProto field = 2;\n\
+    \ and FieldDescriptorProto.name has field number 1:\n\
+    \   optional string name = 1;\n\
+    \\n\
+    \ Thus, the above path gives the location of a field name.  If we removed\n\
+    \ the last element:\n\
+    \   [ 4, 3, 2, 7 ]\n\
+    \ this path refers to the whole field declaration (from the beginning\n\
+    \ of the label to the terminating semicolon).\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\NUL\EOT\DC2\EOT\156\ACK\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\NUL\ENQ\DC2\EOT\156\ACK\r\DC2\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\NUL\SOH\DC2\EOT\156\ACK\DC3\ETB\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\NUL\ETX\DC2\EOT\156\ACK\SUB\ESC\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\NUL\b\DC2\EOT\156\ACK\FS)\n\
+    \\DLE\n\
+    \\b\EOT\DC3\ETX\NUL\STX\NUL\b\STX\DC2\EOT\156\ACK\GS(\n\
+    \\210\STX\n\
+    \\ACK\EOT\DC3\ETX\NUL\STX\SOH\DC2\EOT\163\ACK\EOT*\SUB\193\STX Always has exactly three or four elements: start line, start column,\n\
+    \ end line (optional, otherwise assumed same as start line), end column.\n\
+    \ These are packed into a single field for efficiency.  Note that line\n\
+    \ and column numbers are zero-based -- typically you will want to add\n\
+    \ 1 to each before displaying to a user.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\SOH\EOT\DC2\EOT\163\ACK\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\SOH\ENQ\DC2\EOT\163\ACK\r\DC2\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\SOH\SOH\DC2\EOT\163\ACK\DC3\ETB\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\SOH\ETX\DC2\EOT\163\ACK\SUB\ESC\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\SOH\b\DC2\EOT\163\ACK\FS)\n\
+    \\DLE\n\
+    \\b\EOT\DC3\ETX\NUL\STX\SOH\b\STX\DC2\EOT\163\ACK\GS(\n\
+    \\165\f\n\
+    \\ACK\EOT\DC3\ETX\NUL\STX\STX\DC2\EOT\212\ACK\EOT)\SUB\148\f If this SourceCodeInfo represents a complete declaration, these are any\n\
+    \ comments appearing before and after the declaration which appear to be\n\
+    \ attached to the declaration.\n\
+    \\n\
+    \ A series of line comments appearing on consecutive lines, with no other\n\
+    \ tokens appearing on those lines, will be treated as a single comment.\n\
+    \\n\
+    \ leading_detached_comments will keep paragraphs of comments that appear\n\
+    \ before (but not connected to) the current element. Each paragraph,\n\
+    \ separated by empty lines, will be one comment element in the repeated\n\
+    \ field.\n\
+    \\n\
+    \ Only the comment content is provided; comment markers (e.g. //) are\n\
+    \ stripped out.  For block comments, leading whitespace and an asterisk\n\
+    \ will be stripped from the beginning of each line other than the first.\n\
+    \ Newlines are included in the output.\n\
+    \\n\
+    \ Examples:\n\
+    \\n\
+    \   optional int32 foo = 1;  // Comment attached to foo.\n\
+    \   // Comment attached to bar.\n\
+    \   optional int32 bar = 2;\n\
+    \\n\
+    \   optional string baz = 3;\n\
+    \   // Comment attached to baz.\n\
+    \   // Another line attached to baz.\n\
+    \\n\
+    \   // Comment attached to qux.\n\
+    \   //\n\
+    \   // Another line attached to qux.\n\
+    \   optional double qux = 4;\n\
+    \\n\
+    \   // Detached comment for corge. This is not leading or trailing comments\n\
+    \   // to qux or corge because there are blank lines separating it from\n\
+    \   // both.\n\
+    \\n\
+    \   // Detached comment for corge paragraph 2.\n\
+    \\n\
+    \   optional string corge = 5;\n\
+    \   /* Block comment attached\n\
+    \    * to corge.  Leading asterisks\n\
+    \    * will be removed. */\n\
+    \   /* Block comment attached to\n\
+    \    * grault. */\n\
+    \   optional int32 grault = 6;\n\
+    \\n\
+    \   // ignored detached comments.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\STX\EOT\DC2\EOT\212\ACK\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\STX\ENQ\DC2\EOT\212\ACK\r\DC3\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\STX\SOH\DC2\EOT\212\ACK\DC4$\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\STX\ETX\DC2\EOT\212\ACK'(\n\
+    \\SO\n\
+    \\ACK\EOT\DC3\ETX\NUL\STX\ETX\DC2\EOT\213\ACK\EOT*\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\ETX\EOT\DC2\EOT\213\ACK\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\ETX\ENQ\DC2\EOT\213\ACK\r\DC3\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\ETX\SOH\DC2\EOT\213\ACK\DC4%\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\ETX\ETX\DC2\EOT\213\ACK()\n\
+    \\SO\n\
+    \\ACK\EOT\DC3\ETX\NUL\STX\EOT\DC2\EOT\214\ACK\EOT2\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\EOT\EOT\DC2\EOT\214\ACK\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\EOT\ENQ\DC2\EOT\214\ACK\r\DC3\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\EOT\SOH\DC2\EOT\214\ACK\DC4-\n\
+    \\SI\n\
+    \\a\EOT\DC3\ETX\NUL\STX\EOT\ETX\DC2\EOT\214\ACK01\n\
+    \\238\SOH\n\
+    \\STX\EOT\DC4\DC2\ACK\221\ACK\NUL\242\ACK\SOH\SUB\223\SOH Describes the relationship between generated code and its original source\n\
+    \ file. A GeneratedCodeInfo message is associated with only one generated\n\
+    \ source file, but may contain references to different source .proto files.\n\
+    \\n\
+    \\v\n\
+    \\ETX\EOT\DC4\SOH\DC2\EOT\221\ACK\b\EM\n\
+    \x\n\
+    \\EOT\EOT\DC4\STX\NUL\DC2\EOT\224\ACK\STX%\SUBj An Annotation connects some span of text in generated code to an element\n\
+    \ of its generating .proto file.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC4\STX\NUL\EOT\DC2\EOT\224\ACK\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\DC4\STX\NUL\ACK\DC2\EOT\224\ACK\v\NAK\n\
+    \\r\n\
+    \\ENQ\EOT\DC4\STX\NUL\SOH\DC2\EOT\224\ACK\SYN \n\
+    \\r\n\
+    \\ENQ\EOT\DC4\STX\NUL\ETX\DC2\EOT\224\ACK#$\n\
+    \\SO\n\
+    \\EOT\EOT\DC4\ETX\NUL\DC2\ACK\225\ACK\STX\241\ACK\ETX\n\
+    \\r\n\
+    \\ENQ\EOT\DC4\ETX\NUL\SOH\DC2\EOT\225\ACK\n\
+    \\DC4\n\
+    \\143\SOH\n\
+    \\ACK\EOT\DC4\ETX\NUL\STX\NUL\DC2\EOT\228\ACK\EOT*\SUB\DEL Identifies the element in the original source .proto file. This field\n\
+    \ is formatted the same as SourceCodeInfo.Location.path.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\NUL\EOT\DC2\EOT\228\ACK\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\NUL\ENQ\DC2\EOT\228\ACK\r\DC2\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\NUL\SOH\DC2\EOT\228\ACK\DC3\ETB\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\NUL\ETX\DC2\EOT\228\ACK\SUB\ESC\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\NUL\b\DC2\EOT\228\ACK\FS)\n\
+    \\DLE\n\
+    \\b\EOT\DC4\ETX\NUL\STX\NUL\b\STX\DC2\EOT\228\ACK\GS(\n\
+    \O\n\
+    \\ACK\EOT\DC4\ETX\NUL\STX\SOH\DC2\EOT\231\ACK\EOT$\SUB? Identifies the filesystem path to the original source .proto.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\SOH\EOT\DC2\EOT\231\ACK\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\SOH\ENQ\DC2\EOT\231\ACK\r\DC3\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\SOH\SOH\DC2\EOT\231\ACK\DC4\US\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\SOH\ETX\DC2\EOT\231\ACK\"#\n\
+    \w\n\
+    \\ACK\EOT\DC4\ETX\NUL\STX\STX\DC2\EOT\235\ACK\EOT\GS\SUBg Identifies the starting offset in bytes in the generated code\n\
+    \ that relates to the identified object.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\STX\EOT\DC2\EOT\235\ACK\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\STX\ENQ\DC2\EOT\235\ACK\r\DC2\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\STX\SOH\DC2\EOT\235\ACK\DC3\CAN\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\STX\ETX\DC2\EOT\235\ACK\ESC\FS\n\
+    \\219\SOH\n\
+    \\ACK\EOT\DC4\ETX\NUL\STX\ETX\DC2\EOT\240\ACK\EOT\ESC\SUB\202\SOH Identifies the ending offset in bytes in the generated code that\n\
+    \ relates to the identified offset. The end offset should be one past\n\
+    \ the last relevant byte (so the length of the text = end - begin).\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\ETX\EOT\DC2\EOT\240\ACK\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\ETX\ENQ\DC2\EOT\240\ACK\r\DC2\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\ETX\SOH\DC2\EOT\240\ACK\DC3\SYN\n\
+    \\SI\n\
+    \\a\EOT\DC4\ETX\NUL\STX\ETX\ETX\DC2\EOT\240\ACK\EM\SUB"

--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -81,7 +81,7 @@ generateFiles dflags header files toGenerate = let
       deps = descriptor f ^. #dependency
       imports = Set.toAscList $ Set.fromList
                   $ map (haskellModule . (filesByName !)) deps
-      in generateModule (haskellModule f) imports
+      in generateModule (haskellModule f) (descriptor f) imports
             (publicImports f)
              (definitions f)
              (collectEnvFromDeps deps filesByName)

--- a/proto-lens-tests/tests/descriptor.proto
+++ b/proto-lens-tests/tests/descriptor.proto
@@ -12,3 +12,8 @@ message DescriptorTest {
 
     optional Inner inner = 3;
 }
+
+message DescriptorTest2 {
+    optional string another_string = 1;
+    repeated int32 some_ints = 2;
+}

--- a/proto-lens-tests/tests/descriptor_test.hs
+++ b/proto-lens-tests/tests/descriptor_test.hs
@@ -15,6 +15,7 @@ import Data.ProtoLens.Descriptor
 main :: IO ()
 main = testMain
   [ testDescriptor
+  , testFileDescriptor
   ]
 
 testDescriptor :: TestTree
@@ -24,3 +25,14 @@ testDescriptor = testCase "testDescriptor" $ do
 
   where
     d = messageDescriptor @PB.DescriptorTest
+
+testFileDescriptor :: TestTree
+testFileDescriptor = testCase "testFileDescriptor" $ do
+  "descriptor.proto" @=? view #name d
+  "descriptor" @=? view #package d
+  ["DescriptorTest", "DescriptorTest2"] @=? toListOf (#messageType . traverse . #name) d
+  ["a_string", "some_ints", "inner", "another_string", "some_ints"] @=?
+    toListOf (#messageType . traverse . #field . traverse . #name) d
+
+  where
+    d = fileDescriptor @PB.DescriptorTest

--- a/proto-lens/src/Data/ProtoLens/Message.hs
+++ b/proto-lens/src/Data/ProtoLens/Message.hs
@@ -82,6 +82,13 @@ class Message msg where
     -- from the @proto-lens-protobuf-types@ package.
     packedMessageDescriptor :: Proxy msg -> B.ByteString
 
+    -- | The serialized protobuffer file message descriptor containing this type.
+    --
+    -- For a friendlier version which returns the actual file descriptor type,
+    -- use @Data.ProtoLens.Descriptor.fileDescriptor@
+    -- from the @proto-lens-protobuf-types@ package.
+    packedFileDescriptor :: Proxy msg -> B.ByteString
+
     -- | A message with all fields set to their default values.
     --
     -- Satisfies @encodeMessage defMessage == ""@ and @decodeMessage "" == Right defMessage@.


### PR DESCRIPTION
This change adds packedFileDescriptor to each Message as well as a
fileDescriptor helper function for getting the FileDescriptorProto
from this Message.

The FileDescriptorProto is required for reflectively understanding all
of the contents of a proto.  It's used, for example, by APIs that
persist protos.

While it may seem a little odd to have each Message defined in a proto
return the same FileDescriptorProto, this is about the third thing I
tried working with and found the alternatives to be much worse.

1. If `packedFileDescriptor` is exported from the module itself, much
   code is broken due to duplicate definitions on flat imports.
2. Adding a new module, e.g. `MyProto_Descriptor` worked around the
   issue at no cost by having the flat space separated.

However, both of these mean that an API that needs access to the
FileDescriptorProto has no way to discover it from a proto it's
given.  Manual registration of FileDescriptorProto would always be
required ahead of time for any API that needs it, and this is rather
cumbersome and difficult to enforce programmatically.