### PR TITLE
Remove redundant (.&. 127) from putVarInt

### DIFF
--- a/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
@@ -126,7 +126,7 @@ testMsb b = (b .&. 128) /= 0
 putVarInt :: Word64 -> Builder
 putVarInt n
     | n < 128 = Builder.word8 (fromIntegral n)
-    | otherwise = Builder.word8 (fromIntegral $ n .&. 127 .|. 128)
+    | otherwise = Builder.word8 (fromIntegral $ n .|. 128)
                       <> putVarInt (n `shiftR` 7)
 
 getFixed32 :: Parser Word32


### PR DESCRIPTION
Some evidence of that redundancy:
```
> quickCheck (\(x :: Word64) -> (fromIntegral (x .|. 128) :: Word8) == (fromIntegral (x .&. 127 .|. 128) :: Word8))
+++ OK, passed 100 tests.
```