### PR TITLE
Use tasty-hunit fully instead of HUnit.

### DIFF
--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -23,7 +23,6 @@ build-tools: proto-lens-protoc:proto-lens-protoc
 
 # Dependencies shared by the library and/or several of the tests:
 dependencies:
-    - HUnit
     - QuickCheck
     - base
     - bytestring

--- a/proto-lens-tests/src/Data/ProtoLens/TestUtil.hs
+++ b/proto-lens-tests/src/Data/ProtoLens/TestUtil.hs
@@ -54,9 +54,8 @@ import Test.QuickCheck (noShrinking)
 import Test.QuickCheck (withMaxSuccess)
 #endif
 import Test.Tasty (defaultMain, testGroup, TestTree)
-import Test.Tasty.HUnit (testCase)
+import Test.Tasty.HUnit (testCase, (@=?), assertBool, assertFailure)
 import Test.Tasty.QuickCheck (testProperty)
-import Test.HUnit ((@=?), assertBool, assertFailure)
 import Data.Either (isLeft)
 import Data.Bits (shiftL, shiftR, (.|.), (.&.))
 import qualified Data.Text.Lazy as TL

--- a/proto-lens-tests/tests/any_test.hs
+++ b/proto-lens-tests/tests/any_test.hs
@@ -8,8 +8,7 @@ import Data.ProtoLens.Any
 import Data.ProtoLens.Arbitrary (ArbitraryMessage(..))
 import Proto.Google.Protobuf.Any_Fields (typeUrl, value)
 import Lens.Family2 ((&), (.~), (^.))
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase, (@=?))
 import qualified Data.Text as Text
 import Test.QuickCheck ((===), counterexample, listOf, elements)
 

--- a/proto-lens-tests/tests/decode_delimited_test.hs
+++ b/proto-lens-tests/tests/decode_delimited_test.hs
@@ -7,8 +7,7 @@ import qualified Data.Text as T
 import Data.ProtoLens
 import Data.ProtoLens.Encoding.Bytes (runBuilder)
 import Lens.Family2 ((&), (.~))
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase, (@=?))
 
 import Data.ProtoLens.TestUtil
 import Proto.DecodeDelimited

--- a/proto-lens-tests/tests/dependent_test.hs
+++ b/proto-lens-tests/tests/dependent_test.hs
@@ -2,8 +2,7 @@ module Main (main) where
 
 import Data.ProtoLens (defMessage)
 import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase, (@=?))
 
 import Proto.Dependent (Dependent)
 import Proto.Lib (LibMessage)

--- a/proto-lens-tests/tests/descriptor_test.hs
+++ b/proto-lens-tests/tests/descriptor_test.hs
@@ -5,8 +5,7 @@ module Main where
 
 import Data.ProtoLens.Labels ()
 import Lens.Family2 (view, toListOf)
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase, (@=?))
 
 import Data.ProtoLens.TestUtil (TestTree, testMain)
 import qualified Proto.Descriptor as PB

--- a/proto-lens-tests/tests/enum_test.hs
+++ b/proto-lens-tests/tests/enum_test.hs
@@ -24,8 +24,7 @@ import Data.ProtoLens
 import Data.ProtoLens.Arbitrary
 import Lens.Family2 ((&), (.~), (^.))
 import Test.Tasty (localOption, mkTimeout, testGroup)
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@?=))
+import Test.Tasty.HUnit (testCase, (@?=))
 
 import Data.ProtoLens.TestUtil
 

--- a/proto-lens-tests/tests/imports_test.hs
+++ b/proto-lens-tests/tests/imports_test.hs
@@ -7,8 +7,7 @@ module Main where
 import Data.ProtoLens (Message, defMessage)
 import Data.ProtoLens.Labels ()
 import Lens.Family2 (Lens', view, set)
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase, (@=?))
 
 import Data.ProtoLens.TestUtil (TestTree, testMain)
 import qualified Proto.Enum as Enum

--- a/proto-lens-tests/tests/labels_test.hs
+++ b/proto-lens-tests/tests/labels_test.hs
@@ -10,8 +10,7 @@ import Proto.Canonical (Test1, Test3)
 import Data.ProtoLens (build, defMessage)
 import Data.ProtoLens.Labels ()
 import Data.ProtoLens.TestUtil
-import Test.HUnit ((@?=))
-import Test.Tasty.HUnit (testCase)
+import Test.Tasty.HUnit (testCase, (@?=))
 
 main :: IO ()
 main = testMain

--- a/proto-lens-tests/tests/message_set_test.hs
+++ b/proto-lens-tests/tests/message_set_test.hs
@@ -8,8 +8,7 @@ import Data.ByteString.Builder (Builder)
 import Data.ProtoLens
 import qualified Data.ProtoLens.Encoding.Wire as Wire
 import Lens.Family2 ((&), (.~))
-import Test.HUnit ((@=?))
-import Test.Tasty.HUnit (testCase)
+import Test.Tasty.HUnit (testCase, (@=?))
 
 import Proto.MessageSet
 import Proto.MessageSet_Fields

--- a/proto-lens-tests/tests/names_test.hs
+++ b/proto-lens-tests/tests/names_test.hs
@@ -17,8 +17,7 @@ import Lens.Family2 (Lens', (&), view, set)
 import Prelude hiding (Maybe, maybe, map, head, span)
 import qualified Prelude
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase, (@=?))
 
 import Proto.Names
 import Proto.Names_Fields

--- a/proto-lens-tests/tests/no_package_test.hs
+++ b/proto-lens-tests/tests/no_package_test.hs
@@ -4,8 +4,7 @@ module Main where
 
 import Data.ProtoLens
 import Lens.Family2 ((&), (.~), (^.))
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase, (@=?))
 
 import Data.ProtoLens.TestUtil (TestTree, testMain)
 import Proto.NoPackage

--- a/proto-lens-tests/tests/oneof_test.hs
+++ b/proto-lens-tests/tests/oneof_test.hs
@@ -6,8 +6,7 @@ import Proto.Oneof_Fields
 import Data.ProtoLens
 import Data.ProtoLens.Prism (_Just, (#))
 import Lens.Family2 ((&), (.~), (^?), (%~), view)
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit
+import Test.Tasty.HUnit (testCase, (@=?))
 
 import Data.ProtoLens.TestUtil
 

--- a/proto-lens-tests/tests/optional_test.hs
+++ b/proto-lens-tests/tests/optional_test.hs
@@ -11,8 +11,7 @@ import Proto.Optional_Fields
 import Data.ProtoLens
 import Lens.Family2 ((&), (.~), (^.))
 import Test.Tasty (testGroup)
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase, (@=?))
 
 import Data.ProtoLens.TestUtil
 

--- a/proto-lens-tests/tests/package-deps_test.hs
+++ b/proto-lens-tests/tests/package-deps_test.hs
@@ -2,8 +2,7 @@ module Main where
 
 import Data.ProtoLens (defMessage)
 import Lens.Family2 ((&), (.~), (^.))
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase, (@=?))
 
 import Data.ProtoLens.TestUtil (TestTree, testMain)
 import Proto.PackageDeps (Bar)

--- a/proto-lens-tests/tests/proto3_test.hs
+++ b/proto-lens-tests/tests/proto3_test.hs
@@ -33,8 +33,7 @@ import Proto.Proto3_Fields
     , string
     )
 import Test.Tasty (testGroup)
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?), assertBool)
+import Test.Tasty.HUnit (testCase, (@=?), assertBool)
 
 import Data.ProtoLens.TestUtil
 

--- a/proto-lens-tests/tests/text_format_test.hs
+++ b/proto-lens-tests/tests/text_format_test.hs
@@ -19,8 +19,7 @@ import Data.Proxy (Proxy(..))
 import Lens.Family2 ((&), (.~))
 import Proto.TextFormat
 import Proto.TextFormat_Fields
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase, (@=?))
 import Text.PrettyPrint (renderStyle, style, lineLength)
 
 import Data.ProtoLens.TestUtil

--- a/proto-lens-tests/tests/unknown_fields_test.hs
+++ b/proto-lens-tests/tests/unknown_fields_test.hs
@@ -8,8 +8,7 @@ import Data.ProtoLens
 import qualified Data.ProtoLens.Encoding.Wire as Wire
 import qualified Data.Text.Lazy as LT
 import Lens.Family2 ((&), (.~))
-import Test.Tasty.HUnit (testCase)
-import Test.HUnit ((@=?))
+import Test.Tasty.HUnit (testCase, (@=?))
 
 import Data.ProtoLens.TestUtil
 import Proto.UnknownFields


### PR DESCRIPTION
Previously we switched from `test-framework` to `tasty`,
but continued to use `Test.HUnit` for simple assertion tests.
Unfortunately,  HUnit's exceptions don't get printed nicely by
`tasty`. For example, introducing an intentional bug in a test:

```
    bytes:           FAIL
      Exception: HUnitFailure (Just (SrcLoc {srcLocPackage = "proto-lens-tests-0.1.0.1-CZ6Ohah6nNGOHV46uMAQt", srcLocModule = "Data.ProtoLens.TestUtil", srcLocFile = "src/Data/ProtoLens/TestUtil.hs", srcLocStartLine = 93, srcLocStartCol = 5, srcLocEndLine = 93, srcLocEndCol = 48})) (ExpectedButGot Nothing "\"a: 151\"" "\"a: 150\"")
```

If we switch completely over to importing functions like `=@?`
from `Test.Tasty.HUnit` instead of `Test.HUnit`, we'll get
nicer exceptions like we did with `test-framework`.

```
    bytes:           FAIL
      src/Data/ProtoLens/TestUtil.hs:92:
      expected: "a: 151"
       but got: "a: 150"
```