### PR TITLE
Add support for message set wire format

### DIFF
--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -295,3 +295,12 @@ tests:
       - proto-lens-tests
     generated-other-modules:
       - Proto.Descriptor
+
+  message_set_test:
+    main: message_set_test.hs
+    source-dirs: tests
+    dependencies:
+      - proto-lens-tests
+    generated-other-modules:
+      - Proto.MessageSet
+      - Proto.MessageSet_Fields

--- a/proto-lens-tests/tests/message_set.proto
+++ b/proto-lens-tests/tests/message_set.proto
@@ -1,0 +1,22 @@
+syntax = "proto2";
+
+package message_set;
+
+message Foo {
+    option message_set_wire_format = true;
+    extensions 4 to max;
+}
+
+message Bar {
+    extend Foo {
+        optional Bar bar_extension = 10;
+    }
+    optional string bar = 1;
+}
+
+message Baz {
+    extend Foo {
+        optional Baz baz_extension = 11;
+    }
+    optional string baz = 1;
+}

--- a/proto-lens-tests/tests/message_set_test.hs
+++ b/proto-lens-tests/tests/message_set_test.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Main where
+
+import Data.ByteString.Builder (Builder)
+import Data.ProtoLens
+import qualified Data.ProtoLens.Encoding.Wire as Wire
+import Lens.Family2 ((&), (.~))
+import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase)
+
+import Proto.MessageSet
+import Proto.MessageSet_Fields
+import Data.ProtoLens.TestUtil
+
+main :: IO ()
+main = testMain 
+    [ testMessageSetSerialization "default" (defMessage @Foo) mempty
+    , testMessageSetSerialization "with extension"
+        (defMessage @Foo & unknownFields .~ 
+            [ TaggedValue 10 (Wire.Lengthy $ encodeMessage $ defMessage @Bar & bar .~ "hello") ])
+        (mconcat [tagged 1 $ GroupStart, tagged 2 $ VarInt 10, tagged 3 $ Lengthy (tagged 1 $ Lengthy "hello"), tagged 1 $ GroupEnd])
+    , testMessageSetSerialization "with multiple extensions"
+        (defMessage @Foo & unknownFields .~ 
+            [ TaggedValue 10 (Wire.Lengthy $ encodeMessage $ defMessage @Bar & bar .~ "hello")
+            , TaggedValue 11 (Wire.Lengthy $ encodeMessage $ defMessage @Baz & baz .~ "world") ])
+        (mconcat [ tagged 1 $ GroupStart, tagged 2 $ VarInt 10, tagged 3 $ Lengthy (tagged 1 $ Lengthy "hello"), tagged 1 $ GroupEnd
+                 , tagged 1 $ GroupStart, tagged 2 $ VarInt 11, tagged 3 $ Lengthy (tagged 1 $ Lengthy "world"), tagged 1 $ GroupEnd])
+    , deserializeFrom "empty" (Just $ defMessage @Foo) mempty
+    , deserializeFrom "with bar extension"
+        (Just $ defMessage @Foo & unknownFields .~ 
+            [ TaggedValue 10 (Wire.Lengthy $ encodeMessage $ defMessage @Bar & bar .~ "hello") ])
+        (mconcat [tagged 1 $ GroupStart, tagged 2 $ VarInt 10, tagged 3 $ Lengthy (tagged 1 $ Lengthy "hello"), tagged 1 $ GroupEnd])
+    , deserializeFrom "with reversed tag and message (unsupported)"
+        (Nothing :: Maybe Foo)
+        (mconcat [tagged 1 $ GroupStart, tagged 3 $ Lengthy (tagged 1 $ Lengthy "hello"), tagged 2 $ VarInt 10, tagged 1 $ GroupEnd])
+    ]
+
+testMessageSetSerialization
+    :: forall msg . (Eq msg, Show msg, Message msg)
+    => String -> msg -> Builder -> TestTree
+testMessageSetSerialization name msg bs = testCase name $ do
+    let bs' = toStrictByteString bs
+    bs' @=? encodeMessage msg
+    Right msg @=? decodeMessage bs'

--- a/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Wire.hs
@@ -65,6 +65,8 @@ buildTaggedValue (TaggedValue tag wv) =
     putVarInt (joinTypeAndTag tag (wireValueToInt wv))
     <> buildWireValue wv
 
+-- builds in legacy MessageSet format.
+-- See https://github.com/protocolbuffers/protobuf/blob/dec4939439d9ca2adf2bb14edccf876c2587faf2/src/google/protobuf/descriptor.proto#L444
 buildTaggedValueAsMessageSet :: TaggedValue -> Builder
 buildTaggedValueAsMessageSet (TaggedValue (Tag t) wv) =
     buildTaggedValue ( TaggedValue 1 StartGroup)


### PR DESCRIPTION
This can be enabled by adding "option message_set_wire_format = true" to
the proto message.

The encoding format is taken from C++ code
https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/wire_format.cc#L1046