### PR TITLE
Use commit sha in stack-bootstrap.yaml

### DIFF
--- a/stack-bootstrap.yaml
+++ b/stack-bootstrap.yaml
@@ -8,10 +8,8 @@ packages:
 extra-deps:
 - ghc-source-gen-0.4.0.0
 - git: https://github.com/google/proto-lens
-  # To use the current repository:
-  # git: ../..  # stack runs 'git clone' in a subdirectory
-  # Note: this commit should match the value of bootstrapCommit in bootstrap.hs
-  commit: master
   subdirs:
   - proto-lens
   - proto-lens-runtime
+  # A line like below will be appended by bootstrap.hs.
+  # commit: 0bef8c2f3da645f068b8a26ac168c1da41608182


### PR DESCRIPTION
Latest stack doesn't seem to support named commits such as 'master'.

Get the commit sha from `git rev-parse` and append it to the yaml file.

This doesn't fully fixx (intentional typo to make GitHub not close the issue) https://github.com/google/proto-lens/issues/391 but
goes one step further. We still get an error like:

```
$ stack runghc -- bootstrap.hs
Cloning 0bef8c2f3da645f068b8a26ac168c1da41608182 from https://github.com/google/proto-lens
Unsupported tarball from /tmp/with-repo-archive189930/foo.tar: Symbolic link dest not found from proto-lens/proto-lens-imports/google to ../../google/protobuf/src/google, looking for proto-lens/../google/protobuf/src/google.
This may indicate that the source is a git archive which uses git-annex.
See https://github.com/commercialhaskell/stack/issues/4579 for further information.
bootstrap.hs: readCreateProcess: stack "--stack-yaml=stack-bootstrap.yaml" "path" "--local-install-root" (exit 1): failed
```