### PR TITLE
Upgrade stack to v2.3.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
       cabal-new)
         export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$HOME/.cabal/bin:$PATH;;
     esac
-  - curl -L https://github.com/commercialhaskell/stack/releases/download/v1.9.3/stack-1.9.3-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'
+  - curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'
   - curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip > protoc-release.zip
   - unzip -p protoc-release.zip bin/protoc > $HOME/.local/bin/protoc
   - chmod a+x $HOME/.local/bin/protoc

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To build and test this repository from HEAD, run:
     git submodule update --init --recursive
     stack test
 
-Note: building this repository requires `stack-1.7.1` or newer.
+Note: building this repository requires `stack-2.3.1` or newer.
 
 ## Using in a Cabal or Stack package
 `proto-lens` is available on Hackage and Stackage.  Cabal and Stack projects can use it

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -28,32 +28,32 @@ library:
 
 
   reexported-modules:
-    - Prelude as Data.ProtoLens.Runtime.Prelude,
-    - Control.DeepSeq as Data.ProtoLens.Runtime.Control.DeepSeq,
-    - Data.Int as Data.ProtoLens.Runtime.Data.Int,
-    - Data.Monoid as Data.ProtoLens.Runtime.Data.Monoid,
-    - Data.Word as Data.ProtoLens.Runtime.Data.Word,
-    - Data.ByteString as Data.ProtoLens.Runtime.Data.ByteString,
-    - Data.ByteString.Char8 as Data.ProtoLens.Runtime.Data.ByteString.Char8,
-    - Data.Map as Data.ProtoLens.Runtime.Data.Map,
-    - Data.ProtoLens as Data.ProtoLens.Runtime.Data.ProtoLens,
-    - Data.ProtoLens.Encoding.Bytes as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Bytes,
-    - Data.ProtoLens.Encoding.Growing as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Growing,
-    - Data.ProtoLens.Encoding.Parser.Unsafe as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Parser.Unsafe,
-    - Data.ProtoLens.Field as Data.ProtoLens.Runtime.Data.ProtoLens.Field,
-    - Data.ProtoLens.Prism as Data.ProtoLens.Runtime.Data.ProtoLens.Prism,
+    - Prelude as Data.ProtoLens.Runtime.Prelude
+    - Control.DeepSeq as Data.ProtoLens.Runtime.Control.DeepSeq
+    - Data.Int as Data.ProtoLens.Runtime.Data.Int
+    - Data.Monoid as Data.ProtoLens.Runtime.Data.Monoid
+    - Data.Word as Data.ProtoLens.Runtime.Data.Word
+    - Data.ByteString as Data.ProtoLens.Runtime.Data.ByteString
+    - Data.ByteString.Char8 as Data.ProtoLens.Runtime.Data.ByteString.Char8
+    - Data.Map as Data.ProtoLens.Runtime.Data.Map
+    - Data.ProtoLens as Data.ProtoLens.Runtime.Data.ProtoLens
+    - Data.ProtoLens.Encoding.Bytes as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Bytes
+    - Data.ProtoLens.Encoding.Growing as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Growing
+    - Data.ProtoLens.Encoding.Parser.Unsafe as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Parser.Unsafe
+    - Data.ProtoLens.Field as Data.ProtoLens.Runtime.Data.ProtoLens.Field
+    - Data.ProtoLens.Prism as Data.ProtoLens.Runtime.Data.ProtoLens.Prism
     # TODO: try to avoid exposing the Wire module, or else merge it into the
     # Bytes module.
-    - Data.ProtoLens.Encoding.Wire as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire,
-    - Data.ProtoLens.Service.Types as Data.ProtoLens.Runtime.Data.ProtoLens.Service.Types,
-    - Data.ProtoLens.Message.Enum as Data.ProtoLens.Runtime.Data.ProtoLens.Message.Enum,
-    - Data.Text as Data.ProtoLens.Runtime.Data.Text,
-    - Data.Text.Encoding as Data.ProtoLens.Runtime.Data.Text.Encoding,
-    - Data.Vector as Data.ProtoLens.Runtime.Data.Vector,
-    - Data.Vector.Generic as Data.ProtoLens.Runtime.Data.Vector.Generic,
-    - Data.Vector.Unboxed as Data.ProtoLens.Runtime.Data.Vector.Unboxed,
-    - Lens.Family2 as Data.ProtoLens.Runtime.Lens.Family2,
-    - Lens.Family2.Unchecked as Data.ProtoLens.Runtime.Lens.Family2.Unchecked,
+    - Data.ProtoLens.Encoding.Wire as Data.ProtoLens.Runtime.Data.ProtoLens.Encoding.Wire
+    - Data.ProtoLens.Service.Types as Data.ProtoLens.Runtime.Data.ProtoLens.Service.Types
+    - Data.ProtoLens.Message.Enum as Data.ProtoLens.Runtime.Data.ProtoLens.Message.Enum
+    - Data.Text as Data.ProtoLens.Runtime.Data.Text
+    - Data.Text.Encoding as Data.ProtoLens.Runtime.Data.Text.Encoding
+    - Data.Vector as Data.ProtoLens.Runtime.Data.Vector
+    - Data.Vector.Generic as Data.ProtoLens.Runtime.Data.Vector.Generic
+    - Data.Vector.Unboxed as Data.ProtoLens.Runtime.Data.Vector.Unboxed
+    - Lens.Family2 as Data.ProtoLens.Runtime.Lens.Family2
+    - Lens.Family2.Unchecked as Data.ProtoLens.Runtime.Lens.Family2.Unchecked
     - Text.Read as Data.ProtoLens.Runtime.Text.Read
 
  

--- a/proto-lens-tutorial/stack-nightly.yaml
+++ b/proto-lens-tutorial/stack-nightly.yaml
@@ -3,14 +3,9 @@ packages:
 - person
 - coffee-order
 
-- extra-dep: true
-  location:
-    '..'
-  subdirs:
-    - proto-lens
-    - proto-lens-protoc
-    - proto-lens-runtime
-    - proto-lens-setup
-
 extra-deps:
 - ghc-source-gen-0.3.0.0
+- ../proto-lens
+- ../proto-lens-protoc
+- ../proto-lens-runtime
+- ../proto-lens-setup

--- a/proto-lens-tutorial/stack.yaml
+++ b/proto-lens-tutorial/stack.yaml
@@ -3,14 +3,9 @@ packages:
 - person
 - coffee-order
 
-- extra-dep: true
-  location:
-    '..'
-  subdirs:
-    - proto-lens
-    - proto-lens-protoc
-    - proto-lens-runtime
-    - proto-lens-setup
-
 extra-deps:
 - ghc-source-gen-0.3.0.0
+- ../proto-lens
+- ../proto-lens-protoc
+- ../proto-lens-runtime
+- ../proto-lens-setup

--- a/travis-cabal-new.sh
+++ b/travis-cabal-new.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 set -x
 
 echo Installing hpack
-curl -L https://github.com/sol/hpack/releases/download/0.31.2/hpack_linux.gz \
+curl -L https://github.com/sol/hpack/releases/download/0.34.1/hpack_linux.gz \
   | gunzip > $HOME/.local/bin/hpack
 chmod +x $HOME/.local/bin/hpack
 

--- a/travis-cabal.sh
+++ b/travis-cabal.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 set -x
 
 echo Installing hpack
-curl -L https://github.com/sol/hpack/releases/download/0.31.2/hpack_linux.gz \
+curl -L https://github.com/sol/hpack/releases/download/0.34.1/hpack_linux.gz \
   | gunzip > $HOME/.local/bin/hpack
 chmod +x $HOME/.local/bin/hpack
 


### PR DESCRIPTION
And update the `reexported-modules` section of `proto-lens-runtime/package.yaml`. It changed from line-separated list to comma-separated list in the latest stack (hpack): https://github.com/sol/hpack/commit/c8a5d80238fe09b1ae56702ffb3b3305fd48bcd8.