### PR TITLE
Fix name shadowing with ghc-source-gen 0.4.0.0

### DIFF
--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Generate.hs
@@ -634,8 +634,8 @@ generateEnumDecls info =
                 , ". This value would be out of bounds."
                 ]))
         :
-        [ match [conP_ (unqual from)] $ var $ unqual to
-        | (from, to) <- thePairs
+        [ match [conP_ (unqual from')] $ var $ unqual to
+        | (from', to) <- thePairs
         ]
         ++
         [ match [conP (unqual $ unrecognizedName u) [wildP]]


### PR DESCRIPTION
`from` is a function name from ghc-source-gen now.