### PR TITLE
Fix cabal build on CI

### DIFF
--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -43,7 +43,7 @@ library:
     - parsec == 3.1.*
     - pretty == 1.1.*
     - primitive >= 0.6 && < 0.8
-    - profunctors >= 5.2 && < 5.6
+    - profunctors >= 5.2 && < 6.0
     - tagged == 0.8.*
     - text == 1.2.*
     - transformers >= 0.4 && < 0.6


### PR DESCRIPTION
To fix the cabal build on CI, this PR relaxes the upper bound on the `profunctor` version from `< 5.6` to `< 6.0`.
This allows `proto-lens` to use the latest version of profunctor 5.6 (released on Oct 1).

Currently, `profunctor` is required by the following two dependencies, and cabal seems not to be able to resolve them correctly.
* `discrimination` requires `profunctor == 5.*.*`, cabal installs 5.6 (latest)
* `proto-lens` requires `profunctor >= 5.2 && < 5.6`, cabal installs 5.5.2