### PR TITLE
Fix a warning when there are only enums, no messages.

### DIFF
--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Generate.hs
@@ -148,7 +148,7 @@ generateModule modName fdesc imports publicImports definitions importedEnv servi
     -- messages, it's omitted since it's only used inside of Message
     -- instances.
     packedFileDescriptorProto
-      | null definitions = []
+      | null [m | Message m <- Map.elems definitions] = []
       | otherwise = [
           typeSig "packedFileDescriptor" $ var "Data.ByteString.ByteString",
           valBind "packedFileDescriptor" $ string packedFDesc

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -136,6 +136,7 @@ tests:
     generated-other-modules:
       - Proto.Enum
       - Proto.Enum_Fields
+      - Proto.EnumOnly
 
   names_test:
     main: names_test.hs

--- a/proto-lens-tests/tests/enum_only.proto
+++ b/proto-lens-tests/tests/enum_only.proto
@@ -1,0 +1,10 @@
+// A file that only contains an enum, not a message.
+// Checks that we're not generating unused top-level definitions.
+
+syntax = "proto2";
+
+package enums;
+
+enum Lone {
+  LONE = 0;
+}

--- a/proto-lens-tests/tests/enum_test.hs
+++ b/proto-lens-tests/tests/enum_test.hs
@@ -17,6 +17,7 @@ import Proto.Enum
     , Alias(..)
     , ManyCasesProto
     )
+import Proto.EnumOnly (Lone(..))
 import Proto.Enum_Fields
 import Data.Function (on)
 import Data.ProtoLens
@@ -46,12 +47,13 @@ main = testMain
     , testMonotonicFromEnum
     , testAliases
     , testManyCases
+    , testLone
     ]
 
 testExternalEnum, testNestedEnum, testDefaults, testBadEnumValues,
     testNamedEnumValues, testRoundTrip, testBounded, testMaybeSuccAndPred,
     testEnumFromThenTo, testMonotonicFromEnum, testAliases,
-    testManyCases :: TestTree
+    testManyCases, testLone :: TestTree
 
 testExternalEnum = testGroup "external"
     [ serializeTo (show e1)
@@ -163,3 +165,5 @@ testAliases = testCase "alias" $ do
 
 testManyCases =
     runTypedTest (roundTripTest "many cases" :: TypedTest ManyCasesProto)
+
+testLone = testCase "no messages" $ LONE @?= LONE

--- a/proto-lens-tests/tests/enum_test.hs
+++ b/proto-lens-tests/tests/enum_test.hs
@@ -166,4 +166,6 @@ testAliases = testCase "alias" $ do
 testManyCases =
     runTypedTest (roundTripTest "many cases" :: TypedTest ManyCasesProto)
 
+-- A trivial test to check that the module Lone came from was compiled
+-- successfully.
 testLone = testCase "no messages" $ LONE @?= LONE


### PR DESCRIPTION
Previously we got:

```
...../build/enum_test/autogen/Proto/EnumOnly.hs:72:1: error: [-Wunused-top-binds, -Werror=unused-top-binds]
    Defined but not used: ‘packedFileDescriptor’
   |
72 | packedFileDescriptor
   | ^^^^^^^^^^^^^^^^^^^^
```

The check for whether the file had any messages was incorrect, since it didn't account for enums which are tracked in the same map.