### PR TITLE
Support proto3 optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
         export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:$HOME/.cabal/bin:$PATH;;
     esac
   - curl -L https://github.com/commercialhaskell/stack/releases/download/v2.3.1/stack-2.3.1-linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C $HOME/.local/bin '*/stack'
-  - curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip > protoc-release.zip
+  - curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip > protoc-release.zip
   - unzip -p protoc-release.zip bin/protoc > $HOME/.local/bin/protoc
   - chmod a+x $HOME/.local/bin/protoc
   - rm protoc-release.zip

--- a/docs/installing-protoc.md
+++ b/docs/installing-protoc.md
@@ -23,8 +23,8 @@ but they may be useful for other language bindings/plugins.)
 
 - Alternately, run the following commands:
 
-      PROTOC_ZIP=protoc-3.7.1-osx-x86_64.zip
-      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/$PROTOC_ZIP
+      PROTOC_ZIP=protoc-3.14.0-osx-x86_64.zip
+      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$PROTOC_ZIP
       sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
       sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
       rm -f $PROTOC_ZIP
@@ -32,10 +32,10 @@ but they may be useful for other language bindings/plugins.)
 ## Linux
 - Run the following commands:
 
-      PROTOC_ZIP=protoc-3.7.1-linux-x86_64.zip
-      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/$PROTOC_ZIP
+      PROTOC_ZIP=protoc-3.14.0.-linux-x86_64.zip
+      curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/$PROTOC_ZIP
       sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
       sudo unzip -o $PROTOC_ZIP -d /usr/local 'include/*'
       rm -f $PROTOC_ZIP
 
-- Alternately, manually download and install `protoc` from [here](https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip).
+- Alternately, manually download and install `protoc` from [here](https://github.com/protocolbuffers/protobuf/releases/download/v3.14.0/protoc-3.14.0-linux-x86_64.zip).

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Generate.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Generate.hs
@@ -969,6 +969,9 @@ messageInstance env protoName m =
     fields = messageFields m
                 ++ (messageOneofFields m >>= fmap casePlainField . oneofCases)
     -- The cases of an optional are always treated like proto2 "maybe" fields.
+    -- This code here does not apply to proto3 optional fields which
+    -- are absent from messageOneofFields, but those get treated as
+    -- OptionalMaybeField by fieldKind so they behave the same.
     casePlainField = PlainFieldInfo OptionalMaybeField . caseField
 
 -- | Get the name of the field when used in a text format proto. Groups are

--- a/proto-lens-protoc/app/Proto/Google/Protobuf/Compiler/Plugin.hs
+++ b/proto-lens-protoc/app/Proto/Google/Protobuf/Compiler/Plugin.hs
@@ -5,6 +5,7 @@
 {-# OPTIONS_GHC -Wno-dodgy-exports#-}
 module Proto.Google.Protobuf.Compiler.Plugin (
         CodeGeneratorRequest(), CodeGeneratorResponse(),
+        CodeGeneratorResponse'Feature(..), CodeGeneratorResponse'Feature(),
         CodeGeneratorResponse'File(), Version()
     ) where
 import qualified Data.ProtoLens.Runtime.Control.DeepSeq as Control.DeepSeq
@@ -371,10 +372,13 @@ instance Control.DeepSeq.NFData CodeGeneratorRequest where
      
          * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.error' @:: Lens' CodeGeneratorResponse Data.Text.Text@
          * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.maybe'error' @:: Lens' CodeGeneratorResponse (Prelude.Maybe Data.Text.Text)@
+         * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.supportedFeatures' @:: Lens' CodeGeneratorResponse Data.Word.Word64@
+         * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.maybe'supportedFeatures' @:: Lens' CodeGeneratorResponse (Prelude.Maybe Data.Word.Word64)@
          * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.file' @:: Lens' CodeGeneratorResponse [CodeGeneratorResponse'File]@
          * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.vec'file' @:: Lens' CodeGeneratorResponse (Data.Vector.Vector CodeGeneratorResponse'File)@ -}
 data CodeGeneratorResponse
   = CodeGeneratorResponse'_constructor {_CodeGeneratorResponse'error :: !(Prelude.Maybe Data.Text.Text),
+                                        _CodeGeneratorResponse'supportedFeatures :: !(Prelude.Maybe Data.Word.Word64),
                                         _CodeGeneratorResponse'file :: !(Data.Vector.Vector CodeGeneratorResponse'File),
                                         _CodeGeneratorResponse'_unknownFields :: !Data.ProtoLens.FieldSet}
   deriving stock (Prelude.Eq, Prelude.Ord)
@@ -398,6 +402,22 @@ instance Data.ProtoLens.Field.HasField CodeGeneratorResponse "maybe'error" (Prel
            _CodeGeneratorResponse'error
            (\ x__ y__ -> x__ {_CodeGeneratorResponse'error = y__}))
         Prelude.id
+instance Data.ProtoLens.Field.HasField CodeGeneratorResponse "supportedFeatures" Data.Word.Word64 where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _CodeGeneratorResponse'supportedFeatures
+           (\ x__ y__
+              -> x__ {_CodeGeneratorResponse'supportedFeatures = y__}))
+        (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+instance Data.ProtoLens.Field.HasField CodeGeneratorResponse "maybe'supportedFeatures" (Prelude.Maybe Data.Word.Word64) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _CodeGeneratorResponse'supportedFeatures
+           (\ x__ y__
+              -> x__ {_CodeGeneratorResponse'supportedFeatures = y__}))
+        Prelude.id
 instance Data.ProtoLens.Field.HasField CodeGeneratorResponse "file" [CodeGeneratorResponse'File] where
   fieldOf _
     = (Prelude..)
@@ -420,12 +440,17 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
   packedMessageDescriptor _
     = "\n\
       \\NAKCodeGeneratorResponse\DC2\DC4\n\
-      \\ENQerror\CAN\SOH \SOH(\tR\ENQerror\DC2H\n\
-      \\EOTfile\CAN\SI \ETX(\v24.google.protobuf.compiler.CodeGeneratorResponse.FileR\EOTfile\SUB]\n\
+      \\ENQerror\CAN\SOH \SOH(\tR\ENQerror\DC2-\n\
+      \\DC2supported_features\CAN\STX \SOH(\EOTR\DC1supportedFeatures\DC2H\n\
+      \\EOTfile\CAN\SI \ETX(\v24.google.protobuf.compiler.CodeGeneratorResponse.FileR\EOTfile\SUB\177\SOH\n\
       \\EOTFile\DC2\DC2\n\
       \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2'\n\
       \\SIinsertion_point\CAN\STX \SOH(\tR\SOinsertionPoint\DC2\CAN\n\
-      \\acontent\CAN\SI \SOH(\tR\acontent"
+      \\acontent\CAN\SI \SOH(\tR\acontent\DC2R\n\
+      \\DC3generated_code_info\CAN\DLE \SOH(\v2\".google.protobuf.GeneratedCodeInfoR\DC1generatedCodeInfo\"8\n\
+      \\aFeature\DC2\DLE\n\
+      \\fFEATURE_NONE\DLE\NUL\DC2\ESC\n\
+      \\ETBFEATURE_PROTO3_OPTIONAL\DLE\SOH"
   packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
@@ -436,6 +461,14 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
                  Data.ProtoLens.FieldTypeDescriptor Data.Text.Text)
               (Data.ProtoLens.OptionalField
                  (Data.ProtoLens.Field.field @"maybe'error")) ::
+              Data.ProtoLens.FieldDescriptor CodeGeneratorResponse
+        supportedFeatures__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "supported_features"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.UInt64Field ::
+                 Data.ProtoLens.FieldTypeDescriptor Data.Word.Word64)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'supportedFeatures")) ::
               Data.ProtoLens.FieldDescriptor CodeGeneratorResponse
         file__field_descriptor
           = Data.ProtoLens.FieldDescriptor
@@ -448,6 +481,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
       in
         Data.Map.fromList
           [(Data.ProtoLens.Tag 1, error__field_descriptor),
+           (Data.ProtoLens.Tag 2, supportedFeatures__field_descriptor),
            (Data.ProtoLens.Tag 15, file__field_descriptor)]
   unknownFields
     = Lens.Family2.Unchecked.lens
@@ -456,6 +490,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
   defMessage
     = CodeGeneratorResponse'_constructor
         {_CodeGeneratorResponse'error = Prelude.Nothing,
+         _CodeGeneratorResponse'supportedFeatures = Prelude.Nothing,
          _CodeGeneratorResponse'file = Data.Vector.Generic.empty,
          _CodeGeneratorResponse'_unknownFields = []}
   parseMessage
@@ -501,6 +536,13 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
                                 loop
                                   (Lens.Family2.set (Data.ProtoLens.Field.field @"error") y x)
                                   mutable'file
+                        16
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       Data.ProtoLens.Encoding.Bytes.getVarInt "supported_features"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"supportedFeatures") y x)
+                                  mutable'file
                         122
                           -> do !y <- (Data.ProtoLens.Encoding.Bytes.<?>)
                                         (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
@@ -543,21 +585,31 @@ instance Data.ProtoLens.Message CodeGeneratorResponse where
                           Data.Text.Encoding.encodeUtf8
                           _v))
              ((Data.Monoid.<>)
-                (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
-                   (\ _v
-                      -> (Data.Monoid.<>)
-                           (Data.ProtoLens.Encoding.Bytes.putVarInt 122)
-                           ((Prelude..)
-                              (\ bs
-                                 -> (Data.Monoid.<>)
-                                      (Data.ProtoLens.Encoding.Bytes.putVarInt
-                                         (Prelude.fromIntegral (Data.ByteString.length bs)))
-                                      (Data.ProtoLens.Encoding.Bytes.putBytes bs))
-                              Data.ProtoLens.encodeMessage
-                              _v))
-                   (Lens.Family2.view (Data.ProtoLens.Field.field @"vec'file") _x))
-                (Data.ProtoLens.Encoding.Wire.buildFieldSet
-                   (Lens.Family2.view Data.ProtoLens.unknownFields _x)))
+                (case
+                     Lens.Family2.view
+                       (Data.ProtoLens.Field.field @"maybe'supportedFeatures") _x
+                 of
+                   Prelude.Nothing -> Data.Monoid.mempty
+                   (Prelude.Just _v)
+                     -> (Data.Monoid.<>)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt 16)
+                          (Data.ProtoLens.Encoding.Bytes.putVarInt _v))
+                ((Data.Monoid.<>)
+                   (Data.ProtoLens.Encoding.Bytes.foldMapBuilder
+                      (\ _v
+                         -> (Data.Monoid.<>)
+                              (Data.ProtoLens.Encoding.Bytes.putVarInt 122)
+                              ((Prelude..)
+                                 (\ bs
+                                    -> (Data.Monoid.<>)
+                                         (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                            (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                         (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                 Data.ProtoLens.encodeMessage
+                                 _v))
+                      (Lens.Family2.view (Data.ProtoLens.Field.field @"vec'file") _x))
+                   (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                      (Lens.Family2.view Data.ProtoLens.unknownFields _x))))
 instance Control.DeepSeq.NFData CodeGeneratorResponse where
   rnf
     = \ x__
@@ -565,7 +617,59 @@ instance Control.DeepSeq.NFData CodeGeneratorResponse where
              (_CodeGeneratorResponse'_unknownFields x__)
              (Control.DeepSeq.deepseq
                 (_CodeGeneratorResponse'error x__)
-                (Control.DeepSeq.deepseq (_CodeGeneratorResponse'file x__) ()))
+                (Control.DeepSeq.deepseq
+                   (_CodeGeneratorResponse'supportedFeatures x__)
+                   (Control.DeepSeq.deepseq (_CodeGeneratorResponse'file x__) ())))
+data CodeGeneratorResponse'Feature
+  = CodeGeneratorResponse'FEATURE_NONE |
+    CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL
+  deriving stock (Prelude.Show, Prelude.Eq, Prelude.Ord)
+instance Data.ProtoLens.MessageEnum CodeGeneratorResponse'Feature where
+  maybeToEnum 0 = Prelude.Just CodeGeneratorResponse'FEATURE_NONE
+  maybeToEnum 1
+    = Prelude.Just CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL
+  maybeToEnum _ = Prelude.Nothing
+  showEnum CodeGeneratorResponse'FEATURE_NONE = "FEATURE_NONE"
+  showEnum CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL
+    = "FEATURE_PROTO3_OPTIONAL"
+  readEnum k
+    | (Prelude.==) k "FEATURE_NONE"
+    = Prelude.Just CodeGeneratorResponse'FEATURE_NONE
+    | (Prelude.==) k "FEATURE_PROTO3_OPTIONAL"
+    = Prelude.Just CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL
+    | Prelude.otherwise
+    = (Prelude.>>=) (Text.Read.readMaybe k) Data.ProtoLens.maybeToEnum
+instance Prelude.Bounded CodeGeneratorResponse'Feature where
+  minBound = CodeGeneratorResponse'FEATURE_NONE
+  maxBound = CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL
+instance Prelude.Enum CodeGeneratorResponse'Feature where
+  toEnum k__
+    = Prelude.maybe
+        (Prelude.error
+           ((Prelude.++)
+              "toEnum: unknown value for enum Feature: " (Prelude.show k__)))
+        Prelude.id
+        (Data.ProtoLens.maybeToEnum k__)
+  fromEnum CodeGeneratorResponse'FEATURE_NONE = 0
+  fromEnum CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL = 1
+  succ CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL
+    = Prelude.error
+        "CodeGeneratorResponse'Feature.succ: bad argument CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL. This value would be out of bounds."
+  succ CodeGeneratorResponse'FEATURE_NONE
+    = CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL
+  pred CodeGeneratorResponse'FEATURE_NONE
+    = Prelude.error
+        "CodeGeneratorResponse'Feature.pred: bad argument CodeGeneratorResponse'FEATURE_NONE. This value would be out of bounds."
+  pred CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL
+    = CodeGeneratorResponse'FEATURE_NONE
+  enumFrom = Data.ProtoLens.Message.Enum.messageEnumFrom
+  enumFromTo = Data.ProtoLens.Message.Enum.messageEnumFromTo
+  enumFromThen = Data.ProtoLens.Message.Enum.messageEnumFromThen
+  enumFromThenTo = Data.ProtoLens.Message.Enum.messageEnumFromThenTo
+instance Data.ProtoLens.FieldDefault CodeGeneratorResponse'Feature where
+  fieldDefault = CodeGeneratorResponse'FEATURE_NONE
+instance Control.DeepSeq.NFData CodeGeneratorResponse'Feature where
+  rnf x__ = Prelude.seq x__ ()
 {- | Fields :
      
          * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.name' @:: Lens' CodeGeneratorResponse'File Data.Text.Text@
@@ -573,11 +677,14 @@ instance Control.DeepSeq.NFData CodeGeneratorResponse where
          * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.insertionPoint' @:: Lens' CodeGeneratorResponse'File Data.Text.Text@
          * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.maybe'insertionPoint' @:: Lens' CodeGeneratorResponse'File (Prelude.Maybe Data.Text.Text)@
          * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.content' @:: Lens' CodeGeneratorResponse'File Data.Text.Text@
-         * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.maybe'content' @:: Lens' CodeGeneratorResponse'File (Prelude.Maybe Data.Text.Text)@ -}
+         * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.maybe'content' @:: Lens' CodeGeneratorResponse'File (Prelude.Maybe Data.Text.Text)@
+         * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.generatedCodeInfo' @:: Lens' CodeGeneratorResponse'File Proto.Google.Protobuf.Descriptor.GeneratedCodeInfo@
+         * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.maybe'generatedCodeInfo' @:: Lens' CodeGeneratorResponse'File (Prelude.Maybe Proto.Google.Protobuf.Descriptor.GeneratedCodeInfo)@ -}
 data CodeGeneratorResponse'File
   = CodeGeneratorResponse'File'_constructor {_CodeGeneratorResponse'File'name :: !(Prelude.Maybe Data.Text.Text),
                                              _CodeGeneratorResponse'File'insertionPoint :: !(Prelude.Maybe Data.Text.Text),
                                              _CodeGeneratorResponse'File'content :: !(Prelude.Maybe Data.Text.Text),
+                                             _CodeGeneratorResponse'File'generatedCodeInfo :: !(Prelude.Maybe Proto.Google.Protobuf.Descriptor.GeneratedCodeInfo),
                                              _CodeGeneratorResponse'File'_unknownFields :: !Data.ProtoLens.FieldSet}
   deriving stock (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show CodeGeneratorResponse'File where
@@ -630,6 +737,22 @@ instance Data.ProtoLens.Field.HasField CodeGeneratorResponse'File "maybe'content
            _CodeGeneratorResponse'File'content
            (\ x__ y__ -> x__ {_CodeGeneratorResponse'File'content = y__}))
         Prelude.id
+instance Data.ProtoLens.Field.HasField CodeGeneratorResponse'File "generatedCodeInfo" Proto.Google.Protobuf.Descriptor.GeneratedCodeInfo where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _CodeGeneratorResponse'File'generatedCodeInfo
+           (\ x__ y__
+              -> x__ {_CodeGeneratorResponse'File'generatedCodeInfo = y__}))
+        (Data.ProtoLens.maybeLens Data.ProtoLens.defMessage)
+instance Data.ProtoLens.Field.HasField CodeGeneratorResponse'File "maybe'generatedCodeInfo" (Prelude.Maybe Proto.Google.Protobuf.Descriptor.GeneratedCodeInfo) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _CodeGeneratorResponse'File'generatedCodeInfo
+           (\ x__ y__
+              -> x__ {_CodeGeneratorResponse'File'generatedCodeInfo = y__}))
+        Prelude.id
 instance Data.ProtoLens.Message CodeGeneratorResponse'File where
   messageName _
     = Data.Text.pack
@@ -639,7 +762,8 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
       \\EOTFile\DC2\DC2\n\
       \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2'\n\
       \\SIinsertion_point\CAN\STX \SOH(\tR\SOinsertionPoint\DC2\CAN\n\
-      \\acontent\CAN\SI \SOH(\tR\acontent"
+      \\acontent\CAN\SI \SOH(\tR\acontent\DC2R\n\
+      \\DC3generated_code_info\CAN\DLE \SOH(\v2\".google.protobuf.GeneratedCodeInfoR\DC1generatedCodeInfo"
   packedFileDescriptor _ = packedFileDescriptor
   fieldsByTag
     = let
@@ -667,11 +791,20 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
               (Data.ProtoLens.OptionalField
                  (Data.ProtoLens.Field.field @"maybe'content")) ::
               Data.ProtoLens.FieldDescriptor CodeGeneratorResponse'File
+        generatedCodeInfo__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "generated_code_info"
+              (Data.ProtoLens.MessageField Data.ProtoLens.MessageType ::
+                 Data.ProtoLens.FieldTypeDescriptor Proto.Google.Protobuf.Descriptor.GeneratedCodeInfo)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'generatedCodeInfo")) ::
+              Data.ProtoLens.FieldDescriptor CodeGeneratorResponse'File
       in
         Data.Map.fromList
           [(Data.ProtoLens.Tag 1, name__field_descriptor),
            (Data.ProtoLens.Tag 2, insertionPoint__field_descriptor),
-           (Data.ProtoLens.Tag 15, content__field_descriptor)]
+           (Data.ProtoLens.Tag 15, content__field_descriptor),
+           (Data.ProtoLens.Tag 16, generatedCodeInfo__field_descriptor)]
   unknownFields
     = Lens.Family2.Unchecked.lens
         _CodeGeneratorResponse'File'_unknownFields
@@ -682,6 +815,7 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
         {_CodeGeneratorResponse'File'name = Prelude.Nothing,
          _CodeGeneratorResponse'File'insertionPoint = Prelude.Nothing,
          _CodeGeneratorResponse'File'content = Prelude.Nothing,
+         _CodeGeneratorResponse'File'generatedCodeInfo = Prelude.Nothing,
          _CodeGeneratorResponse'File'_unknownFields = []}
   parseMessage
     = let
@@ -744,6 +878,15 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
                                                 (Prelude.Right r) -> Prelude.Right r))
                                        "content"
                                 loop (Lens.Family2.set (Data.ProtoLens.Field.field @"content") y x)
+                        130
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (do len <- Data.ProtoLens.Encoding.Bytes.getVarInt
+                                           Data.ProtoLens.Encoding.Bytes.isolate
+                                             (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
+                                       "generated_code_info"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"generatedCodeInfo") y x)
                         wire
                           -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                         wire
@@ -804,8 +947,25 @@ instance Data.ProtoLens.Message CodeGeneratorResponse'File where
                                         (Data.ProtoLens.Encoding.Bytes.putBytes bs))
                                 Data.Text.Encoding.encodeUtf8
                                 _v))
-                   (Data.ProtoLens.Encoding.Wire.buildFieldSet
-                      (Lens.Family2.view Data.ProtoLens.unknownFields _x))))
+                   ((Data.Monoid.<>)
+                      (case
+                           Lens.Family2.view
+                             (Data.ProtoLens.Field.field @"maybe'generatedCodeInfo") _x
+                       of
+                         Prelude.Nothing -> Data.Monoid.mempty
+                         (Prelude.Just _v)
+                           -> (Data.Monoid.<>)
+                                (Data.ProtoLens.Encoding.Bytes.putVarInt 130)
+                                ((Prelude..)
+                                   (\ bs
+                                      -> (Data.Monoid.<>)
+                                           (Data.ProtoLens.Encoding.Bytes.putVarInt
+                                              (Prelude.fromIntegral (Data.ByteString.length bs)))
+                                           (Data.ProtoLens.Encoding.Bytes.putBytes bs))
+                                   Data.ProtoLens.encodeMessage
+                                   _v))
+                      (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                         (Lens.Family2.view Data.ProtoLens.unknownFields _x)))))
 instance Control.DeepSeq.NFData CodeGeneratorResponse'File where
   rnf
     = \ x__
@@ -816,7 +976,9 @@ instance Control.DeepSeq.NFData CodeGeneratorResponse'File where
                 (Control.DeepSeq.deepseq
                    (_CodeGeneratorResponse'File'insertionPoint x__)
                    (Control.DeepSeq.deepseq
-                      (_CodeGeneratorResponse'File'content x__) ())))
+                      (_CodeGeneratorResponse'File'content x__)
+                      (Control.DeepSeq.deepseq
+                         (_CodeGeneratorResponse'File'generatedCodeInfo x__) ()))))
 {- | Fields :
      
          * 'Proto.Google.Protobuf.Compiler.Plugin_Fields.major' @:: Lens' Version Data.Int.Int32@
@@ -1085,16 +1247,21 @@ packedFileDescriptor
     \\tparameter\CAN\STX \SOH(\tR\tparameter\DC2C\n\
     \\n\
     \proto_file\CAN\SI \ETX(\v2$.google.protobuf.FileDescriptorProtoR\tprotoFile\DC2L\n\
-    \\DLEcompiler_version\CAN\ETX \SOH(\v2!.google.protobuf.compiler.VersionR\SIcompilerVersion\"\214\SOH\n\
+    \\DLEcompiler_version\CAN\ETX \SOH(\v2!.google.protobuf.compiler.VersionR\SIcompilerVersion\"\148\ETX\n\
     \\NAKCodeGeneratorResponse\DC2\DC4\n\
-    \\ENQerror\CAN\SOH \SOH(\tR\ENQerror\DC2H\n\
-    \\EOTfile\CAN\SI \ETX(\v24.google.protobuf.compiler.CodeGeneratorResponse.FileR\EOTfile\SUB]\n\
+    \\ENQerror\CAN\SOH \SOH(\tR\ENQerror\DC2-\n\
+    \\DC2supported_features\CAN\STX \SOH(\EOTR\DC1supportedFeatures\DC2H\n\
+    \\EOTfile\CAN\SI \ETX(\v24.google.protobuf.compiler.CodeGeneratorResponse.FileR\EOTfile\SUB\177\SOH\n\
     \\EOTFile\DC2\DC2\n\
     \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2'\n\
     \\SIinsertion_point\CAN\STX \SOH(\tR\SOinsertionPoint\DC2\CAN\n\
-    \\acontent\CAN\SI \SOH(\tR\acontentBg\n\
-    \\FScom.google.protobuf.compilerB\fPluginProtosZ9github.com/golang/protobuf/protoc-gen-go/plugin;plugin_goJ\166@\n\
-    \\a\DC2\ENQ.\NUL\166\SOH\SOH\n\
+    \\acontent\CAN\SI \SOH(\tR\acontent\DC2R\n\
+    \\DC3generated_code_info\CAN\DLE \SOH(\v2\".google.protobuf.GeneratedCodeInfoR\DC1generatedCodeInfo\"8\n\
+    \\aFeature\DC2\DLE\n\
+    \\fFEATURE_NONE\DLE\NUL\DC2\ESC\n\
+    \\ETBFEATURE_PROTO3_OPTIONAL\DLE\SOHBW\n\
+    \\FScom.google.protobuf.compilerB\fPluginProtosZ)google.golang.org/protobuf/types/pluginpbJ\249C\n\
+    \\a\DC2\ENQ.\NUL\182\SOH\SOH\n\
     \\202\DC1\n\
     \\SOH\f\DC2\ETX.\NUL\DC22\193\f Protocol Buffers - Google's data interchange format\n\
     \ Copyright 2008 Google Inc.  All rights reserved.\n\
@@ -1142,131 +1309,107 @@ packedFileDescriptor
     \ flag \"--${NAME}_out\" is passed to protoc.\n\
     \\n\
     \\b\n\
-    \\SOH\STX\DC2\ETX/\b \n\
+    \\SOH\STX\DC2\ETX0\NUL!\n\
     \\b\n\
-    \\SOH\b\DC2\ETX0\NUL5\n\
-    \\v\n\
-    \\EOT\b\231\a\NUL\DC2\ETX0\NUL5\n\
-    \\f\n\
-    \\ENQ\b\231\a\NUL\STX\DC2\ETX0\a\DC3\n\
-    \\r\n\
-    \\ACK\b\231\a\NUL\STX\NUL\DC2\ETX0\a\DC3\n\
-    \\SO\n\
-    \\a\b\231\a\NUL\STX\NUL\SOH\DC2\ETX0\a\DC3\n\
-    \\f\n\
-    \\ENQ\b\231\a\NUL\a\DC2\ETX0\SYN4\n\
-    \\b\n\
-    \\SOH\b\DC2\ETX1\NUL-\n\
-    \\v\n\
-    \\EOT\b\231\a\SOH\DC2\ETX1\NUL-\n\
-    \\f\n\
-    \\ENQ\b\231\a\SOH\STX\DC2\ETX1\a\ESC\n\
-    \\r\n\
-    \\ACK\b\231\a\SOH\STX\NUL\DC2\ETX1\a\ESC\n\
-    \\SO\n\
-    \\a\b\231\a\SOH\STX\NUL\SOH\DC2\ETX1\a\ESC\n\
-    \\f\n\
-    \\ENQ\b\231\a\SOH\a\DC2\ETX1\RS,\n\
-    \\b\n\
-    \\SOH\b\DC2\ETX3\NULP\n\
-    \\v\n\
-    \\EOT\b\231\a\STX\DC2\ETX3\NULP\n\
-    \\f\n\
-    \\ENQ\b\231\a\STX\STX\DC2\ETX3\a\DC1\n\
-    \\r\n\
-    \\ACK\b\231\a\STX\STX\NUL\DC2\ETX3\a\DC1\n\
-    \\SO\n\
-    \\a\b\231\a\STX\STX\NUL\SOH\DC2\ETX3\a\DC1\n\
-    \\f\n\
-    \\ENQ\b\231\a\STX\a\DC2\ETX3\DC4O\n\
+    \\SOH\b\DC2\ETX1\NUL5\n\
     \\t\n\
-    \\STX\ETX\NUL\DC2\ETX5\a)\n\
+    \\STX\b\SOH\DC2\ETX1\NUL5\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX2\NUL-\n\
+    \\t\n\
+    \\STX\b\b\DC2\ETX2\NUL-\n\
+    \\b\n\
+    \\SOH\b\DC2\ETX4\NUL@\n\
+    \\t\n\
+    \\STX\b\v\DC2\ETX4\NUL@\n\
+    \\t\n\
+    \\STX\ETX\NUL\DC2\ETX6\NUL*\n\
     \6\n\
-    \\STX\EOT\NUL\DC2\EOT8\NUL?\SOH\SUB* The version number of protocol compiler.\n\
+    \\STX\EOT\NUL\DC2\EOT9\NUL@\SOH\SUB* The version number of protocol compiler.\n\
     \\n\
     \\n\
     \\n\
-    \\ETX\EOT\NUL\SOH\DC2\ETX8\b\SI\n\
+    \\ETX\EOT\NUL\SOH\DC2\ETX9\b\SI\n\
     \\v\n\
-    \\EOT\EOT\NUL\STX\NUL\DC2\ETX9\STX\ESC\n\
+    \\EOT\EOT\NUL\STX\NUL\DC2\ETX:\STX\ESC\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\NUL\EOT\DC2\ETX9\STX\n\
+    \\ENQ\EOT\NUL\STX\NUL\EOT\DC2\ETX:\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\NUL\ENQ\DC2\ETX9\v\DLE\n\
+    \\ENQ\EOT\NUL\STX\NUL\ENQ\DC2\ETX:\v\DLE\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\NUL\SOH\DC2\ETX9\DC1\SYN\n\
+    \\ENQ\EOT\NUL\STX\NUL\SOH\DC2\ETX:\DC1\SYN\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\NUL\ETX\DC2\ETX9\EM\SUB\n\
+    \\ENQ\EOT\NUL\STX\NUL\ETX\DC2\ETX:\EM\SUB\n\
     \\v\n\
-    \\EOT\EOT\NUL\STX\SOH\DC2\ETX:\STX\ESC\n\
+    \\EOT\EOT\NUL\STX\SOH\DC2\ETX;\STX\ESC\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\SOH\EOT\DC2\ETX:\STX\n\
+    \\ENQ\EOT\NUL\STX\SOH\EOT\DC2\ETX;\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\SOH\ENQ\DC2\ETX:\v\DLE\n\
+    \\ENQ\EOT\NUL\STX\SOH\ENQ\DC2\ETX;\v\DLE\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\SOH\SOH\DC2\ETX:\DC1\SYN\n\
+    \\ENQ\EOT\NUL\STX\SOH\SOH\DC2\ETX;\DC1\SYN\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\SOH\ETX\DC2\ETX:\EM\SUB\n\
+    \\ENQ\EOT\NUL\STX\SOH\ETX\DC2\ETX;\EM\SUB\n\
     \\v\n\
-    \\EOT\EOT\NUL\STX\STX\DC2\ETX;\STX\ESC\n\
+    \\EOT\EOT\NUL\STX\STX\DC2\ETX<\STX\ESC\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\STX\EOT\DC2\ETX;\STX\n\
+    \\ENQ\EOT\NUL\STX\STX\EOT\DC2\ETX<\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\STX\ENQ\DC2\ETX;\v\DLE\n\
+    \\ENQ\EOT\NUL\STX\STX\ENQ\DC2\ETX<\v\DLE\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\STX\SOH\DC2\ETX;\DC1\SYN\n\
+    \\ENQ\EOT\NUL\STX\STX\SOH\DC2\ETX<\DC1\SYN\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\STX\ETX\DC2\ETX;\EM\SUB\n\
+    \\ENQ\EOT\NUL\STX\STX\ETX\DC2\ETX<\EM\SUB\n\
     \\128\SOH\n\
-    \\EOT\EOT\NUL\STX\ETX\DC2\ETX>\STX\GS\SUBs A suffix for alpha, beta or rc release, e.g., \"alpha-1\", \"rc2\". It should\n\
+    \\EOT\EOT\NUL\STX\ETX\DC2\ETX?\STX\GS\SUBs A suffix for alpha, beta or rc release, e.g., \"alpha-1\", \"rc2\". It should\n\
     \ be empty for mainline stable releases.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\ETX\EOT\DC2\ETX>\STX\n\
+    \\ENQ\EOT\NUL\STX\ETX\EOT\DC2\ETX?\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\ETX\ENQ\DC2\ETX>\v\DC1\n\
+    \\ENQ\EOT\NUL\STX\ETX\ENQ\DC2\ETX?\v\DC1\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\ETX\SOH\DC2\ETX>\DC2\CAN\n\
+    \\ENQ\EOT\NUL\STX\ETX\SOH\DC2\ETX?\DC2\CAN\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\ETX\ETX\DC2\ETX>\ESC\FS\n\
+    \\ENQ\EOT\NUL\STX\ETX\ETX\DC2\ETX?\ESC\FS\n\
     \O\n\
-    \\STX\EOT\SOH\DC2\EOTB\NUL^\SOH\SUBC An encoded CodeGeneratorRequest is written to the plugin's stdin.\n\
+    \\STX\EOT\SOH\DC2\EOTC\NUL_\SOH\SUBC An encoded CodeGeneratorRequest is written to the plugin's stdin.\n\
     \\n\
     \\n\
     \\n\
-    \\ETX\EOT\SOH\SOH\DC2\ETXB\b\FS\n\
+    \\ETX\EOT\SOH\SOH\DC2\ETXC\b\FS\n\
     \\209\SOH\n\
-    \\EOT\EOT\SOH\STX\NUL\DC2\ETXF\STX'\SUB\195\SOH The .proto files that were explicitly listed on the command-line.  The\n\
+    \\EOT\EOT\SOH\STX\NUL\DC2\ETXG\STX'\SUB\195\SOH The .proto files that were explicitly listed on the command-line.  The\n\
     \ code generator should generate code only for these files.  Each file's\n\
     \ descriptor will be included in proto_file, below.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\NUL\EOT\DC2\ETXF\STX\n\
+    \\ENQ\EOT\SOH\STX\NUL\EOT\DC2\ETXG\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\NUL\ENQ\DC2\ETXF\v\DC1\n\
+    \\ENQ\EOT\SOH\STX\NUL\ENQ\DC2\ETXG\v\DC1\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\NUL\SOH\DC2\ETXF\DC2\"\n\
+    \\ENQ\EOT\SOH\STX\NUL\SOH\DC2\ETXG\DC2\"\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\NUL\ETX\DC2\ETXF%&\n\
+    \\ENQ\EOT\SOH\STX\NUL\ETX\DC2\ETXG%&\n\
     \B\n\
-    \\EOT\EOT\SOH\STX\SOH\DC2\ETXI\STX \SUB5 The generator parameter passed on the command-line.\n\
+    \\EOT\EOT\SOH\STX\SOH\DC2\ETXJ\STX \SUB5 The generator parameter passed on the command-line.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\SOH\EOT\DC2\ETXI\STX\n\
+    \\ENQ\EOT\SOH\STX\SOH\EOT\DC2\ETXJ\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\SOH\ENQ\DC2\ETXI\v\DC1\n\
+    \\ENQ\EOT\SOH\STX\SOH\ENQ\DC2\ETXJ\v\DC1\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\SOH\SOH\DC2\ETXI\DC2\ESC\n\
+    \\ENQ\EOT\SOH\STX\SOH\SOH\DC2\ETXJ\DC2\ESC\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\SOH\ETX\DC2\ETXI\RS\US\n\
+    \\ENQ\EOT\SOH\STX\SOH\ETX\DC2\ETXJ\RS\US\n\
     \\135\ACK\n\
-    \\EOT\EOT\SOH\STX\STX\DC2\ETXY\STX/\SUB\249\ENQ FileDescriptorProtos for all files in files_to_generate and everything\n\
+    \\EOT\EOT\SOH\STX\STX\DC2\ETXZ\STX/\SUB\249\ENQ FileDescriptorProtos for all files in files_to_generate and everything\n\
     \ they import.  The files will appear in topological order, so each file\n\
     \ appears before any file that imports it.\n\
     \\n\
@@ -1282,34 +1425,34 @@ packedFileDescriptor
     \ fully qualified.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\STX\EOT\DC2\ETXY\STX\n\
+    \\ENQ\EOT\SOH\STX\STX\EOT\DC2\ETXZ\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\STX\ACK\DC2\ETXY\v\RS\n\
+    \\ENQ\EOT\SOH\STX\STX\ACK\DC2\ETXZ\v\RS\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\STX\SOH\DC2\ETXY\US)\n\
+    \\ENQ\EOT\SOH\STX\STX\SOH\DC2\ETXZ\US)\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\STX\ETX\DC2\ETXY,.\n\
+    \\ENQ\EOT\SOH\STX\STX\ETX\DC2\ETXZ,.\n\
     \7\n\
-    \\EOT\EOT\SOH\STX\ETX\DC2\ETX\\\STX(\SUB* The version number of protocol compiler.\n\
+    \\EOT\EOT\SOH\STX\ETX\DC2\ETX]\STX(\SUB* The version number of protocol compiler.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ETX\EOT\DC2\ETX\\\STX\n\
+    \\ENQ\EOT\SOH\STX\ETX\EOT\DC2\ETX]\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ETX\ACK\DC2\ETX\\\v\DC2\n\
+    \\ENQ\EOT\SOH\STX\ETX\ACK\DC2\ETX]\v\DC2\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ETX\SOH\DC2\ETX\\\DC3#\n\
+    \\ENQ\EOT\SOH\STX\ETX\SOH\DC2\ETX]\DC3#\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ETX\ETX\DC2\ETX\\&'\n\
+    \\ENQ\EOT\SOH\STX\ETX\ETX\DC2\ETX]&'\n\
     \L\n\
-    \\STX\EOT\STX\DC2\ENQa\NUL\166\SOH\SOH\SUB? The plugin writes an encoded CodeGeneratorResponse to stdout.\n\
+    \\STX\EOT\STX\DC2\ENQb\NUL\182\SOH\SOH\SUB? The plugin writes an encoded CodeGeneratorResponse to stdout.\n\
     \\n\
     \\n\
     \\n\
-    \\ETX\EOT\STX\SOH\DC2\ETXa\b\GS\n\
+    \\ETX\EOT\STX\SOH\DC2\ETXb\b\GS\n\
     \\237\ETX\n\
-    \\EOT\EOT\STX\STX\NUL\DC2\ETXj\STX\FS\SUB\223\ETX Error message.  If non-empty, code generation failed.  The plugin process\n\
+    \\EOT\EOT\STX\STX\NUL\DC2\ETXk\STX\FS\SUB\223\ETX Error message.  If non-empty, code generation failed.  The plugin process\n\
     \ should exit with status code zero even if it reports an error in this way.\n\
     \\n\
     \ This should be used to indicate errors in .proto files which prevent the\n\
@@ -1319,22 +1462,52 @@ packedFileDescriptor
     \ exiting with a non-zero status code.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\NUL\EOT\DC2\ETXj\STX\n\
+    \\ENQ\EOT\STX\STX\NUL\EOT\DC2\ETXk\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\NUL\ENQ\DC2\ETXj\v\DC1\n\
+    \\ENQ\EOT\STX\STX\NUL\ENQ\DC2\ETXk\v\DC1\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\NUL\SOH\DC2\ETXj\DC2\ETB\n\
+    \\ENQ\EOT\STX\STX\NUL\SOH\DC2\ETXk\DC2\ETB\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\NUL\ETX\DC2\ETXj\SUB\ESC\n\
-    \4\n\
-    \\EOT\EOT\STX\ETX\NUL\DC2\ENQm\STX\164\SOH\ETX\SUB% Represents a single generated file.\n\
+    \\ENQ\EOT\STX\STX\NUL\ETX\DC2\ETXk\SUB\ESC\n\
+    \\137\SOH\n\
+    \\EOT\EOT\STX\STX\SOH\DC2\ETXo\STX)\SUB| A bitmask of supported features that the code generator supports.\n\
+    \ This is a bitwise \"or\" of values from the Feature enum.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\ETX\NUL\SOH\DC2\ETXm\n\
+    \\ENQ\EOT\STX\STX\SOH\EOT\DC2\ETXo\STX\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\ENQ\DC2\ETXo\v\DC1\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\SOH\DC2\ETXo\DC2$\n\
+    \\f\n\
+    \\ENQ\EOT\STX\STX\SOH\ETX\DC2\ETXo'(\n\
+    \+\n\
+    \\EOT\EOT\STX\EOT\NUL\DC2\EOTr\STXu\ETX\SUB\GS Sync with code_generator.h.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\EOT\NUL\SOH\DC2\ETXr\a\SO\n\
+    \\r\n\
+    \\ACK\EOT\STX\EOT\NUL\STX\NUL\DC2\ETXs\EOT\NAK\n\
     \\SO\n\
-    \\173\ENQ\n\
-    \\ACK\EOT\STX\ETX\NUL\STX\NUL\DC2\ETXy\EOT\GS\SUB\157\ENQ The file name, relative to the output directory.  The name must not\n\
+    \\a\EOT\STX\EOT\NUL\STX\NUL\SOH\DC2\ETXs\EOT\DLE\n\
+    \\SO\n\
+    \\a\EOT\STX\EOT\NUL\STX\NUL\STX\DC2\ETXs\DC3\DC4\n\
+    \\r\n\
+    \\ACK\EOT\STX\EOT\NUL\STX\SOH\DC2\ETXt\EOT \n\
+    \\SO\n\
+    \\a\EOT\STX\EOT\NUL\STX\SOH\SOH\DC2\ETXt\EOT\ESC\n\
+    \\SO\n\
+    \\a\EOT\STX\EOT\NUL\STX\SOH\STX\DC2\ETXt\RS\US\n\
+    \4\n\
+    \\EOT\EOT\STX\ETX\NUL\DC2\ENQx\STX\180\SOH\ETX\SUB% Represents a single generated file.\n\
+    \\n\
+    \\f\n\
+    \\ENQ\EOT\STX\ETX\NUL\SOH\DC2\ETXx\n\
+    \\SO\n\
+    \\174\ENQ\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\NUL\DC2\EOT\132\SOH\EOT\GS\SUB\157\ENQ The file name, relative to the output directory.  The name must not\n\
     \ contain \".\" or \"..\" components and must be relative, not be absolute (so,\n\
     \ the file cannot lie outside the output directory).  \"/\" must be used as\n\
     \ the path separator, not \"\\\".\n\
@@ -1346,16 +1519,16 @@ packedFileDescriptor
     \ this writing protoc does not optimize for this -- it will read the entire\n\
     \ CodeGeneratorResponse before writing files to disk.\n\
     \\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\NUL\EOT\DC2\ETXy\EOT\f\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\NUL\ENQ\DC2\ETXy\r\DC3\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\NUL\SOH\DC2\ETXy\DC4\CAN\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\NUL\ETX\DC2\ETXy\ESC\FS\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\EOT\DC2\EOT\132\SOH\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\ENQ\DC2\EOT\132\SOH\r\DC3\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\SOH\DC2\EOT\132\SOH\DC4\CAN\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\ETX\DC2\EOT\132\SOH\ESC\FS\n\
     \\174\DLE\n\
-    \\ACK\EOT\STX\ETX\NUL\STX\SOH\DC2\EOT\160\SOH\EOT(\SUB\157\DLE If non-empty, indicates that the named file should already exist, and the\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\SOH\DC2\EOT\171\SOH\EOT(\SUB\157\DLE If non-empty, indicates that the named file should already exist, and the\n\
     \ content here is to be inserted into that file at a defined insertion\n\
     \ point.  This feature allows a code generator to extend the output\n\
     \ produced by another code generator.  The original generator may provide\n\
@@ -1394,32 +1567,45 @@ packedFileDescriptor
     \ If |insertion_point| is present, |name| must also be present.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\STX\ETX\NUL\STX\SOH\EOT\DC2\EOT\160\SOH\EOT\f\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\EOT\DC2\EOT\171\SOH\EOT\f\n\
     \\SI\n\
-    \\a\EOT\STX\ETX\NUL\STX\SOH\ENQ\DC2\EOT\160\SOH\r\DC3\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\ENQ\DC2\EOT\171\SOH\r\DC3\n\
     \\SI\n\
-    \\a\EOT\STX\ETX\NUL\STX\SOH\SOH\DC2\EOT\160\SOH\DC4#\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\SOH\DC2\EOT\171\SOH\DC4#\n\
     \\SI\n\
-    \\a\EOT\STX\ETX\NUL\STX\SOH\ETX\DC2\EOT\160\SOH&'\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\ETX\DC2\EOT\171\SOH&'\n\
     \$\n\
-    \\ACK\EOT\STX\ETX\NUL\STX\STX\DC2\EOT\163\SOH\EOT!\SUB\DC4 The file contents.\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\STX\DC2\EOT\174\SOH\EOT!\SUB\DC4 The file contents.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\STX\ETX\NUL\STX\STX\EOT\DC2\EOT\163\SOH\EOT\f\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\EOT\DC2\EOT\174\SOH\EOT\f\n\
     \\SI\n\
-    \\a\EOT\STX\ETX\NUL\STX\STX\ENQ\DC2\EOT\163\SOH\r\DC3\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\ENQ\DC2\EOT\174\SOH\r\DC3\n\
     \\SI\n\
-    \\a\EOT\STX\ETX\NUL\STX\STX\SOH\DC2\EOT\163\SOH\DC4\ESC\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\SOH\DC2\EOT\174\SOH\DC4\ESC\n\
     \\SI\n\
-    \\a\EOT\STX\ETX\NUL\STX\STX\ETX\DC2\EOT\163\SOH\RS \n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\ETX\DC2\EOT\174\SOH\RS \n\
+    \\225\SOH\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\ETX\DC2\EOT\179\SOH\EOT8\SUB\208\SOH Information describing the file content being inserted. If an insertion\n\
+    \ point is used, this information will be appropriately offset and inserted\n\
+    \ into the code generation metadata for the generated files.\n\
+    \\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\ETX\EOT\DC2\EOT\179\SOH\EOT\f\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\ETX\ACK\DC2\EOT\179\SOH\r\RS\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\ETX\SOH\DC2\EOT\179\SOH\US2\n\
+    \\SI\n\
+    \\a\EOT\STX\ETX\NUL\STX\ETX\ETX\DC2\EOT\179\SOH57\n\
     \\f\n\
-    \\EOT\EOT\STX\STX\SOH\DC2\EOT\165\SOH\STX\SUB\n\
+    \\EOT\EOT\STX\STX\STX\DC2\EOT\181\SOH\STX\SUB\n\
     \\r\n\
-    \\ENQ\EOT\STX\STX\SOH\EOT\DC2\EOT\165\SOH\STX\n\
+    \\ENQ\EOT\STX\STX\STX\EOT\DC2\EOT\181\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\STX\STX\SOH\ACK\DC2\EOT\165\SOH\v\SI\n\
+    \\ENQ\EOT\STX\STX\STX\ACK\DC2\EOT\181\SOH\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\STX\STX\SOH\SOH\DC2\EOT\165\SOH\DLE\DC4\n\
+    \\ENQ\EOT\STX\STX\STX\SOH\DC2\EOT\181\SOH\DLE\DC4\n\
     \\r\n\
-    \\ENQ\EOT\STX\STX\SOH\ETX\DC2\EOT\165\SOH\ETB\EM"
+    \\ENQ\EOT\STX\STX\STX\ETX\DC2\EOT\181\SOH\ETB\EM"

--- a/proto-lens-protoc/app/Proto/Google/Protobuf/Compiler/Plugin_Fields.hs
+++ b/proto-lens-protoc/app/Proto/Google/Protobuf/Compiler/Plugin_Fields.hs
@@ -55,6 +55,12 @@ fileToGenerate ::
    Data.ProtoLens.Field.HasField s "fileToGenerate" a) =>
   Lens.Family2.LensLike' f s a
 fileToGenerate = Data.ProtoLens.Field.field @"fileToGenerate"
+generatedCodeInfo ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "generatedCodeInfo" a) =>
+  Lens.Family2.LensLike' f s a
+generatedCodeInfo = Data.ProtoLens.Field.field @"generatedCodeInfo"
 insertionPoint ::
   forall f s a.
   (Prelude.Functor f,
@@ -85,6 +91,13 @@ maybe'error ::
    Data.ProtoLens.Field.HasField s "maybe'error" a) =>
   Lens.Family2.LensLike' f s a
 maybe'error = Data.ProtoLens.Field.field @"maybe'error"
+maybe'generatedCodeInfo ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'generatedCodeInfo" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'generatedCodeInfo
+  = Data.ProtoLens.Field.field @"maybe'generatedCodeInfo"
 maybe'insertionPoint ::
   forall f s a.
   (Prelude.Functor f,
@@ -128,6 +141,13 @@ maybe'suffix ::
    Data.ProtoLens.Field.HasField s "maybe'suffix" a) =>
   Lens.Family2.LensLike' f s a
 maybe'suffix = Data.ProtoLens.Field.field @"maybe'suffix"
+maybe'supportedFeatures ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'supportedFeatures" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'supportedFeatures
+  = Data.ProtoLens.Field.field @"maybe'supportedFeatures"
 minor ::
   forall f s a.
   (Prelude.Functor f, Data.ProtoLens.Field.HasField s "minor" a) =>
@@ -160,6 +180,12 @@ suffix ::
   (Prelude.Functor f, Data.ProtoLens.Field.HasField s "suffix" a) =>
   Lens.Family2.LensLike' f s a
 suffix = Data.ProtoLens.Field.field @"suffix"
+supportedFeatures ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "supportedFeatures" a) =>
+  Lens.Family2.LensLike' f s a
+supportedFeatures = Data.ProtoLens.Field.field @"supportedFeatures"
 vec'file ::
   forall f s a.
   (Prelude.Functor f,

--- a/proto-lens-protoc/app/Proto/Google/Protobuf/Descriptor.hs
+++ b/proto-lens-protoc/app/Proto/Google/Protobuf/Descriptor.hs
@@ -2695,7 +2695,9 @@ instance Control.DeepSeq.NFData ExtensionRangeOptions where
          * 'Proto.Google.Protobuf.Descriptor_Fields.jsonName' @:: Lens' FieldDescriptorProto Data.Text.Text@
          * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'jsonName' @:: Lens' FieldDescriptorProto (Prelude.Maybe Data.Text.Text)@
          * 'Proto.Google.Protobuf.Descriptor_Fields.options' @:: Lens' FieldDescriptorProto FieldOptions@
-         * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'options' @:: Lens' FieldDescriptorProto (Prelude.Maybe FieldOptions)@ -}
+         * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'options' @:: Lens' FieldDescriptorProto (Prelude.Maybe FieldOptions)@
+         * 'Proto.Google.Protobuf.Descriptor_Fields.proto3Optional' @:: Lens' FieldDescriptorProto Prelude.Bool@
+         * 'Proto.Google.Protobuf.Descriptor_Fields.maybe'proto3Optional' @:: Lens' FieldDescriptorProto (Prelude.Maybe Prelude.Bool)@ -}
 data FieldDescriptorProto
   = FieldDescriptorProto'_constructor {_FieldDescriptorProto'name :: !(Prelude.Maybe Data.Text.Text),
                                        _FieldDescriptorProto'number :: !(Prelude.Maybe Data.Int.Int32),
@@ -2707,6 +2709,7 @@ data FieldDescriptorProto
                                        _FieldDescriptorProto'oneofIndex :: !(Prelude.Maybe Data.Int.Int32),
                                        _FieldDescriptorProto'jsonName :: !(Prelude.Maybe Data.Text.Text),
                                        _FieldDescriptorProto'options :: !(Prelude.Maybe FieldOptions),
+                                       _FieldDescriptorProto'proto3Optional :: !(Prelude.Maybe Prelude.Bool),
                                        _FieldDescriptorProto'_unknownFields :: !Data.ProtoLens.FieldSet}
   deriving stock (Prelude.Eq, Prelude.Ord)
 instance Prelude.Show FieldDescriptorProto where
@@ -2855,6 +2858,20 @@ instance Data.ProtoLens.Field.HasField FieldDescriptorProto "maybe'options" (Pre
            _FieldDescriptorProto'options
            (\ x__ y__ -> x__ {_FieldDescriptorProto'options = y__}))
         Prelude.id
+instance Data.ProtoLens.Field.HasField FieldDescriptorProto "proto3Optional" Prelude.Bool where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _FieldDescriptorProto'proto3Optional
+           (\ x__ y__ -> x__ {_FieldDescriptorProto'proto3Optional = y__}))
+        (Data.ProtoLens.maybeLens Data.ProtoLens.fieldDefault)
+instance Data.ProtoLens.Field.HasField FieldDescriptorProto "maybe'proto3Optional" (Prelude.Maybe Prelude.Bool) where
+  fieldOf _
+    = (Prelude..)
+        (Lens.Family2.Unchecked.lens
+           _FieldDescriptorProto'proto3Optional
+           (\ x__ y__ -> x__ {_FieldDescriptorProto'proto3Optional = y__}))
+        Prelude.id
 instance Data.ProtoLens.Message FieldDescriptorProto where
   messageName _
     = Data.Text.pack "google.protobuf.FieldDescriptorProto"
@@ -2872,7 +2889,8 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
       \oneofIndex\DC2\ESC\n\
       \\tjson_name\CAN\n\
       \ \SOH(\tR\bjsonName\DC27\n\
-      \\aoptions\CAN\b \SOH(\v2\GS.google.protobuf.FieldOptionsR\aoptions\"\182\STX\n\
+      \\aoptions\CAN\b \SOH(\v2\GS.google.protobuf.FieldOptionsR\aoptions\DC2'\n\
+      \\SIproto3_optional\CAN\DC1 \SOH(\bR\SOproto3Optional\"\182\STX\n\
       \\EOTType\DC2\SI\n\
       \\vTYPE_DOUBLE\DLE\SOH\DC2\SO\n\
       \\n\
@@ -2985,6 +3003,14 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
               (Data.ProtoLens.OptionalField
                  (Data.ProtoLens.Field.field @"maybe'options")) ::
               Data.ProtoLens.FieldDescriptor FieldDescriptorProto
+        proto3Optional__field_descriptor
+          = Data.ProtoLens.FieldDescriptor
+              "proto3_optional"
+              (Data.ProtoLens.ScalarField Data.ProtoLens.BoolField ::
+                 Data.ProtoLens.FieldTypeDescriptor Prelude.Bool)
+              (Data.ProtoLens.OptionalField
+                 (Data.ProtoLens.Field.field @"maybe'proto3Optional")) ::
+              Data.ProtoLens.FieldDescriptor FieldDescriptorProto
       in
         Data.Map.fromList
           [(Data.ProtoLens.Tag 1, name__field_descriptor),
@@ -2996,7 +3022,8 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
            (Data.ProtoLens.Tag 7, defaultValue__field_descriptor),
            (Data.ProtoLens.Tag 9, oneofIndex__field_descriptor),
            (Data.ProtoLens.Tag 10, jsonName__field_descriptor),
-           (Data.ProtoLens.Tag 8, options__field_descriptor)]
+           (Data.ProtoLens.Tag 8, options__field_descriptor),
+           (Data.ProtoLens.Tag 17, proto3Optional__field_descriptor)]
   unknownFields
     = Lens.Family2.Unchecked.lens
         _FieldDescriptorProto'_unknownFields
@@ -3013,6 +3040,7 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
          _FieldDescriptorProto'oneofIndex = Prelude.Nothing,
          _FieldDescriptorProto'jsonName = Prelude.Nothing,
          _FieldDescriptorProto'options = Prelude.Nothing,
+         _FieldDescriptorProto'proto3Optional = Prelude.Nothing,
          _FieldDescriptorProto'_unknownFields = []}
   parseMessage
     = let
@@ -3142,6 +3170,14 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                                              (Prelude.fromIntegral len) Data.ProtoLens.parseMessage)
                                        "options"
                                 loop (Lens.Family2.set (Data.ProtoLens.Field.field @"options") y x)
+                        136
+                          -> do y <- (Data.ProtoLens.Encoding.Bytes.<?>)
+                                       (Prelude.fmap
+                                          ((Prelude./=) 0) Data.ProtoLens.Encoding.Bytes.getVarInt)
+                                       "proto3_optional"
+                                loop
+                                  (Lens.Family2.set
+                                     (Data.ProtoLens.Field.field @"proto3Optional") y x)
                         wire
                           -> do !y <- Data.ProtoLens.Encoding.Wire.parseTaggedValueFromWire
                                         wire
@@ -3307,9 +3343,24 @@ instance Data.ProtoLens.Message FieldDescriptorProto where
                                                                 bs))
                                                      Data.ProtoLens.encodeMessage
                                                      _v))
-                                        (Data.ProtoLens.Encoding.Wire.buildFieldSet
-                                           (Lens.Family2.view
-                                              Data.ProtoLens.unknownFields _x)))))))))))
+                                        ((Data.Monoid.<>)
+                                           (case
+                                                Lens.Family2.view
+                                                  (Data.ProtoLens.Field.field
+                                                     @"maybe'proto3Optional")
+                                                  _x
+                                            of
+                                              Prelude.Nothing -> Data.Monoid.mempty
+                                              (Prelude.Just _v)
+                                                -> (Data.Monoid.<>)
+                                                     (Data.ProtoLens.Encoding.Bytes.putVarInt 136)
+                                                     ((Prelude..)
+                                                        Data.ProtoLens.Encoding.Bytes.putVarInt
+                                                        (\ b -> if b then 1 else 0)
+                                                        _v))
+                                           (Data.ProtoLens.Encoding.Wire.buildFieldSet
+                                              (Lens.Family2.view
+                                                 Data.ProtoLens.unknownFields _x))))))))))))
 instance Control.DeepSeq.NFData FieldDescriptorProto where
   rnf
     = \ x__
@@ -3334,7 +3385,10 @@ instance Control.DeepSeq.NFData FieldDescriptorProto where
                                      (Control.DeepSeq.deepseq
                                         (_FieldDescriptorProto'jsonName x__)
                                         (Control.DeepSeq.deepseq
-                                           (_FieldDescriptorProto'options x__) ()))))))))))
+                                           (_FieldDescriptorProto'options x__)
+                                           (Control.DeepSeq.deepseq
+                                              (_FieldDescriptorProto'proto3Optional x__)
+                                              ())))))))))))
 data FieldDescriptorProto'Label
   = FieldDescriptorProto'LABEL_OPTIONAL |
     FieldDescriptorProto'LABEL_REQUIRED |
@@ -5560,7 +5614,7 @@ instance Data.ProtoLens.Field.HasField FileOptions "ccEnableArenas" Prelude.Bool
         (Lens.Family2.Unchecked.lens
            _FileOptions'ccEnableArenas
            (\ x__ y__ -> x__ {_FileOptions'ccEnableArenas = y__}))
-        (Data.ProtoLens.maybeLens Prelude.False)
+        (Data.ProtoLens.maybeLens Prelude.True)
 instance Data.ProtoLens.Field.HasField FileOptions "maybe'ccEnableArenas" (Prelude.Maybe Prelude.Bool) where
   fieldOf _
     = (Prelude..)
@@ -5702,8 +5756,8 @@ instance Data.ProtoLens.Message FileOptions where
       \\DC4php_generic_services\CAN* \SOH(\b:\ENQfalseR\DC2phpGenericServices\DC2%\n\
       \\n\
       \deprecated\CAN\ETB \SOH(\b:\ENQfalseR\n\
-      \deprecated\DC2/\n\
-      \\DLEcc_enable_arenas\CAN\US \SOH(\b:\ENQfalseR\SOccEnableArenas\DC2*\n\
+      \deprecated\DC2.\n\
+      \\DLEcc_enable_arenas\CAN\US \SOH(\b:\EOTtrueR\SOccEnableArenas\DC2*\n\
       \\DC1objc_class_prefix\CAN$ \SOH(\tR\SIobjcClassPrefix\DC2)\n\
       \\DLEcsharp_namespace\CAN% \SOH(\tR\SIcsharpNamespace\DC2!\n\
       \\fswift_prefix\CAN' \SOH(\tR\vswiftPrefix\DC2(\n\
@@ -10326,7 +10380,7 @@ packedFileDescriptor
     \\ENQstart\CAN\SOH \SOH(\ENQR\ENQstart\DC2\DLE\n\
     \\ETXend\CAN\STX \SOH(\ENQR\ETXend\"|\n\
     \\NAKExtensionRangeOptions\DC2X\n\
-    \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STX\"\152\ACK\n\
+    \\DC4uninterpreted_option\CAN\231\a \ETX(\v2$.google.protobuf.UninterpretedOptionR\DC3uninterpretedOption*\t\b\232\a\DLE\128\128\128\128\STX\"\193\ACK\n\
     \\DC4FieldDescriptorProto\DC2\DC2\n\
     \\EOTname\CAN\SOH \SOH(\tR\EOTname\DC2\SYN\n\
     \\ACKnumber\CAN\ETX \SOH(\ENQR\ACKnumber\DC2A\n\
@@ -10339,7 +10393,8 @@ packedFileDescriptor
     \oneofIndex\DC2\ESC\n\
     \\tjson_name\CAN\n\
     \ \SOH(\tR\bjsonName\DC27\n\
-    \\aoptions\CAN\b \SOH(\v2\GS.google.protobuf.FieldOptionsR\aoptions\"\182\STX\n\
+    \\aoptions\CAN\b \SOH(\v2\GS.google.protobuf.FieldOptionsR\aoptions\DC2'\n\
+    \\SIproto3_optional\CAN\DC1 \SOH(\bR\SOproto3Optional\"\182\STX\n\
     \\EOTType\DC2\SI\n\
     \\vTYPE_DOUBLE\DLE\SOH\DC2\SO\n\
     \\n\
@@ -10397,7 +10452,7 @@ packedFileDescriptor
     \outputType\DC28\n\
     \\aoptions\CAN\EOT \SOH(\v2\RS.google.protobuf.MethodOptionsR\aoptions\DC20\n\
     \\DLEclient_streaming\CAN\ENQ \SOH(\b:\ENQfalseR\SIclientStreaming\DC20\n\
-    \\DLEserver_streaming\CAN\ACK \SOH(\b:\ENQfalseR\SIserverStreaming\"\146\t\n\
+    \\DLEserver_streaming\CAN\ACK \SOH(\b:\ENQfalseR\SIserverStreaming\"\145\t\n\
     \\vFileOptions\DC2!\n\
     \\fjava_package\CAN\SOH \SOH(\tR\vjavaPackage\DC20\n\
     \\DC4java_outer_classname\CAN\b \SOH(\tR\DC2javaOuterClassname\DC25\n\
@@ -10414,8 +10469,8 @@ packedFileDescriptor
     \\DC4php_generic_services\CAN* \SOH(\b:\ENQfalseR\DC2phpGenericServices\DC2%\n\
     \\n\
     \deprecated\CAN\ETB \SOH(\b:\ENQfalseR\n\
-    \deprecated\DC2/\n\
-    \\DLEcc_enable_arenas\CAN\US \SOH(\b:\ENQfalseR\SOccEnableArenas\DC2*\n\
+    \deprecated\DC2.\n\
+    \\DLEcc_enable_arenas\CAN\US \SOH(\b:\EOTtrueR\SOccEnableArenas\DC2*\n\
     \\DC1objc_class_prefix\CAN$ \SOH(\tR\SIobjcClassPrefix\DC2)\n\
     \\DLEcsharp_namespace\CAN% \SOH(\tR\SIcsharpNamespace\DC2!\n\
     \\fswift_prefix\CAN' \SOH(\tR\vswiftPrefix\DC2(\n\
@@ -10516,9 +10571,9 @@ packedFileDescriptor
     \\vsource_file\CAN\STX \SOH(\tR\n\
     \sourceFile\DC2\DC4\n\
     \\ENQbegin\CAN\ETX \SOH(\ENQR\ENQbegin\DC2\DLE\n\
-    \\ETXend\CAN\EOT \SOH(\ENQR\ETXendB\143\SOH\n\
-    \\DC3com.google.protobufB\DLEDescriptorProtosH\SOHZ>github.com/golang/protobuf/protoc-gen-go/descriptor;descriptor\248\SOH\SOH\162\STX\ETXGPB\170\STX\SUBGoogle.Protobuf.ReflectionJ\180\196\STX\n\
-    \\a\DC2\ENQ'\NUL\242\ACK\SOH\n\
+    \\ETXend\CAN\EOT \SOH(\ENQR\ETXendB~\n\
+    \\DC3com.google.protobufB\DLEDescriptorProtosH\SOHZ-google.golang.org/protobuf/types/descriptorpb\248\SOH\SOH\162\STX\ETXGPB\170\STX\SUBGoogle.Protobuf.ReflectionJ\188\200\STX\n\
+    \\a\DC2\ENQ'\NUL\140\a\SOH\n\
     \\170\SI\n\
     \\SOH\f\DC2\ETX'\NUL\DC22\193\f Protocol Buffers - Google's data interchange format\n\
     \ Copyright 2008 Google Inc.  All rights reserved.\n\
@@ -10558,830 +10613,813 @@ packedFileDescriptor
     \ without any other information (e.g. without reading its imports).\n\
     \\n\
     \\b\n\
-    \\SOH\STX\DC2\ETX)\b\ETB\n\
+    \\SOH\STX\DC2\ETX)\NUL\CAN\n\
     \\b\n\
-    \\SOH\b\DC2\ETX*\NULU\n\
-    \\v\n\
-    \\EOT\b\231\a\NUL\DC2\ETX*\NULU\n\
-    \\f\n\
-    \\ENQ\b\231\a\NUL\STX\DC2\ETX*\a\DC1\n\
-    \\r\n\
-    \\ACK\b\231\a\NUL\STX\NUL\DC2\ETX*\a\DC1\n\
-    \\SO\n\
-    \\a\b\231\a\NUL\STX\NUL\SOH\DC2\ETX*\a\DC1\n\
-    \\f\n\
-    \\ENQ\b\231\a\NUL\a\DC2\ETX*\DC4T\n\
+    \\SOH\b\DC2\ETX+\NULD\n\
+    \\t\n\
+    \\STX\b\v\DC2\ETX+\NULD\n\
     \\b\n\
-    \\SOH\b\DC2\ETX+\NUL,\n\
-    \\v\n\
-    \\EOT\b\231\a\SOH\DC2\ETX+\NUL,\n\
-    \\f\n\
-    \\ENQ\b\231\a\SOH\STX\DC2\ETX+\a\DC3\n\
-    \\r\n\
-    \\ACK\b\231\a\SOH\STX\NUL\DC2\ETX+\a\DC3\n\
-    \\SO\n\
-    \\a\b\231\a\SOH\STX\NUL\SOH\DC2\ETX+\a\DC3\n\
-    \\f\n\
-    \\ENQ\b\231\a\SOH\a\DC2\ETX+\SYN+\n\
+    \\SOH\b\DC2\ETX,\NUL,\n\
+    \\t\n\
+    \\STX\b\SOH\DC2\ETX,\NUL,\n\
     \\b\n\
-    \\SOH\b\DC2\ETX,\NUL1\n\
-    \\v\n\
-    \\EOT\b\231\a\STX\DC2\ETX,\NUL1\n\
-    \\f\n\
-    \\ENQ\b\231\a\STX\STX\DC2\ETX,\a\ESC\n\
-    \\r\n\
-    \\ACK\b\231\a\STX\STX\NUL\DC2\ETX,\a\ESC\n\
-    \\SO\n\
-    \\a\b\231\a\STX\STX\NUL\SOH\DC2\ETX,\a\ESC\n\
-    \\f\n\
-    \\ENQ\b\231\a\STX\a\DC2\ETX,\RS0\n\
+    \\SOH\b\DC2\ETX-\NUL1\n\
+    \\t\n\
+    \\STX\b\b\DC2\ETX-\NUL1\n\
     \\b\n\
-    \\SOH\b\DC2\ETX-\NUL7\n\
-    \\v\n\
-    \\EOT\b\231\a\ETX\DC2\ETX-\NUL7\n\
-    \\f\n\
-    \\ENQ\b\231\a\ETX\STX\DC2\ETX-\a\ETB\n\
-    \\r\n\
-    \\ACK\b\231\a\ETX\STX\NUL\DC2\ETX-\a\ETB\n\
-    \\SO\n\
-    \\a\b\231\a\ETX\STX\NUL\SOH\DC2\ETX-\a\ETB\n\
-    \\f\n\
-    \\ENQ\b\231\a\ETX\a\DC2\ETX-\SUB6\n\
+    \\SOH\b\DC2\ETX.\NUL7\n\
+    \\t\n\
+    \\STX\b%\DC2\ETX.\NUL7\n\
     \\b\n\
-    \\SOH\b\DC2\ETX.\NUL!\n\
-    \\v\n\
-    \\EOT\b\231\a\EOT\DC2\ETX.\NUL!\n\
-    \\f\n\
-    \\ENQ\b\231\a\EOT\STX\DC2\ETX.\a\CAN\n\
-    \\r\n\
-    \\ACK\b\231\a\EOT\STX\NUL\DC2\ETX.\a\CAN\n\
-    \\SO\n\
-    \\a\b\231\a\EOT\STX\NUL\SOH\DC2\ETX.\a\CAN\n\
-    \\f\n\
-    \\ENQ\b\231\a\EOT\a\DC2\ETX.\ESC \n\
+    \\SOH\b\DC2\ETX/\NUL!\n\
+    \\t\n\
+    \\STX\b$\DC2\ETX/\NUL!\n\
     \\b\n\
-    \\SOH\b\DC2\ETX/\NUL\US\n\
-    \\v\n\
-    \\EOT\b\231\a\ENQ\DC2\ETX/\NUL\US\n\
-    \\f\n\
-    \\ENQ\b\231\a\ENQ\STX\DC2\ETX/\a\ETB\n\
-    \\r\n\
-    \\ACK\b\231\a\ENQ\STX\NUL\DC2\ETX/\a\ETB\n\
-    \\SO\n\
-    \\a\b\231\a\ENQ\STX\NUL\SOH\DC2\ETX/\a\ETB\n\
-    \\f\n\
-    \\ENQ\b\231\a\ENQ\ETX\DC2\ETX/\SUB\RS\n\
+    \\SOH\b\DC2\ETX0\NUL\US\n\
+    \\t\n\
+    \\STX\b\US\DC2\ETX0\NUL\US\n\
     \\b\n\
-    \\SOH\b\DC2\ETX3\NUL\FS\n\
-    \\129\SOH\n\
-    \\EOT\b\231\a\ACK\DC2\ETX3\NUL\FS\SUBt descriptor.proto must be optimized for speed because reflection-based\n\
+    \\SOH\b\DC2\ETX4\NUL\FS\n\
+    \\DEL\n\
+    \\STX\b\t\DC2\ETX4\NUL\FS\SUBt descriptor.proto must be optimized for speed because reflection-based\n\
     \ algorithms don't work during bootstrapping.\n\
     \\n\
-    \\f\n\
-    \\ENQ\b\231\a\ACK\STX\DC2\ETX3\a\DC3\n\
-    \\r\n\
-    \\ACK\b\231\a\ACK\STX\NUL\DC2\ETX3\a\DC3\n\
-    \\SO\n\
-    \\a\b\231\a\ACK\STX\NUL\SOH\DC2\ETX3\a\DC3\n\
-    \\f\n\
-    \\ENQ\b\231\a\ACK\ETX\DC2\ETX3\SYN\ESC\n\
     \j\n\
-    \\STX\EOT\NUL\DC2\EOT7\NUL9\SOH\SUB^ The protocol compiler can output a FileDescriptorSet containing the .proto\n\
+    \\STX\EOT\NUL\DC2\EOT8\NUL:\SOH\SUB^ The protocol compiler can output a FileDescriptorSet containing the .proto\n\
     \ files it parses.\n\
     \\n\
     \\n\
     \\n\
-    \\ETX\EOT\NUL\SOH\DC2\ETX7\b\EM\n\
+    \\ETX\EOT\NUL\SOH\DC2\ETX8\b\EM\n\
     \\v\n\
-    \\EOT\EOT\NUL\STX\NUL\DC2\ETX8\STX(\n\
+    \\EOT\EOT\NUL\STX\NUL\DC2\ETX9\STX(\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\NUL\EOT\DC2\ETX8\STX\n\
+    \\ENQ\EOT\NUL\STX\NUL\EOT\DC2\ETX9\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\NUL\ACK\DC2\ETX8\v\RS\n\
+    \\ENQ\EOT\NUL\STX\NUL\ACK\DC2\ETX9\v\RS\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\NUL\SOH\DC2\ETX8\US#\n\
+    \\ENQ\EOT\NUL\STX\NUL\SOH\DC2\ETX9\US#\n\
     \\f\n\
-    \\ENQ\EOT\NUL\STX\NUL\ETX\DC2\ETX8&'\n\
+    \\ENQ\EOT\NUL\STX\NUL\ETX\DC2\ETX9&'\n\
     \/\n\
-    \\STX\EOT\SOH\DC2\EOT<\NULY\SOH\SUB# Describes a complete .proto file.\n\
+    \\STX\EOT\SOH\DC2\EOT=\NULZ\SOH\SUB# Describes a complete .proto file.\n\
     \\n\
     \\n\
     \\n\
-    \\ETX\EOT\SOH\SOH\DC2\ETX<\b\ESC\n\
+    \\ETX\EOT\SOH\SOH\DC2\ETX=\b\ESC\n\
     \9\n\
-    \\EOT\EOT\SOH\STX\NUL\DC2\ETX=\STX\ESC\", file name, relative to root of source tree\n\
+    \\EOT\EOT\SOH\STX\NUL\DC2\ETX>\STX\ESC\", file name, relative to root of source tree\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\NUL\EOT\DC2\ETX=\STX\n\
+    \\ENQ\EOT\SOH\STX\NUL\EOT\DC2\ETX>\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\NUL\ENQ\DC2\ETX=\v\DC1\n\
+    \\ENQ\EOT\SOH\STX\NUL\ENQ\DC2\ETX>\v\DC1\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\NUL\SOH\DC2\ETX=\DC2\SYN\n\
+    \\ENQ\EOT\SOH\STX\NUL\SOH\DC2\ETX>\DC2\SYN\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\NUL\ETX\DC2\ETX=\EM\SUB\n\
+    \\ENQ\EOT\SOH\STX\NUL\ETX\DC2\ETX>\EM\SUB\n\
     \*\n\
-    \\EOT\EOT\SOH\STX\SOH\DC2\ETX>\STX\RS\"\GS e.g. \"foo\", \"foo.bar\", etc.\n\
+    \\EOT\EOT\SOH\STX\SOH\DC2\ETX?\STX\RS\"\GS e.g. \"foo\", \"foo.bar\", etc.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\SOH\EOT\DC2\ETX>\STX\n\
+    \\ENQ\EOT\SOH\STX\SOH\EOT\DC2\ETX?\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\SOH\ENQ\DC2\ETX>\v\DC1\n\
+    \\ENQ\EOT\SOH\STX\SOH\ENQ\DC2\ETX?\v\DC1\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\SOH\SOH\DC2\ETX>\DC2\EM\n\
+    \\ENQ\EOT\SOH\STX\SOH\SOH\DC2\ETX?\DC2\EM\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\SOH\ETX\DC2\ETX>\FS\GS\n\
+    \\ENQ\EOT\SOH\STX\SOH\ETX\DC2\ETX?\FS\GS\n\
     \4\n\
-    \\EOT\EOT\SOH\STX\STX\DC2\ETXA\STX!\SUB' Names of files imported by this file.\n\
+    \\EOT\EOT\SOH\STX\STX\DC2\ETXB\STX!\SUB' Names of files imported by this file.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\STX\EOT\DC2\ETXA\STX\n\
+    \\ENQ\EOT\SOH\STX\STX\EOT\DC2\ETXB\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\STX\ENQ\DC2\ETXA\v\DC1\n\
+    \\ENQ\EOT\SOH\STX\STX\ENQ\DC2\ETXB\v\DC1\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\STX\SOH\DC2\ETXA\DC2\FS\n\
+    \\ENQ\EOT\SOH\STX\STX\SOH\DC2\ETXB\DC2\FS\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\STX\ETX\DC2\ETXA\US \n\
+    \\ENQ\EOT\SOH\STX\STX\ETX\DC2\ETXB\US \n\
     \Q\n\
-    \\EOT\EOT\SOH\STX\ETX\DC2\ETXC\STX(\SUBD Indexes of the public imported files in the dependency list above.\n\
+    \\EOT\EOT\SOH\STX\ETX\DC2\ETXD\STX(\SUBD Indexes of the public imported files in the dependency list above.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ETX\EOT\DC2\ETXC\STX\n\
+    \\ENQ\EOT\SOH\STX\ETX\EOT\DC2\ETXD\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ETX\ENQ\DC2\ETXC\v\DLE\n\
+    \\ENQ\EOT\SOH\STX\ETX\ENQ\DC2\ETXD\v\DLE\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ETX\SOH\DC2\ETXC\DC1\"\n\
+    \\ENQ\EOT\SOH\STX\ETX\SOH\DC2\ETXD\DC1\"\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ETX\ETX\DC2\ETXC%'\n\
+    \\ENQ\EOT\SOH\STX\ETX\ETX\DC2\ETXD%'\n\
     \z\n\
-    \\EOT\EOT\SOH\STX\EOT\DC2\ETXF\STX&\SUBm Indexes of the weak imported files in the dependency list.\n\
+    \\EOT\EOT\SOH\STX\EOT\DC2\ETXG\STX&\SUBm Indexes of the weak imported files in the dependency list.\n\
     \ For Google-internal migration only. Do not use.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\EOT\EOT\DC2\ETXF\STX\n\
+    \\ENQ\EOT\SOH\STX\EOT\EOT\DC2\ETXG\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\EOT\ENQ\DC2\ETXF\v\DLE\n\
+    \\ENQ\EOT\SOH\STX\EOT\ENQ\DC2\ETXG\v\DLE\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\EOT\SOH\DC2\ETXF\DC1 \n\
+    \\ENQ\EOT\SOH\STX\EOT\SOH\DC2\ETXG\DC1 \n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\EOT\ETX\DC2\ETXF#%\n\
+    \\ENQ\EOT\SOH\STX\EOT\ETX\DC2\ETXG#%\n\
     \6\n\
-    \\EOT\EOT\SOH\STX\ENQ\DC2\ETXI\STX,\SUB) All top-level definitions in this file.\n\
+    \\EOT\EOT\SOH\STX\ENQ\DC2\ETXJ\STX,\SUB) All top-level definitions in this file.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ENQ\EOT\DC2\ETXI\STX\n\
+    \\ENQ\EOT\SOH\STX\ENQ\EOT\DC2\ETXJ\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ENQ\ACK\DC2\ETXI\v\SUB\n\
+    \\ENQ\EOT\SOH\STX\ENQ\ACK\DC2\ETXJ\v\SUB\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ENQ\SOH\DC2\ETXI\ESC'\n\
+    \\ENQ\EOT\SOH\STX\ENQ\SOH\DC2\ETXJ\ESC'\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ENQ\ETX\DC2\ETXI*+\n\
+    \\ENQ\EOT\SOH\STX\ENQ\ETX\DC2\ETXJ*+\n\
     \\v\n\
-    \\EOT\EOT\SOH\STX\ACK\DC2\ETXJ\STX-\n\
+    \\EOT\EOT\SOH\STX\ACK\DC2\ETXK\STX-\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ACK\EOT\DC2\ETXJ\STX\n\
+    \\ENQ\EOT\SOH\STX\ACK\EOT\DC2\ETXK\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ACK\ACK\DC2\ETXJ\v\RS\n\
+    \\ENQ\EOT\SOH\STX\ACK\ACK\DC2\ETXK\v\RS\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ACK\SOH\DC2\ETXJ\US(\n\
+    \\ENQ\EOT\SOH\STX\ACK\SOH\DC2\ETXK\US(\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\ACK\ETX\DC2\ETXJ+,\n\
+    \\ENQ\EOT\SOH\STX\ACK\ETX\DC2\ETXK+,\n\
     \\v\n\
-    \\EOT\EOT\SOH\STX\a\DC2\ETXK\STX.\n\
+    \\EOT\EOT\SOH\STX\a\DC2\ETXL\STX.\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\a\EOT\DC2\ETXK\STX\n\
+    \\ENQ\EOT\SOH\STX\a\EOT\DC2\ETXL\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\a\ACK\DC2\ETXK\v!\n\
+    \\ENQ\EOT\SOH\STX\a\ACK\DC2\ETXL\v!\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\a\SOH\DC2\ETXK\")\n\
+    \\ENQ\EOT\SOH\STX\a\SOH\DC2\ETXL\")\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\a\ETX\DC2\ETXK,-\n\
+    \\ENQ\EOT\SOH\STX\a\ETX\DC2\ETXL,-\n\
     \\v\n\
-    \\EOT\EOT\SOH\STX\b\DC2\ETXL\STX.\n\
+    \\EOT\EOT\SOH\STX\b\DC2\ETXM\STX.\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\b\EOT\DC2\ETXL\STX\n\
+    \\ENQ\EOT\SOH\STX\b\EOT\DC2\ETXM\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\b\ACK\DC2\ETXL\v\US\n\
+    \\ENQ\EOT\SOH\STX\b\ACK\DC2\ETXM\v\US\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\b\SOH\DC2\ETXL )\n\
+    \\ENQ\EOT\SOH\STX\b\SOH\DC2\ETXM )\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\b\ETX\DC2\ETXL,-\n\
+    \\ENQ\EOT\SOH\STX\b\ETX\DC2\ETXM,-\n\
     \\v\n\
-    \\EOT\EOT\SOH\STX\t\DC2\ETXN\STX#\n\
+    \\EOT\EOT\SOH\STX\t\DC2\ETXO\STX#\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\t\EOT\DC2\ETXN\STX\n\
+    \\ENQ\EOT\SOH\STX\t\EOT\DC2\ETXO\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\t\ACK\DC2\ETXN\v\SYN\n\
+    \\ENQ\EOT\SOH\STX\t\ACK\DC2\ETXO\v\SYN\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\t\SOH\DC2\ETXN\ETB\RS\n\
+    \\ENQ\EOT\SOH\STX\t\SOH\DC2\ETXO\ETB\RS\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\t\ETX\DC2\ETXN!\"\n\
+    \\ENQ\EOT\SOH\STX\t\ETX\DC2\ETXO!\"\n\
     \\244\SOH\n\
     \\EOT\EOT\SOH\STX\n\
-    \\DC2\ETXT\STX/\SUB\230\SOH This field contains optional information about the original source code.\n\
+    \\DC2\ETXU\STX/\SUB\230\SOH This field contains optional information about the original source code.\n\
     \ You may safely remove this entire field without harming runtime\n\
     \ functionality of the descriptors -- the information is needed only by\n\
     \ development tools.\n\
     \\n\
     \\f\n\
     \\ENQ\EOT\SOH\STX\n\
-    \\EOT\DC2\ETXT\STX\n\
+    \\EOT\DC2\ETXU\STX\n\
     \\n\
     \\f\n\
     \\ENQ\EOT\SOH\STX\n\
-    \\ACK\DC2\ETXT\v\EM\n\
+    \\ACK\DC2\ETXU\v\EM\n\
     \\f\n\
     \\ENQ\EOT\SOH\STX\n\
-    \\SOH\DC2\ETXT\SUB*\n\
+    \\SOH\DC2\ETXU\SUB*\n\
     \\f\n\
     \\ENQ\EOT\SOH\STX\n\
-    \\ETX\DC2\ETXT-.\n\
+    \\ETX\DC2\ETXU-.\n\
     \]\n\
-    \\EOT\EOT\SOH\STX\v\DC2\ETXX\STX\RS\SUBP The syntax of the proto file.\n\
+    \\EOT\EOT\SOH\STX\v\DC2\ETXY\STX\RS\SUBP The syntax of the proto file.\n\
     \ The supported values are \"proto2\" and \"proto3\".\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\v\EOT\DC2\ETXX\STX\n\
+    \\ENQ\EOT\SOH\STX\v\EOT\DC2\ETXY\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\v\ENQ\DC2\ETXX\v\DC1\n\
+    \\ENQ\EOT\SOH\STX\v\ENQ\DC2\ETXY\v\DC1\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\v\SOH\DC2\ETXX\DC2\CAN\n\
+    \\ENQ\EOT\SOH\STX\v\SOH\DC2\ETXY\DC2\CAN\n\
     \\f\n\
-    \\ENQ\EOT\SOH\STX\v\ETX\DC2\ETXX\ESC\GS\n\
+    \\ENQ\EOT\SOH\STX\v\ETX\DC2\ETXY\ESC\GS\n\
     \'\n\
-    \\STX\EOT\STX\DC2\EOT\\\NUL|\SOH\SUB\ESC Describes a message type.\n\
+    \\STX\EOT\STX\DC2\EOT]\NUL}\SOH\SUB\ESC Describes a message type.\n\
     \\n\
     \\n\
     \\n\
-    \\ETX\EOT\STX\SOH\DC2\ETX\\\b\ETB\n\
+    \\ETX\EOT\STX\SOH\DC2\ETX]\b\ETB\n\
     \\v\n\
-    \\EOT\EOT\STX\STX\NUL\DC2\ETX]\STX\ESC\n\
+    \\EOT\EOT\STX\STX\NUL\DC2\ETX^\STX\ESC\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\NUL\EOT\DC2\ETX]\STX\n\
+    \\ENQ\EOT\STX\STX\NUL\EOT\DC2\ETX^\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\NUL\ENQ\DC2\ETX]\v\DC1\n\
+    \\ENQ\EOT\STX\STX\NUL\ENQ\DC2\ETX^\v\DC1\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\NUL\SOH\DC2\ETX]\DC2\SYN\n\
+    \\ENQ\EOT\STX\STX\NUL\SOH\DC2\ETX^\DC2\SYN\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\NUL\ETX\DC2\ETX]\EM\SUB\n\
+    \\ENQ\EOT\STX\STX\NUL\ETX\DC2\ETX^\EM\SUB\n\
     \\v\n\
-    \\EOT\EOT\STX\STX\SOH\DC2\ETX_\STX*\n\
+    \\EOT\EOT\STX\STX\SOH\DC2\ETX`\STX*\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\SOH\EOT\DC2\ETX_\STX\n\
+    \\ENQ\EOT\STX\STX\SOH\EOT\DC2\ETX`\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\SOH\ACK\DC2\ETX_\v\US\n\
+    \\ENQ\EOT\STX\STX\SOH\ACK\DC2\ETX`\v\US\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\SOH\SOH\DC2\ETX_ %\n\
+    \\ENQ\EOT\STX\STX\SOH\SOH\DC2\ETX` %\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\SOH\ETX\DC2\ETX_()\n\
+    \\ENQ\EOT\STX\STX\SOH\ETX\DC2\ETX`()\n\
     \\v\n\
-    \\EOT\EOT\STX\STX\STX\DC2\ETX`\STX.\n\
+    \\EOT\EOT\STX\STX\STX\DC2\ETXa\STX.\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\STX\EOT\DC2\ETX`\STX\n\
+    \\ENQ\EOT\STX\STX\STX\EOT\DC2\ETXa\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\STX\ACK\DC2\ETX`\v\US\n\
+    \\ENQ\EOT\STX\STX\STX\ACK\DC2\ETXa\v\US\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\STX\SOH\DC2\ETX` )\n\
+    \\ENQ\EOT\STX\STX\STX\SOH\DC2\ETXa )\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\STX\ETX\DC2\ETX`,-\n\
+    \\ENQ\EOT\STX\STX\STX\ETX\DC2\ETXa,-\n\
     \\v\n\
-    \\EOT\EOT\STX\STX\ETX\DC2\ETXb\STX+\n\
+    \\EOT\EOT\STX\STX\ETX\DC2\ETXc\STX+\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ETX\EOT\DC2\ETXb\STX\n\
+    \\ENQ\EOT\STX\STX\ETX\EOT\DC2\ETXc\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ETX\ACK\DC2\ETXb\v\SUB\n\
+    \\ENQ\EOT\STX\STX\ETX\ACK\DC2\ETXc\v\SUB\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ETX\SOH\DC2\ETXb\ESC&\n\
+    \\ENQ\EOT\STX\STX\ETX\SOH\DC2\ETXc\ESC&\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ETX\ETX\DC2\ETXb)*\n\
+    \\ENQ\EOT\STX\STX\ETX\ETX\DC2\ETXc)*\n\
     \\v\n\
-    \\EOT\EOT\STX\STX\EOT\DC2\ETXc\STX-\n\
+    \\EOT\EOT\STX\STX\EOT\DC2\ETXd\STX-\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\EOT\EOT\DC2\ETXc\STX\n\
+    \\ENQ\EOT\STX\STX\EOT\EOT\DC2\ETXd\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\EOT\ACK\DC2\ETXc\v\RS\n\
+    \\ENQ\EOT\STX\STX\EOT\ACK\DC2\ETXd\v\RS\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\EOT\SOH\DC2\ETXc\US(\n\
+    \\ENQ\EOT\STX\STX\EOT\SOH\DC2\ETXd\US(\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\EOT\ETX\DC2\ETXc+,\n\
+    \\ENQ\EOT\STX\STX\EOT\ETX\DC2\ETXd+,\n\
     \\f\n\
-    \\EOT\EOT\STX\ETX\NUL\DC2\EOTe\STXj\ETX\n\
+    \\EOT\EOT\STX\ETX\NUL\DC2\EOTf\STXk\ETX\n\
     \\f\n\
-    \\ENQ\EOT\STX\ETX\NUL\SOH\DC2\ETXe\n\
+    \\ENQ\EOT\STX\ETX\NUL\SOH\DC2\ETXf\n\
     \\CAN\n\
+    \\ESC\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\NUL\DC2\ETXg\EOT\GS\"\f Inclusive.\n\
+    \\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\EOT\DC2\ETXg\EOT\f\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\ENQ\DC2\ETXg\r\DC2\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\SOH\DC2\ETXg\DC3\CAN\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\NUL\ETX\DC2\ETXg\ESC\FS\n\
+    \\ESC\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\SOH\DC2\ETXh\EOT\ESC\"\f Exclusive.\n\
+    \\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\EOT\DC2\ETXh\EOT\f\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\ENQ\DC2\ETXh\r\DC2\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\SOH\DC2\ETXh\DC3\SYN\n\
+    \\SO\n\
+    \\a\EOT\STX\ETX\NUL\STX\SOH\ETX\DC2\ETXh\EM\SUB\n\
     \\r\n\
-    \\ACK\EOT\STX\ETX\NUL\STX\NUL\DC2\ETXf\EOT\GS\n\
+    \\ACK\EOT\STX\ETX\NUL\STX\STX\DC2\ETXj\EOT/\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\NUL\EOT\DC2\ETXf\EOT\f\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\EOT\DC2\ETXj\EOT\f\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\NUL\ENQ\DC2\ETXf\r\DC2\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\ACK\DC2\ETXj\r\"\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\NUL\SOH\DC2\ETXf\DC3\CAN\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\SOH\DC2\ETXj#*\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\NUL\ETX\DC2\ETXf\ESC\FS\n\
-    \\r\n\
-    \\ACK\EOT\STX\ETX\NUL\STX\SOH\DC2\ETXg\EOT\ESC\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\SOH\EOT\DC2\ETXg\EOT\f\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\SOH\ENQ\DC2\ETXg\r\DC2\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\SOH\SOH\DC2\ETXg\DC3\SYN\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\SOH\ETX\DC2\ETXg\EM\SUB\n\
-    \\r\n\
-    \\ACK\EOT\STX\ETX\NUL\STX\STX\DC2\ETXi\EOT/\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\STX\EOT\DC2\ETXi\EOT\f\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\STX\ACK\DC2\ETXi\r\"\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\STX\SOH\DC2\ETXi#*\n\
-    \\SO\n\
-    \\a\EOT\STX\ETX\NUL\STX\STX\ETX\DC2\ETXi-.\n\
+    \\a\EOT\STX\ETX\NUL\STX\STX\ETX\DC2\ETXj-.\n\
     \\v\n\
-    \\EOT\EOT\STX\STX\ENQ\DC2\ETXk\STX.\n\
+    \\EOT\EOT\STX\STX\ENQ\DC2\ETXl\STX.\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ENQ\EOT\DC2\ETXk\STX\n\
+    \\ENQ\EOT\STX\STX\ENQ\EOT\DC2\ETXl\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ENQ\ACK\DC2\ETXk\v\EM\n\
+    \\ENQ\EOT\STX\STX\ENQ\ACK\DC2\ETXl\v\EM\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ENQ\SOH\DC2\ETXk\SUB)\n\
+    \\ENQ\EOT\STX\STX\ENQ\SOH\DC2\ETXl\SUB)\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ENQ\ETX\DC2\ETXk,-\n\
+    \\ENQ\EOT\STX\STX\ENQ\ETX\DC2\ETXl,-\n\
     \\v\n\
-    \\EOT\EOT\STX\STX\ACK\DC2\ETXm\STX/\n\
+    \\EOT\EOT\STX\STX\ACK\DC2\ETXn\STX/\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ACK\EOT\DC2\ETXm\STX\n\
+    \\ENQ\EOT\STX\STX\ACK\EOT\DC2\ETXn\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ACK\ACK\DC2\ETXm\v\US\n\
+    \\ENQ\EOT\STX\STX\ACK\ACK\DC2\ETXn\v\US\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ACK\SOH\DC2\ETXm *\n\
+    \\ENQ\EOT\STX\STX\ACK\SOH\DC2\ETXn *\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\ACK\ETX\DC2\ETXm-.\n\
+    \\ENQ\EOT\STX\STX\ACK\ETX\DC2\ETXn-.\n\
     \\v\n\
-    \\EOT\EOT\STX\STX\a\DC2\ETXo\STX&\n\
+    \\EOT\EOT\STX\STX\a\DC2\ETXp\STX&\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\a\EOT\DC2\ETXo\STX\n\
+    \\ENQ\EOT\STX\STX\a\EOT\DC2\ETXp\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\a\ACK\DC2\ETXo\v\EM\n\
+    \\ENQ\EOT\STX\STX\a\ACK\DC2\ETXp\v\EM\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\a\SOH\DC2\ETXo\SUB!\n\
+    \\ENQ\EOT\STX\STX\a\SOH\DC2\ETXp\SUB!\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\a\ETX\DC2\ETXo$%\n\
+    \\ENQ\EOT\STX\STX\a\ETX\DC2\ETXp$%\n\
     \\170\SOH\n\
-    \\EOT\EOT\STX\ETX\SOH\DC2\EOTt\STXw\ETX\SUB\155\SOH Range of reserved tag numbers. Reserved tag numbers may not be used by\n\
+    \\EOT\EOT\STX\ETX\SOH\DC2\EOTu\STXx\ETX\SUB\155\SOH Range of reserved tag numbers. Reserved tag numbers may not be used by\n\
     \ fields or extension ranges in the same message. Reserved ranges may\n\
     \ not overlap.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\ETX\SOH\SOH\DC2\ETXt\n\
+    \\ENQ\EOT\STX\ETX\SOH\SOH\DC2\ETXu\n\
     \\ETB\n\
     \\ESC\n\
-    \\ACK\EOT\STX\ETX\SOH\STX\NUL\DC2\ETXu\EOT\GS\"\f Inclusive.\n\
+    \\ACK\EOT\STX\ETX\SOH\STX\NUL\DC2\ETXv\EOT\GS\"\f Inclusive.\n\
     \\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\SOH\STX\NUL\EOT\DC2\ETXu\EOT\f\n\
+    \\a\EOT\STX\ETX\SOH\STX\NUL\EOT\DC2\ETXv\EOT\f\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\SOH\STX\NUL\ENQ\DC2\ETXu\r\DC2\n\
+    \\a\EOT\STX\ETX\SOH\STX\NUL\ENQ\DC2\ETXv\r\DC2\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\SOH\STX\NUL\SOH\DC2\ETXu\DC3\CAN\n\
+    \\a\EOT\STX\ETX\SOH\STX\NUL\SOH\DC2\ETXv\DC3\CAN\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\SOH\STX\NUL\ETX\DC2\ETXu\ESC\FS\n\
+    \\a\EOT\STX\ETX\SOH\STX\NUL\ETX\DC2\ETXv\ESC\FS\n\
     \\ESC\n\
-    \\ACK\EOT\STX\ETX\SOH\STX\SOH\DC2\ETXv\EOT\ESC\"\f Exclusive.\n\
+    \\ACK\EOT\STX\ETX\SOH\STX\SOH\DC2\ETXw\EOT\ESC\"\f Exclusive.\n\
     \\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\SOH\STX\SOH\EOT\DC2\ETXv\EOT\f\n\
+    \\a\EOT\STX\ETX\SOH\STX\SOH\EOT\DC2\ETXw\EOT\f\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\SOH\STX\SOH\ENQ\DC2\ETXv\r\DC2\n\
+    \\a\EOT\STX\ETX\SOH\STX\SOH\ENQ\DC2\ETXw\r\DC2\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\SOH\STX\SOH\SOH\DC2\ETXv\DC3\SYN\n\
+    \\a\EOT\STX\ETX\SOH\STX\SOH\SOH\DC2\ETXw\DC3\SYN\n\
     \\SO\n\
-    \\a\EOT\STX\ETX\SOH\STX\SOH\ETX\DC2\ETXv\EM\SUB\n\
+    \\a\EOT\STX\ETX\SOH\STX\SOH\ETX\DC2\ETXw\EM\SUB\n\
     \\v\n\
-    \\EOT\EOT\STX\STX\b\DC2\ETXx\STX,\n\
+    \\EOT\EOT\STX\STX\b\DC2\ETXy\STX,\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\b\EOT\DC2\ETXx\STX\n\
+    \\ENQ\EOT\STX\STX\b\EOT\DC2\ETXy\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\b\ACK\DC2\ETXx\v\CAN\n\
+    \\ENQ\EOT\STX\STX\b\ACK\DC2\ETXy\v\CAN\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\b\SOH\DC2\ETXx\EM'\n\
+    \\ENQ\EOT\STX\STX\b\SOH\DC2\ETXy\EM'\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\b\ETX\DC2\ETXx*+\n\
+    \\ENQ\EOT\STX\STX\b\ETX\DC2\ETXy*+\n\
     \\130\SOH\n\
-    \\EOT\EOT\STX\STX\t\DC2\ETX{\STX%\SUBu Reserved field names, which may not be used by fields in the same message.\n\
+    \\EOT\EOT\STX\STX\t\DC2\ETX|\STX%\SUBu Reserved field names, which may not be used by fields in the same message.\n\
     \ A given name may only be reserved once.\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\t\EOT\DC2\ETX{\STX\n\
+    \\ENQ\EOT\STX\STX\t\EOT\DC2\ETX|\STX\n\
     \\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\t\ENQ\DC2\ETX{\v\DC1\n\
+    \\ENQ\EOT\STX\STX\t\ENQ\DC2\ETX|\v\DC1\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\t\SOH\DC2\ETX{\DC2\US\n\
+    \\ENQ\EOT\STX\STX\t\SOH\DC2\ETX|\DC2\US\n\
     \\f\n\
-    \\ENQ\EOT\STX\STX\t\ETX\DC2\ETX{\"$\n\
+    \\ENQ\EOT\STX\STX\t\ETX\DC2\ETX|\"$\n\
     \\v\n\
-    \\STX\EOT\ETX\DC2\ENQ~\NUL\132\SOH\SOH\n\
+    \\STX\EOT\ETX\DC2\ENQ\DEL\NUL\134\SOH\SOH\n\
     \\n\
     \\n\
-    \\ETX\EOT\ETX\SOH\DC2\ETX~\b\GS\n\
+    \\ETX\EOT\ETX\SOH\DC2\ETX\DEL\b\GS\n\
     \O\n\
-    \\EOT\EOT\ETX\STX\NUL\DC2\EOT\128\SOH\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\EOT\EOT\ETX\STX\NUL\DC2\EOT\129\SOH\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ETX\STX\NUL\EOT\DC2\EOT\128\SOH\STX\n\
+    \\ENQ\EOT\ETX\STX\NUL\EOT\DC2\EOT\129\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ETX\STX\NUL\ACK\DC2\EOT\128\SOH\v\RS\n\
+    \\ENQ\EOT\ETX\STX\NUL\ACK\DC2\EOT\129\SOH\v\RS\n\
     \\r\n\
-    \\ENQ\EOT\ETX\STX\NUL\SOH\DC2\EOT\128\SOH\US3\n\
+    \\ENQ\EOT\ETX\STX\NUL\SOH\DC2\EOT\129\SOH\US3\n\
     \\r\n\
-    \\ENQ\EOT\ETX\STX\NUL\ETX\DC2\EOT\128\SOH69\n\
+    \\ENQ\EOT\ETX\STX\NUL\ETX\DC2\EOT\129\SOH69\n\
     \Z\n\
-    \\ETX\EOT\ETX\ENQ\DC2\EOT\131\SOH\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\ETX\EOT\ETX\ENQ\DC2\EOT\133\SOH\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\ETX\ENQ\NUL\DC2\EOT\131\SOH\r\CAN\n\
+    \\EOT\EOT\ETX\ENQ\NUL\DC2\EOT\133\SOH\r\CAN\n\
     \\r\n\
-    \\ENQ\EOT\ETX\ENQ\NUL\SOH\DC2\EOT\131\SOH\r\DC1\n\
+    \\ENQ\EOT\ETX\ENQ\NUL\SOH\DC2\EOT\133\SOH\r\DC1\n\
     \\r\n\
-    \\ENQ\EOT\ETX\ENQ\NUL\STX\DC2\EOT\131\SOH\NAK\CAN\n\
+    \\ENQ\EOT\ETX\ENQ\NUL\STX\DC2\EOT\133\SOH\NAK\CAN\n\
     \3\n\
-    \\STX\EOT\EOT\DC2\ACK\135\SOH\NUL\213\SOH\SOH\SUB% Describes a field within a message.\n\
+    \\STX\EOT\EOT\DC2\ACK\137\SOH\NUL\238\SOH\SOH\SUB% Describes a field within a message.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\EOT\SOH\DC2\EOT\135\SOH\b\FS\n\
+    \\ETX\EOT\EOT\SOH\DC2\EOT\137\SOH\b\FS\n\
     \\SO\n\
-    \\EOT\EOT\EOT\EOT\NUL\DC2\ACK\136\SOH\STX\167\SOH\ETX\n\
+    \\EOT\EOT\EOT\EOT\NUL\DC2\ACK\138\SOH\STX\169\SOH\ETX\n\
     \\r\n\
-    \\ENQ\EOT\EOT\EOT\NUL\SOH\DC2\EOT\136\SOH\a\v\n\
+    \\ENQ\EOT\EOT\EOT\NUL\SOH\DC2\EOT\138\SOH\a\v\n\
     \S\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\NUL\DC2\EOT\139\SOH\EOT\FS\SUBC 0 is reserved for errors.\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\NUL\DC2\EOT\141\SOH\EOT\DC4\SUBC 0 is reserved for errors.\n\
     \ Order is weird for historical reasons.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\NUL\SOH\DC2\EOT\139\SOH\EOT\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\NUL\SOH\DC2\EOT\141\SOH\EOT\SI\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\NUL\STX\DC2\EOT\139\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\NUL\STX\NUL\STX\DC2\EOT\141\SOH\DC2\DC3\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\SOH\DC2\EOT\140\SOH\EOT\FS\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\SOH\DC2\EOT\142\SOH\EOT\DC3\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\SOH\SOH\DC2\EOT\140\SOH\EOT\SO\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SOH\SOH\DC2\EOT\142\SOH\EOT\SO\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\SOH\STX\DC2\EOT\140\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SOH\STX\DC2\EOT\142\SOH\DC1\DC2\n\
     \w\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\STX\DC2\EOT\143\SOH\EOT\FS\SUBg Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\STX\DC2\EOT\145\SOH\EOT\DC3\SUBg Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if\n\
     \ negative values are likely.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\STX\SOH\DC2\EOT\143\SOH\EOT\SO\n\
+    \\a\EOT\EOT\EOT\NUL\STX\STX\SOH\DC2\EOT\145\SOH\EOT\SO\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\STX\STX\DC2\EOT\143\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\NUL\STX\STX\STX\DC2\EOT\145\SOH\DC1\DC2\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\ETX\DC2\EOT\144\SOH\EOT\FS\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\ETX\DC2\EOT\146\SOH\EOT\DC4\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\ETX\SOH\DC2\EOT\144\SOH\EOT\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ETX\SOH\DC2\EOT\146\SOH\EOT\SI\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\ETX\STX\DC2\EOT\144\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ETX\STX\DC2\EOT\146\SOH\DC2\DC3\n\
     \w\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\EOT\DC2\EOT\147\SOH\EOT\FS\SUBg Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\EOT\DC2\EOT\149\SOH\EOT\DC3\SUBg Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if\n\
     \ negative values are likely.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\EOT\SOH\DC2\EOT\147\SOH\EOT\SO\n\
+    \\a\EOT\EOT\EOT\NUL\STX\EOT\SOH\DC2\EOT\149\SOH\EOT\SO\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\EOT\STX\DC2\EOT\147\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\NUL\STX\EOT\STX\DC2\EOT\149\SOH\DC1\DC2\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\ENQ\DC2\EOT\148\SOH\EOT\FS\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\ENQ\DC2\EOT\150\SOH\EOT\NAK\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\ENQ\SOH\DC2\EOT\148\SOH\EOT\DLE\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ENQ\SOH\DC2\EOT\150\SOH\EOT\DLE\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\ENQ\STX\DC2\EOT\148\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ENQ\STX\DC2\EOT\150\SOH\DC3\DC4\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\ACK\DC2\EOT\149\SOH\EOT\FS\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\ACK\DC2\EOT\151\SOH\EOT\NAK\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\ACK\SOH\DC2\EOT\149\SOH\EOT\DLE\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ACK\SOH\DC2\EOT\151\SOH\EOT\DLE\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\ACK\STX\DC2\EOT\149\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\NUL\STX\ACK\STX\DC2\EOT\151\SOH\DC3\DC4\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\a\DC2\EOT\150\SOH\EOT\FS\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\a\DC2\EOT\152\SOH\EOT\DC2\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\a\SOH\DC2\EOT\150\SOH\EOT\r\n\
+    \\a\EOT\EOT\EOT\NUL\STX\a\SOH\DC2\EOT\152\SOH\EOT\r\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\a\STX\DC2\EOT\150\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\NUL\STX\a\STX\DC2\EOT\152\SOH\DLE\DC1\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\b\DC2\EOT\151\SOH\EOT\FS\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\b\DC2\EOT\153\SOH\EOT\DC4\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\b\SOH\DC2\EOT\151\SOH\EOT\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\b\SOH\DC2\EOT\153\SOH\EOT\SI\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\b\STX\DC2\EOT\151\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\NUL\STX\b\STX\DC2\EOT\153\SOH\DC2\DC3\n\
     \\226\SOH\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\t\DC2\EOT\156\SOH\EOT\GS\SUB\209\SOH Tag-delimited aggregate.\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\t\DC2\EOT\158\SOH\EOT\DC4\SUB\209\SOH Tag-delimited aggregate.\n\
     \ Group type is deprecated and not supported in proto3. However, Proto3\n\
     \ implementations should still be able to parse the group wire format and\n\
     \ treat group fields as unknown fields.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\t\SOH\DC2\EOT\156\SOH\EOT\SO\n\
+    \\a\EOT\EOT\EOT\NUL\STX\t\SOH\DC2\EOT\158\SOH\EOT\SO\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\t\STX\DC2\EOT\156\SOH\SUB\FS\n\
+    \\a\EOT\EOT\EOT\NUL\STX\t\STX\DC2\EOT\158\SOH\DC1\DC3\n\
     \-\n\
     \\ACK\EOT\EOT\EOT\NUL\STX\n\
-    \\DC2\EOT\157\SOH\EOT\GS\"\GS Length-delimited aggregate.\n\
+    \\DC2\EOT\159\SOH\EOT\SYN\"\GS Length-delimited aggregate.\n\
     \\n\
     \\SI\n\
     \\a\EOT\EOT\EOT\NUL\STX\n\
-    \\SOH\DC2\EOT\157\SOH\EOT\DLE\n\
+    \\SOH\DC2\EOT\159\SOH\EOT\DLE\n\
     \\SI\n\
     \\a\EOT\EOT\EOT\NUL\STX\n\
-    \\STX\DC2\EOT\157\SOH\SUB\FS\n\
+    \\STX\DC2\EOT\159\SOH\DC3\NAK\n\
     \#\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\v\DC2\EOT\160\SOH\EOT\GS\SUB\DC3 New in version 2.\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\v\DC2\EOT\162\SOH\EOT\DC4\SUB\DC3 New in version 2.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\v\SOH\DC2\EOT\160\SOH\EOT\SO\n\
+    \\a\EOT\EOT\EOT\NUL\STX\v\SOH\DC2\EOT\162\SOH\EOT\SO\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\v\STX\DC2\EOT\160\SOH\SUB\FS\n\
+    \\a\EOT\EOT\EOT\NUL\STX\v\STX\DC2\EOT\162\SOH\DC1\DC3\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\f\DC2\EOT\161\SOH\EOT\GS\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\f\DC2\EOT\163\SOH\EOT\NAK\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\f\SOH\DC2\EOT\161\SOH\EOT\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\f\SOH\DC2\EOT\163\SOH\EOT\SI\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\f\STX\DC2\EOT\161\SOH\SUB\FS\n\
+    \\a\EOT\EOT\EOT\NUL\STX\f\STX\DC2\EOT\163\SOH\DC2\DC4\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\r\DC2\EOT\162\SOH\EOT\GS\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\r\DC2\EOT\164\SOH\EOT\DC3\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\r\SOH\DC2\EOT\162\SOH\EOT\r\n\
+    \\a\EOT\EOT\EOT\NUL\STX\r\SOH\DC2\EOT\164\SOH\EOT\r\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\r\STX\DC2\EOT\162\SOH\SUB\FS\n\
+    \\a\EOT\EOT\EOT\NUL\STX\r\STX\DC2\EOT\164\SOH\DLE\DC2\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\SO\DC2\EOT\163\SOH\EOT\GS\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\SO\DC2\EOT\165\SOH\EOT\ETB\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\SO\SOH\DC2\EOT\163\SOH\EOT\DC1\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SO\SOH\DC2\EOT\165\SOH\EOT\DC1\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\SO\STX\DC2\EOT\163\SOH\SUB\FS\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SO\STX\DC2\EOT\165\SOH\DC4\SYN\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\SI\DC2\EOT\164\SOH\EOT\GS\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\SI\DC2\EOT\166\SOH\EOT\ETB\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\SI\SOH\DC2\EOT\164\SOH\EOT\DC1\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SI\SOH\DC2\EOT\166\SOH\EOT\DC1\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\SI\STX\DC2\EOT\164\SOH\SUB\FS\n\
+    \\a\EOT\EOT\EOT\NUL\STX\SI\STX\DC2\EOT\166\SOH\DC4\SYN\n\
     \'\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\DLE\DC2\EOT\165\SOH\EOT\GS\"\ETB Uses ZigZag encoding.\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\DLE\DC2\EOT\167\SOH\EOT\NAK\"\ETB Uses ZigZag encoding.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\DLE\SOH\DC2\EOT\165\SOH\EOT\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\DLE\SOH\DC2\EOT\167\SOH\EOT\SI\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\DLE\STX\DC2\EOT\165\SOH\SUB\FS\n\
+    \\a\EOT\EOT\EOT\NUL\STX\DLE\STX\DC2\EOT\167\SOH\DC2\DC4\n\
     \'\n\
-    \\ACK\EOT\EOT\EOT\NUL\STX\DC1\DC2\EOT\166\SOH\EOT\GS\"\ETB Uses ZigZag encoding.\n\
+    \\ACK\EOT\EOT\EOT\NUL\STX\DC1\DC2\EOT\168\SOH\EOT\NAK\"\ETB Uses ZigZag encoding.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\DC1\SOH\DC2\EOT\166\SOH\EOT\SI\n\
+    \\a\EOT\EOT\EOT\NUL\STX\DC1\SOH\DC2\EOT\168\SOH\EOT\SI\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\NUL\STX\DC1\STX\DC2\EOT\166\SOH\SUB\FS\n\
+    \\a\EOT\EOT\EOT\NUL\STX\DC1\STX\DC2\EOT\168\SOH\DC2\DC4\n\
     \\SO\n\
-    \\EOT\EOT\EOT\EOT\SOH\DC2\ACK\169\SOH\STX\174\SOH\ETX\n\
+    \\EOT\EOT\EOT\EOT\SOH\DC2\ACK\171\SOH\STX\176\SOH\ETX\n\
     \\r\n\
-    \\ENQ\EOT\EOT\EOT\SOH\SOH\DC2\EOT\169\SOH\a\f\n\
+    \\ENQ\EOT\EOT\EOT\SOH\SOH\DC2\EOT\171\SOH\a\f\n\
     \*\n\
-    \\ACK\EOT\EOT\EOT\SOH\STX\NUL\DC2\EOT\171\SOH\EOT\FS\SUB\SUB 0 is reserved for errors\n\
+    \\ACK\EOT\EOT\EOT\SOH\STX\NUL\DC2\EOT\173\SOH\EOT\ETB\SUB\SUB 0 is reserved for errors\n\
     \\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\SOH\STX\NUL\SOH\DC2\EOT\171\SOH\EOT\DC2\n\
+    \\a\EOT\EOT\EOT\SOH\STX\NUL\SOH\DC2\EOT\173\SOH\EOT\DC2\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\SOH\STX\NUL\STX\DC2\EOT\171\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\SOH\STX\NUL\STX\DC2\EOT\173\SOH\NAK\SYN\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\SOH\STX\SOH\DC2\EOT\172\SOH\EOT\FS\n\
+    \\ACK\EOT\EOT\EOT\SOH\STX\SOH\DC2\EOT\174\SOH\EOT\ETB\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\SOH\STX\SOH\SOH\DC2\EOT\172\SOH\EOT\DC2\n\
+    \\a\EOT\EOT\EOT\SOH\STX\SOH\SOH\DC2\EOT\174\SOH\EOT\DC2\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\SOH\STX\SOH\STX\DC2\EOT\172\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\SOH\STX\SOH\STX\DC2\EOT\174\SOH\NAK\SYN\n\
     \\SO\n\
-    \\ACK\EOT\EOT\EOT\SOH\STX\STX\DC2\EOT\173\SOH\EOT\FS\n\
+    \\ACK\EOT\EOT\EOT\SOH\STX\STX\DC2\EOT\175\SOH\EOT\ETB\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\SOH\STX\STX\SOH\DC2\EOT\173\SOH\EOT\DC2\n\
+    \\a\EOT\EOT\EOT\SOH\STX\STX\SOH\DC2\EOT\175\SOH\EOT\DC2\n\
     \\SI\n\
-    \\a\EOT\EOT\EOT\SOH\STX\STX\STX\DC2\EOT\173\SOH\SUB\ESC\n\
+    \\a\EOT\EOT\EOT\SOH\STX\STX\STX\DC2\EOT\175\SOH\NAK\SYN\n\
     \\f\n\
-    \\EOT\EOT\EOT\STX\NUL\DC2\EOT\176\SOH\STX\ESC\n\
+    \\EOT\EOT\EOT\STX\NUL\DC2\EOT\178\SOH\STX\ESC\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\NUL\EOT\DC2\EOT\176\SOH\STX\n\
+    \\ENQ\EOT\EOT\STX\NUL\EOT\DC2\EOT\178\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\NUL\ENQ\DC2\EOT\176\SOH\v\DC1\n\
+    \\ENQ\EOT\EOT\STX\NUL\ENQ\DC2\EOT\178\SOH\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\NUL\SOH\DC2\EOT\176\SOH\DC2\SYN\n\
+    \\ENQ\EOT\EOT\STX\NUL\SOH\DC2\EOT\178\SOH\DC2\SYN\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\NUL\ETX\DC2\EOT\176\SOH\EM\SUB\n\
+    \\ENQ\EOT\EOT\STX\NUL\ETX\DC2\EOT\178\SOH\EM\SUB\n\
     \\f\n\
-    \\EOT\EOT\EOT\STX\SOH\DC2\EOT\177\SOH\STX\FS\n\
+    \\EOT\EOT\EOT\STX\SOH\DC2\EOT\179\SOH\STX\FS\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\SOH\EOT\DC2\EOT\177\SOH\STX\n\
+    \\ENQ\EOT\EOT\STX\SOH\EOT\DC2\EOT\179\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\SOH\ENQ\DC2\EOT\177\SOH\v\DLE\n\
+    \\ENQ\EOT\EOT\STX\SOH\ENQ\DC2\EOT\179\SOH\v\DLE\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\SOH\SOH\DC2\EOT\177\SOH\DC1\ETB\n\
+    \\ENQ\EOT\EOT\STX\SOH\SOH\DC2\EOT\179\SOH\DC1\ETB\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\SOH\ETX\DC2\EOT\177\SOH\SUB\ESC\n\
+    \\ENQ\EOT\EOT\STX\SOH\ETX\DC2\EOT\179\SOH\SUB\ESC\n\
     \\f\n\
-    \\EOT\EOT\EOT\STX\STX\DC2\EOT\178\SOH\STX\ESC\n\
+    \\EOT\EOT\EOT\STX\STX\DC2\EOT\180\SOH\STX\ESC\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\STX\EOT\DC2\EOT\178\SOH\STX\n\
+    \\ENQ\EOT\EOT\STX\STX\EOT\DC2\EOT\180\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\STX\ACK\DC2\EOT\178\SOH\v\DLE\n\
+    \\ENQ\EOT\EOT\STX\STX\ACK\DC2\EOT\180\SOH\v\DLE\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\STX\SOH\DC2\EOT\178\SOH\DC1\SYN\n\
+    \\ENQ\EOT\EOT\STX\STX\SOH\DC2\EOT\180\SOH\DC1\SYN\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\STX\ETX\DC2\EOT\178\SOH\EM\SUB\n\
+    \\ENQ\EOT\EOT\STX\STX\ETX\DC2\EOT\180\SOH\EM\SUB\n\
     \\156\SOH\n\
-    \\EOT\EOT\EOT\STX\ETX\DC2\EOT\182\SOH\STX\EM\SUB\141\SOH If type_name is set, this need not be set.  If both this and type_name\n\
+    \\EOT\EOT\EOT\STX\ETX\DC2\EOT\184\SOH\STX\EM\SUB\141\SOH If type_name is set, this need not be set.  If both this and type_name\n\
     \ are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ETX\EOT\DC2\EOT\182\SOH\STX\n\
+    \\ENQ\EOT\EOT\STX\ETX\EOT\DC2\EOT\184\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ETX\ACK\DC2\EOT\182\SOH\v\SI\n\
+    \\ENQ\EOT\EOT\STX\ETX\ACK\DC2\EOT\184\SOH\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ETX\SOH\DC2\EOT\182\SOH\DLE\DC4\n\
+    \\ENQ\EOT\EOT\STX\ETX\SOH\DC2\EOT\184\SOH\DLE\DC4\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ETX\ETX\DC2\EOT\182\SOH\ETB\CAN\n\
+    \\ENQ\EOT\EOT\STX\ETX\ETX\DC2\EOT\184\SOH\ETB\CAN\n\
     \\183\STX\n\
-    \\EOT\EOT\EOT\STX\EOT\DC2\EOT\189\SOH\STX \SUB\168\STX For message and enum types, this is the name of the type.  If the name\n\
+    \\EOT\EOT\EOT\STX\EOT\DC2\EOT\191\SOH\STX \SUB\168\STX For message and enum types, this is the name of the type.  If the name\n\
     \ starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping\n\
     \ rules are used to find the type (i.e. first the nested types within this\n\
     \ message are searched, then within the parent, on up to the root\n\
     \ namespace).\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\EOT\EOT\DC2\EOT\189\SOH\STX\n\
+    \\ENQ\EOT\EOT\STX\EOT\EOT\DC2\EOT\191\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\EOT\ENQ\DC2\EOT\189\SOH\v\DC1\n\
+    \\ENQ\EOT\EOT\STX\EOT\ENQ\DC2\EOT\191\SOH\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\EOT\SOH\DC2\EOT\189\SOH\DC2\ESC\n\
+    \\ENQ\EOT\EOT\STX\EOT\SOH\DC2\EOT\191\SOH\DC2\ESC\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\EOT\ETX\DC2\EOT\189\SOH\RS\US\n\
+    \\ENQ\EOT\EOT\STX\EOT\ETX\DC2\EOT\191\SOH\RS\US\n\
     \~\n\
-    \\EOT\EOT\EOT\STX\ENQ\DC2\EOT\193\SOH\STX\US\SUBp For extensions, this is the name of the type being extended.  It is\n\
+    \\EOT\EOT\EOT\STX\ENQ\DC2\EOT\195\SOH\STX\US\SUBp For extensions, this is the name of the type being extended.  It is\n\
     \ resolved in the same manner as type_name.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ENQ\EOT\DC2\EOT\193\SOH\STX\n\
+    \\ENQ\EOT\EOT\STX\ENQ\EOT\DC2\EOT\195\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ENQ\ENQ\DC2\EOT\193\SOH\v\DC1\n\
+    \\ENQ\EOT\EOT\STX\ENQ\ENQ\DC2\EOT\195\SOH\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ENQ\SOH\DC2\EOT\193\SOH\DC2\SUB\n\
+    \\ENQ\EOT\EOT\STX\ENQ\SOH\DC2\EOT\195\SOH\DC2\SUB\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ENQ\ETX\DC2\EOT\193\SOH\GS\RS\n\
+    \\ENQ\EOT\EOT\STX\ENQ\ETX\DC2\EOT\195\SOH\GS\RS\n\
     \\177\STX\n\
-    \\EOT\EOT\EOT\STX\ACK\DC2\EOT\200\SOH\STX$\SUB\162\STX For numeric types, contains the original text representation of the value.\n\
+    \\EOT\EOT\EOT\STX\ACK\DC2\EOT\202\SOH\STX$\SUB\162\STX For numeric types, contains the original text representation of the value.\n\
     \ For booleans, \"true\" or \"false\".\n\
     \ For strings, contains the default text contents (not escaped in any way).\n\
     \ For bytes, contains the C escaped value.  All bytes >= 128 are escaped.\n\
     \ TODO(kenton):  Base-64 encode?\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ACK\EOT\DC2\EOT\200\SOH\STX\n\
+    \\ENQ\EOT\EOT\STX\ACK\EOT\DC2\EOT\202\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ACK\ENQ\DC2\EOT\200\SOH\v\DC1\n\
+    \\ENQ\EOT\EOT\STX\ACK\ENQ\DC2\EOT\202\SOH\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ACK\SOH\DC2\EOT\200\SOH\DC2\US\n\
+    \\ENQ\EOT\EOT\STX\ACK\SOH\DC2\EOT\202\SOH\DC2\US\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\ACK\ETX\DC2\EOT\200\SOH\"#\n\
+    \\ENQ\EOT\EOT\STX\ACK\ETX\DC2\EOT\202\SOH\"#\n\
     \\132\SOH\n\
-    \\EOT\EOT\EOT\STX\a\DC2\EOT\204\SOH\STX!\SUBv If set, gives the index of a oneof in the containing type's oneof_decl\n\
+    \\EOT\EOT\EOT\STX\a\DC2\EOT\206\SOH\STX!\SUBv If set, gives the index of a oneof in the containing type's oneof_decl\n\
     \ list.  This field is a member of that oneof.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\a\EOT\DC2\EOT\204\SOH\STX\n\
+    \\ENQ\EOT\EOT\STX\a\EOT\DC2\EOT\206\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\a\ENQ\DC2\EOT\204\SOH\v\DLE\n\
+    \\ENQ\EOT\EOT\STX\a\ENQ\DC2\EOT\206\SOH\v\DLE\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\a\SOH\DC2\EOT\204\SOH\DC1\FS\n\
+    \\ENQ\EOT\EOT\STX\a\SOH\DC2\EOT\206\SOH\DC1\FS\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\a\ETX\DC2\EOT\204\SOH\US \n\
+    \\ENQ\EOT\EOT\STX\a\ETX\DC2\EOT\206\SOH\US \n\
     \\250\SOH\n\
-    \\EOT\EOT\EOT\STX\b\DC2\EOT\210\SOH\STX!\SUB\235\SOH JSON name of this field. The value is set by protocol compiler. If the\n\
+    \\EOT\EOT\EOT\STX\b\DC2\EOT\212\SOH\STX!\SUB\235\SOH JSON name of this field. The value is set by protocol compiler. If the\n\
     \ user has set a \"json_name\" option on this field, that option's value\n\
     \ will be used. Otherwise, it's deduced from the field's name by converting\n\
     \ it to camelCase.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\b\EOT\DC2\EOT\210\SOH\STX\n\
+    \\ENQ\EOT\EOT\STX\b\EOT\DC2\EOT\212\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\b\ENQ\DC2\EOT\210\SOH\v\DC1\n\
+    \\ENQ\EOT\EOT\STX\b\ENQ\DC2\EOT\212\SOH\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\b\SOH\DC2\EOT\210\SOH\DC2\ESC\n\
+    \\ENQ\EOT\EOT\STX\b\SOH\DC2\EOT\212\SOH\DC2\ESC\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\b\ETX\DC2\EOT\210\SOH\RS \n\
+    \\ENQ\EOT\EOT\STX\b\ETX\DC2\EOT\212\SOH\RS \n\
     \\f\n\
-    \\EOT\EOT\EOT\STX\t\DC2\EOT\212\SOH\STX$\n\
+    \\EOT\EOT\EOT\STX\t\DC2\EOT\214\SOH\STX$\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\t\EOT\DC2\EOT\212\SOH\STX\n\
+    \\ENQ\EOT\EOT\STX\t\EOT\DC2\EOT\214\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\t\ACK\DC2\EOT\212\SOH\v\ETB\n\
+    \\ENQ\EOT\EOT\STX\t\ACK\DC2\EOT\214\SOH\v\ETB\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\t\SOH\DC2\EOT\212\SOH\CAN\US\n\
+    \\ENQ\EOT\EOT\STX\t\SOH\DC2\EOT\214\SOH\CAN\US\n\
     \\r\n\
-    \\ENQ\EOT\EOT\STX\t\ETX\DC2\EOT\212\SOH\"#\n\
+    \\ENQ\EOT\EOT\STX\t\ETX\DC2\EOT\214\SOH\"#\n\
+    \\179\t\n\
+    \\EOT\EOT\EOT\STX\n\
+    \\DC2\EOT\237\SOH\STX%\SUB\164\t If true, this is a proto3 \"optional\". When a proto3 field is optional, it\n\
+    \ tracks presence regardless of field type.\n\
+    \\n\
+    \ When proto3_optional is true, this field must be belong to a oneof to\n\
+    \ signal to old proto3 clients that presence is tracked for this field. This\n\
+    \ oneof is known as a \"synthetic\" oneof, and this field must be its sole\n\
+    \ member (each proto3 optional field gets its own synthetic oneof). Synthetic\n\
+    \ oneofs exist in the descriptor only, and do not generate any API. Synthetic\n\
+    \ oneofs must be ordered after all \"real\" oneofs.\n\
+    \\n\
+    \ For message fields, proto3_optional doesn't create any semantic change,\n\
+    \ since non-repeated message fields always track presence. However it still\n\
+    \ indicates the semantic detail of whether the user wrote \"optional\" or not.\n\
+    \ This can be useful for round-tripping the .proto file. For consistency we\n\
+    \ give message fields a synthetic oneof also, even though it is not required\n\
+    \ to track presence. This is especially important because the parser can't\n\
+    \ tell if a field is a message or an enum, so it must always create a\n\
+    \ synthetic oneof.\n\
+    \\n\
+    \ Proto2 optional fields do not set this flag, because they already indicate\n\
+    \ optional with `LABEL_OPTIONAL`.\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\n\
+    \\EOT\DC2\EOT\237\SOH\STX\n\
+    \\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\n\
+    \\ENQ\DC2\EOT\237\SOH\v\SI\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\n\
+    \\SOH\DC2\EOT\237\SOH\DLE\US\n\
+    \\r\n\
+    \\ENQ\EOT\EOT\STX\n\
+    \\ETX\DC2\EOT\237\SOH\"$\n\
     \\"\n\
-    \\STX\EOT\ENQ\DC2\ACK\216\SOH\NUL\219\SOH\SOH\SUB\DC4 Describes a oneof.\n\
+    \\STX\EOT\ENQ\DC2\ACK\241\SOH\NUL\244\SOH\SOH\SUB\DC4 Describes a oneof.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\ENQ\SOH\DC2\EOT\216\SOH\b\FS\n\
+    \\ETX\EOT\ENQ\SOH\DC2\EOT\241\SOH\b\FS\n\
     \\f\n\
-    \\EOT\EOT\ENQ\STX\NUL\DC2\EOT\217\SOH\STX\ESC\n\
+    \\EOT\EOT\ENQ\STX\NUL\DC2\EOT\242\SOH\STX\ESC\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\NUL\EOT\DC2\EOT\217\SOH\STX\n\
+    \\ENQ\EOT\ENQ\STX\NUL\EOT\DC2\EOT\242\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\NUL\ENQ\DC2\EOT\217\SOH\v\DC1\n\
+    \\ENQ\EOT\ENQ\STX\NUL\ENQ\DC2\EOT\242\SOH\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\NUL\SOH\DC2\EOT\217\SOH\DC2\SYN\n\
+    \\ENQ\EOT\ENQ\STX\NUL\SOH\DC2\EOT\242\SOH\DC2\SYN\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\NUL\ETX\DC2\EOT\217\SOH\EM\SUB\n\
+    \\ENQ\EOT\ENQ\STX\NUL\ETX\DC2\EOT\242\SOH\EM\SUB\n\
     \\f\n\
-    \\EOT\EOT\ENQ\STX\SOH\DC2\EOT\218\SOH\STX$\n\
+    \\EOT\EOT\ENQ\STX\SOH\DC2\EOT\243\SOH\STX$\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\SOH\EOT\DC2\EOT\218\SOH\STX\n\
+    \\ENQ\EOT\ENQ\STX\SOH\EOT\DC2\EOT\243\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\SOH\ACK\DC2\EOT\218\SOH\v\ETB\n\
+    \\ENQ\EOT\ENQ\STX\SOH\ACK\DC2\EOT\243\SOH\v\ETB\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\SOH\SOH\DC2\EOT\218\SOH\CAN\US\n\
+    \\ENQ\EOT\ENQ\STX\SOH\SOH\DC2\EOT\243\SOH\CAN\US\n\
     \\r\n\
-    \\ENQ\EOT\ENQ\STX\SOH\ETX\DC2\EOT\218\SOH\"#\n\
+    \\ENQ\EOT\ENQ\STX\SOH\ETX\DC2\EOT\243\SOH\"#\n\
     \'\n\
-    \\STX\EOT\ACK\DC2\ACK\222\SOH\NUL\248\SOH\SOH\SUB\EM Describes an enum type.\n\
+    \\STX\EOT\ACK\DC2\ACK\247\SOH\NUL\145\STX\SOH\SUB\EM Describes an enum type.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\ACK\SOH\DC2\EOT\222\SOH\b\ESC\n\
+    \\ETX\EOT\ACK\SOH\DC2\EOT\247\SOH\b\ESC\n\
     \\f\n\
-    \\EOT\EOT\ACK\STX\NUL\DC2\EOT\223\SOH\STX\ESC\n\
+    \\EOT\EOT\ACK\STX\NUL\DC2\EOT\248\SOH\STX\ESC\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\NUL\EOT\DC2\EOT\223\SOH\STX\n\
+    \\ENQ\EOT\ACK\STX\NUL\EOT\DC2\EOT\248\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\NUL\ENQ\DC2\EOT\223\SOH\v\DC1\n\
+    \\ENQ\EOT\ACK\STX\NUL\ENQ\DC2\EOT\248\SOH\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\NUL\SOH\DC2\EOT\223\SOH\DC2\SYN\n\
+    \\ENQ\EOT\ACK\STX\NUL\SOH\DC2\EOT\248\SOH\DC2\SYN\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\NUL\ETX\DC2\EOT\223\SOH\EM\SUB\n\
+    \\ENQ\EOT\ACK\STX\NUL\ETX\DC2\EOT\248\SOH\EM\SUB\n\
     \\f\n\
-    \\EOT\EOT\ACK\STX\SOH\DC2\EOT\225\SOH\STX.\n\
+    \\EOT\EOT\ACK\STX\SOH\DC2\EOT\250\SOH\STX.\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\SOH\EOT\DC2\EOT\225\SOH\STX\n\
+    \\ENQ\EOT\ACK\STX\SOH\EOT\DC2\EOT\250\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\SOH\ACK\DC2\EOT\225\SOH\v#\n\
+    \\ENQ\EOT\ACK\STX\SOH\ACK\DC2\EOT\250\SOH\v#\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\SOH\SOH\DC2\EOT\225\SOH$)\n\
+    \\ENQ\EOT\ACK\STX\SOH\SOH\DC2\EOT\250\SOH$)\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\SOH\ETX\DC2\EOT\225\SOH,-\n\
+    \\ENQ\EOT\ACK\STX\SOH\ETX\DC2\EOT\250\SOH,-\n\
     \\f\n\
-    \\EOT\EOT\ACK\STX\STX\DC2\EOT\227\SOH\STX#\n\
+    \\EOT\EOT\ACK\STX\STX\DC2\EOT\252\SOH\STX#\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\STX\EOT\DC2\EOT\227\SOH\STX\n\
+    \\ENQ\EOT\ACK\STX\STX\EOT\DC2\EOT\252\SOH\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\STX\ACK\DC2\EOT\227\SOH\v\SYN\n\
+    \\ENQ\EOT\ACK\STX\STX\ACK\DC2\EOT\252\SOH\v\SYN\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\STX\SOH\DC2\EOT\227\SOH\ETB\RS\n\
+    \\ENQ\EOT\ACK\STX\STX\SOH\DC2\EOT\252\SOH\ETB\RS\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\STX\ETX\DC2\EOT\227\SOH!\"\n\
+    \\ENQ\EOT\ACK\STX\STX\ETX\DC2\EOT\252\SOH!\"\n\
     \\175\STX\n\
-    \\EOT\EOT\ACK\ETX\NUL\DC2\ACK\235\SOH\STX\238\SOH\ETX\SUB\158\STX Range of reserved numeric values. Reserved values may not be used by\n\
+    \\EOT\EOT\ACK\ETX\NUL\DC2\ACK\132\STX\STX\135\STX\ETX\SUB\158\STX Range of reserved numeric values. Reserved values may not be used by\n\
     \ entries in the same enum. Reserved ranges may not overlap.\n\
     \\n\
     \ Note that this is distinct from DescriptorProto.ReservedRange in that it\n\
@@ -11389,219 +11427,219 @@ packedFileDescriptor
     \ domain.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ACK\ETX\NUL\SOH\DC2\EOT\235\SOH\n\
+    \\ENQ\EOT\ACK\ETX\NUL\SOH\DC2\EOT\132\STX\n\
     \\ESC\n\
     \\FS\n\
-    \\ACK\EOT\ACK\ETX\NUL\STX\NUL\DC2\EOT\236\SOH\EOT\GS\"\f Inclusive.\n\
+    \\ACK\EOT\ACK\ETX\NUL\STX\NUL\DC2\EOT\133\STX\EOT\GS\"\f Inclusive.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\ACK\ETX\NUL\STX\NUL\EOT\DC2\EOT\236\SOH\EOT\f\n\
+    \\a\EOT\ACK\ETX\NUL\STX\NUL\EOT\DC2\EOT\133\STX\EOT\f\n\
     \\SI\n\
-    \\a\EOT\ACK\ETX\NUL\STX\NUL\ENQ\DC2\EOT\236\SOH\r\DC2\n\
+    \\a\EOT\ACK\ETX\NUL\STX\NUL\ENQ\DC2\EOT\133\STX\r\DC2\n\
     \\SI\n\
-    \\a\EOT\ACK\ETX\NUL\STX\NUL\SOH\DC2\EOT\236\SOH\DC3\CAN\n\
+    \\a\EOT\ACK\ETX\NUL\STX\NUL\SOH\DC2\EOT\133\STX\DC3\CAN\n\
     \\SI\n\
-    \\a\EOT\ACK\ETX\NUL\STX\NUL\ETX\DC2\EOT\236\SOH\ESC\FS\n\
+    \\a\EOT\ACK\ETX\NUL\STX\NUL\ETX\DC2\EOT\133\STX\ESC\FS\n\
     \\FS\n\
-    \\ACK\EOT\ACK\ETX\NUL\STX\SOH\DC2\EOT\237\SOH\EOT\ESC\"\f Inclusive.\n\
+    \\ACK\EOT\ACK\ETX\NUL\STX\SOH\DC2\EOT\134\STX\EOT\ESC\"\f Inclusive.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\ACK\ETX\NUL\STX\SOH\EOT\DC2\EOT\237\SOH\EOT\f\n\
+    \\a\EOT\ACK\ETX\NUL\STX\SOH\EOT\DC2\EOT\134\STX\EOT\f\n\
     \\SI\n\
-    \\a\EOT\ACK\ETX\NUL\STX\SOH\ENQ\DC2\EOT\237\SOH\r\DC2\n\
+    \\a\EOT\ACK\ETX\NUL\STX\SOH\ENQ\DC2\EOT\134\STX\r\DC2\n\
     \\SI\n\
-    \\a\EOT\ACK\ETX\NUL\STX\SOH\SOH\DC2\EOT\237\SOH\DC3\SYN\n\
+    \\a\EOT\ACK\ETX\NUL\STX\SOH\SOH\DC2\EOT\134\STX\DC3\SYN\n\
     \\SI\n\
-    \\a\EOT\ACK\ETX\NUL\STX\SOH\ETX\DC2\EOT\237\SOH\EM\SUB\n\
+    \\a\EOT\ACK\ETX\NUL\STX\SOH\ETX\DC2\EOT\134\STX\EM\SUB\n\
     \\170\SOH\n\
-    \\EOT\EOT\ACK\STX\ETX\DC2\EOT\243\SOH\STX0\SUB\155\SOH Range of reserved numeric values. Reserved numeric values may not be used\n\
+    \\EOT\EOT\ACK\STX\ETX\DC2\EOT\140\STX\STX0\SUB\155\SOH Range of reserved numeric values. Reserved numeric values may not be used\n\
     \ by enum values in the same enum declaration. Reserved ranges may not\n\
     \ overlap.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\ETX\EOT\DC2\EOT\243\SOH\STX\n\
+    \\ENQ\EOT\ACK\STX\ETX\EOT\DC2\EOT\140\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\ETX\ACK\DC2\EOT\243\SOH\v\FS\n\
+    \\ENQ\EOT\ACK\STX\ETX\ACK\DC2\EOT\140\STX\v\FS\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\ETX\SOH\DC2\EOT\243\SOH\GS+\n\
+    \\ENQ\EOT\ACK\STX\ETX\SOH\DC2\EOT\140\STX\GS+\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\ETX\ETX\DC2\EOT\243\SOH./\n\
+    \\ENQ\EOT\ACK\STX\ETX\ETX\DC2\EOT\140\STX./\n\
     \l\n\
-    \\EOT\EOT\ACK\STX\EOT\DC2\EOT\247\SOH\STX$\SUB^ Reserved enum value names, which may not be reused. A given name may only\n\
+    \\EOT\EOT\ACK\STX\EOT\DC2\EOT\144\STX\STX$\SUB^ Reserved enum value names, which may not be reused. A given name may only\n\
     \ be reserved once.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\EOT\EOT\DC2\EOT\247\SOH\STX\n\
+    \\ENQ\EOT\ACK\STX\EOT\EOT\DC2\EOT\144\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\EOT\ENQ\DC2\EOT\247\SOH\v\DC1\n\
+    \\ENQ\EOT\ACK\STX\EOT\ENQ\DC2\EOT\144\STX\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\EOT\SOH\DC2\EOT\247\SOH\DC2\US\n\
+    \\ENQ\EOT\ACK\STX\EOT\SOH\DC2\EOT\144\STX\DC2\US\n\
     \\r\n\
-    \\ENQ\EOT\ACK\STX\EOT\ETX\DC2\EOT\247\SOH\"#\n\
+    \\ENQ\EOT\ACK\STX\EOT\ETX\DC2\EOT\144\STX\"#\n\
     \1\n\
-    \\STX\EOT\a\DC2\ACK\251\SOH\NUL\128\STX\SOH\SUB# Describes a value within an enum.\n\
+    \\STX\EOT\a\DC2\ACK\148\STX\NUL\153\STX\SOH\SUB# Describes a value within an enum.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\a\SOH\DC2\EOT\251\SOH\b \n\
+    \\ETX\EOT\a\SOH\DC2\EOT\148\STX\b \n\
     \\f\n\
-    \\EOT\EOT\a\STX\NUL\DC2\EOT\252\SOH\STX\ESC\n\
+    \\EOT\EOT\a\STX\NUL\DC2\EOT\149\STX\STX\ESC\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\NUL\EOT\DC2\EOT\252\SOH\STX\n\
+    \\ENQ\EOT\a\STX\NUL\EOT\DC2\EOT\149\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\NUL\ENQ\DC2\EOT\252\SOH\v\DC1\n\
+    \\ENQ\EOT\a\STX\NUL\ENQ\DC2\EOT\149\STX\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\NUL\SOH\DC2\EOT\252\SOH\DC2\SYN\n\
+    \\ENQ\EOT\a\STX\NUL\SOH\DC2\EOT\149\STX\DC2\SYN\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\NUL\ETX\DC2\EOT\252\SOH\EM\SUB\n\
+    \\ENQ\EOT\a\STX\NUL\ETX\DC2\EOT\149\STX\EM\SUB\n\
     \\f\n\
-    \\EOT\EOT\a\STX\SOH\DC2\EOT\253\SOH\STX\FS\n\
+    \\EOT\EOT\a\STX\SOH\DC2\EOT\150\STX\STX\FS\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\SOH\EOT\DC2\EOT\253\SOH\STX\n\
+    \\ENQ\EOT\a\STX\SOH\EOT\DC2\EOT\150\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\SOH\ENQ\DC2\EOT\253\SOH\v\DLE\n\
+    \\ENQ\EOT\a\STX\SOH\ENQ\DC2\EOT\150\STX\v\DLE\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\SOH\SOH\DC2\EOT\253\SOH\DC1\ETB\n\
+    \\ENQ\EOT\a\STX\SOH\SOH\DC2\EOT\150\STX\DC1\ETB\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\SOH\ETX\DC2\EOT\253\SOH\SUB\ESC\n\
+    \\ENQ\EOT\a\STX\SOH\ETX\DC2\EOT\150\STX\SUB\ESC\n\
     \\f\n\
-    \\EOT\EOT\a\STX\STX\DC2\EOT\255\SOH\STX(\n\
+    \\EOT\EOT\a\STX\STX\DC2\EOT\152\STX\STX(\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\STX\EOT\DC2\EOT\255\SOH\STX\n\
+    \\ENQ\EOT\a\STX\STX\EOT\DC2\EOT\152\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\STX\ACK\DC2\EOT\255\SOH\v\ESC\n\
+    \\ENQ\EOT\a\STX\STX\ACK\DC2\EOT\152\STX\v\ESC\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\STX\SOH\DC2\EOT\255\SOH\FS#\n\
+    \\ENQ\EOT\a\STX\STX\SOH\DC2\EOT\152\STX\FS#\n\
     \\r\n\
-    \\ENQ\EOT\a\STX\STX\ETX\DC2\EOT\255\SOH&'\n\
+    \\ENQ\EOT\a\STX\STX\ETX\DC2\EOT\152\STX&'\n\
     \$\n\
-    \\STX\EOT\b\DC2\ACK\131\STX\NUL\136\STX\SOH\SUB\SYN Describes a service.\n\
+    \\STX\EOT\b\DC2\ACK\156\STX\NUL\161\STX\SOH\SUB\SYN Describes a service.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\b\SOH\DC2\EOT\131\STX\b\RS\n\
+    \\ETX\EOT\b\SOH\DC2\EOT\156\STX\b\RS\n\
     \\f\n\
-    \\EOT\EOT\b\STX\NUL\DC2\EOT\132\STX\STX\ESC\n\
+    \\EOT\EOT\b\STX\NUL\DC2\EOT\157\STX\STX\ESC\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\NUL\EOT\DC2\EOT\132\STX\STX\n\
+    \\ENQ\EOT\b\STX\NUL\EOT\DC2\EOT\157\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\NUL\ENQ\DC2\EOT\132\STX\v\DC1\n\
+    \\ENQ\EOT\b\STX\NUL\ENQ\DC2\EOT\157\STX\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\NUL\SOH\DC2\EOT\132\STX\DC2\SYN\n\
+    \\ENQ\EOT\b\STX\NUL\SOH\DC2\EOT\157\STX\DC2\SYN\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\NUL\ETX\DC2\EOT\132\STX\EM\SUB\n\
+    \\ENQ\EOT\b\STX\NUL\ETX\DC2\EOT\157\STX\EM\SUB\n\
     \\f\n\
-    \\EOT\EOT\b\STX\SOH\DC2\EOT\133\STX\STX,\n\
+    \\EOT\EOT\b\STX\SOH\DC2\EOT\158\STX\STX,\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\SOH\EOT\DC2\EOT\133\STX\STX\n\
+    \\ENQ\EOT\b\STX\SOH\EOT\DC2\EOT\158\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\SOH\ACK\DC2\EOT\133\STX\v \n\
+    \\ENQ\EOT\b\STX\SOH\ACK\DC2\EOT\158\STX\v \n\
     \\r\n\
-    \\ENQ\EOT\b\STX\SOH\SOH\DC2\EOT\133\STX!'\n\
+    \\ENQ\EOT\b\STX\SOH\SOH\DC2\EOT\158\STX!'\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\SOH\ETX\DC2\EOT\133\STX*+\n\
+    \\ENQ\EOT\b\STX\SOH\ETX\DC2\EOT\158\STX*+\n\
     \\f\n\
-    \\EOT\EOT\b\STX\STX\DC2\EOT\135\STX\STX&\n\
+    \\EOT\EOT\b\STX\STX\DC2\EOT\160\STX\STX&\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\STX\EOT\DC2\EOT\135\STX\STX\n\
+    \\ENQ\EOT\b\STX\STX\EOT\DC2\EOT\160\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\STX\ACK\DC2\EOT\135\STX\v\EM\n\
+    \\ENQ\EOT\b\STX\STX\ACK\DC2\EOT\160\STX\v\EM\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\STX\SOH\DC2\EOT\135\STX\SUB!\n\
+    \\ENQ\EOT\b\STX\STX\SOH\DC2\EOT\160\STX\SUB!\n\
     \\r\n\
-    \\ENQ\EOT\b\STX\STX\ETX\DC2\EOT\135\STX$%\n\
+    \\ENQ\EOT\b\STX\STX\ETX\DC2\EOT\160\STX$%\n\
     \0\n\
-    \\STX\EOT\t\DC2\ACK\139\STX\NUL\153\STX\SOH\SUB\" Describes a method of a service.\n\
+    \\STX\EOT\t\DC2\ACK\164\STX\NUL\178\STX\SOH\SUB\" Describes a method of a service.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\t\SOH\DC2\EOT\139\STX\b\GS\n\
+    \\ETX\EOT\t\SOH\DC2\EOT\164\STX\b\GS\n\
     \\f\n\
-    \\EOT\EOT\t\STX\NUL\DC2\EOT\140\STX\STX\ESC\n\
+    \\EOT\EOT\t\STX\NUL\DC2\EOT\165\STX\STX\ESC\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\NUL\EOT\DC2\EOT\140\STX\STX\n\
+    \\ENQ\EOT\t\STX\NUL\EOT\DC2\EOT\165\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\NUL\ENQ\DC2\EOT\140\STX\v\DC1\n\
+    \\ENQ\EOT\t\STX\NUL\ENQ\DC2\EOT\165\STX\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\NUL\SOH\DC2\EOT\140\STX\DC2\SYN\n\
+    \\ENQ\EOT\t\STX\NUL\SOH\DC2\EOT\165\STX\DC2\SYN\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\NUL\ETX\DC2\EOT\140\STX\EM\SUB\n\
+    \\ENQ\EOT\t\STX\NUL\ETX\DC2\EOT\165\STX\EM\SUB\n\
     \\151\SOH\n\
-    \\EOT\EOT\t\STX\SOH\DC2\EOT\144\STX\STX!\SUB\136\SOH Input and output type names.  These are resolved in the same way as\n\
+    \\EOT\EOT\t\STX\SOH\DC2\EOT\169\STX\STX!\SUB\136\SOH Input and output type names.  These are resolved in the same way as\n\
     \ FieldDescriptorProto.type_name, but must refer to a message type.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\SOH\EOT\DC2\EOT\144\STX\STX\n\
+    \\ENQ\EOT\t\STX\SOH\EOT\DC2\EOT\169\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\SOH\ENQ\DC2\EOT\144\STX\v\DC1\n\
+    \\ENQ\EOT\t\STX\SOH\ENQ\DC2\EOT\169\STX\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\SOH\SOH\DC2\EOT\144\STX\DC2\FS\n\
+    \\ENQ\EOT\t\STX\SOH\SOH\DC2\EOT\169\STX\DC2\FS\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\SOH\ETX\DC2\EOT\144\STX\US \n\
+    \\ENQ\EOT\t\STX\SOH\ETX\DC2\EOT\169\STX\US \n\
     \\f\n\
-    \\EOT\EOT\t\STX\STX\DC2\EOT\145\STX\STX\"\n\
+    \\EOT\EOT\t\STX\STX\DC2\EOT\170\STX\STX\"\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\STX\EOT\DC2\EOT\145\STX\STX\n\
+    \\ENQ\EOT\t\STX\STX\EOT\DC2\EOT\170\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\STX\ENQ\DC2\EOT\145\STX\v\DC1\n\
+    \\ENQ\EOT\t\STX\STX\ENQ\DC2\EOT\170\STX\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\STX\SOH\DC2\EOT\145\STX\DC2\GS\n\
+    \\ENQ\EOT\t\STX\STX\SOH\DC2\EOT\170\STX\DC2\GS\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\STX\ETX\DC2\EOT\145\STX !\n\
+    \\ENQ\EOT\t\STX\STX\ETX\DC2\EOT\170\STX !\n\
     \\f\n\
-    \\EOT\EOT\t\STX\ETX\DC2\EOT\147\STX\STX%\n\
+    \\EOT\EOT\t\STX\ETX\DC2\EOT\172\STX\STX%\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ETX\EOT\DC2\EOT\147\STX\STX\n\
+    \\ENQ\EOT\t\STX\ETX\EOT\DC2\EOT\172\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ETX\ACK\DC2\EOT\147\STX\v\CAN\n\
+    \\ENQ\EOT\t\STX\ETX\ACK\DC2\EOT\172\STX\v\CAN\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ETX\SOH\DC2\EOT\147\STX\EM \n\
+    \\ENQ\EOT\t\STX\ETX\SOH\DC2\EOT\172\STX\EM \n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ETX\ETX\DC2\EOT\147\STX#$\n\
+    \\ENQ\EOT\t\STX\ETX\ETX\DC2\EOT\172\STX#$\n\
     \E\n\
-    \\EOT\EOT\t\STX\EOT\DC2\EOT\150\STX\STX5\SUB7 Identifies if client streams multiple client messages\n\
+    \\EOT\EOT\t\STX\EOT\DC2\EOT\175\STX\STX7\SUB7 Identifies if client streams multiple client messages\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\EOT\EOT\DC2\EOT\150\STX\STX\n\
+    \\ENQ\EOT\t\STX\EOT\EOT\DC2\EOT\175\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\EOT\ENQ\DC2\EOT\150\STX\v\SI\n\
+    \\ENQ\EOT\t\STX\EOT\ENQ\DC2\EOT\175\STX\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\EOT\SOH\DC2\EOT\150\STX\DLE \n\
+    \\ENQ\EOT\t\STX\EOT\SOH\DC2\EOT\175\STX\DLE \n\
     \\r\n\
-    \\ENQ\EOT\t\STX\EOT\ETX\DC2\EOT\150\STX#$\n\
+    \\ENQ\EOT\t\STX\EOT\ETX\DC2\EOT\175\STX#$\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\EOT\b\DC2\EOT\150\STX%4\n\
+    \\ENQ\EOT\t\STX\EOT\b\DC2\EOT\175\STX%6\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\EOT\a\DC2\EOT\150\STX.3\n\
+    \\ENQ\EOT\t\STX\EOT\a\DC2\EOT\175\STX05\n\
     \E\n\
-    \\EOT\EOT\t\STX\ENQ\DC2\EOT\152\STX\STX5\SUB7 Identifies if server streams multiple server messages\n\
+    \\EOT\EOT\t\STX\ENQ\DC2\EOT\177\STX\STX7\SUB7 Identifies if server streams multiple server messages\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ENQ\EOT\DC2\EOT\152\STX\STX\n\
+    \\ENQ\EOT\t\STX\ENQ\EOT\DC2\EOT\177\STX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ENQ\ENQ\DC2\EOT\152\STX\v\SI\n\
+    \\ENQ\EOT\t\STX\ENQ\ENQ\DC2\EOT\177\STX\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ENQ\SOH\DC2\EOT\152\STX\DLE \n\
+    \\ENQ\EOT\t\STX\ENQ\SOH\DC2\EOT\177\STX\DLE \n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ENQ\ETX\DC2\EOT\152\STX#$\n\
+    \\ENQ\EOT\t\STX\ENQ\ETX\DC2\EOT\177\STX#$\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ENQ\b\DC2\EOT\152\STX%4\n\
+    \\ENQ\EOT\t\STX\ENQ\b\DC2\EOT\177\STX%6\n\
     \\r\n\
-    \\ENQ\EOT\t\STX\ENQ\a\DC2\EOT\152\STX.3\n\
+    \\ENQ\EOT\t\STX\ENQ\a\DC2\EOT\177\STX05\n\
     \\175\SO\n\
     \\STX\EOT\n\
-    \\DC2\ACK\189\STX\NUL\183\ETX\SOH2N ===================================================================\n\
+    \\DC2\ACK\213\STX\NUL\208\ETX\SOH2N ===================================================================\n\
     \ Options\n\
     \2\208\r Each of the definitions above may have \"options\" attached.  These are\n\
     \ just annotations which may cause code to be generated slightly differently\n\
@@ -11634,30 +11672,30 @@ packedFileDescriptor
     \\n\
     \\v\n\
     \\ETX\EOT\n\
-    \\SOH\DC2\EOT\189\STX\b\DC3\n\
+    \\SOH\DC2\EOT\213\STX\b\DC3\n\
     \\244\SOH\n\
     \\EOT\EOT\n\
-    \\STX\NUL\DC2\EOT\195\STX\STX#\SUB\229\SOH Sets the Java package where classes generated from this .proto will be\n\
+    \\STX\NUL\DC2\EOT\219\STX\STX#\SUB\229\SOH Sets the Java package where classes generated from this .proto will be\n\
     \ placed.  By default, the proto package is used, but this is often\n\
     \ inappropriate because proto packages do not normally start with backwards\n\
     \ domain names.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\NUL\EOT\DC2\EOT\195\STX\STX\n\
+    \\STX\NUL\EOT\DC2\EOT\219\STX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\NUL\ENQ\DC2\EOT\195\STX\v\DC1\n\
+    \\STX\NUL\ENQ\DC2\EOT\219\STX\v\DC1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\NUL\SOH\DC2\EOT\195\STX\DC2\RS\n\
+    \\STX\NUL\SOH\DC2\EOT\219\STX\DC2\RS\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\NUL\ETX\DC2\EOT\195\STX!\"\n\
+    \\STX\NUL\ETX\DC2\EOT\219\STX!\"\n\
     \\191\STX\n\
     \\EOT\EOT\n\
-    \\STX\SOH\DC2\EOT\203\STX\STX+\SUB\176\STX If set, all the classes from the .proto file are wrapped in a single\n\
+    \\STX\SOH\DC2\EOT\227\STX\STX+\SUB\176\STX If set, all the classes from the .proto file are wrapped in a single\n\
     \ outer class with the given name.  This applies to both Proto1\n\
     \ (equivalent to the old \"--one_java_file\" option) and Proto2 (where\n\
     \ a .proto always translates to a single class, but you may want to\n\
@@ -11665,20 +11703,20 @@ packedFileDescriptor
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SOH\EOT\DC2\EOT\203\STX\STX\n\
+    \\STX\SOH\EOT\DC2\EOT\227\STX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SOH\ENQ\DC2\EOT\203\STX\v\DC1\n\
+    \\STX\SOH\ENQ\DC2\EOT\227\STX\v\DC1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SOH\SOH\DC2\EOT\203\STX\DC2&\n\
+    \\STX\SOH\SOH\DC2\EOT\227\STX\DC2&\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SOH\ETX\DC2\EOT\203\STX)*\n\
+    \\STX\SOH\ETX\DC2\EOT\227\STX)*\n\
     \\163\ETX\n\
     \\EOT\EOT\n\
-    \\STX\STX\DC2\EOT\211\STX\STX9\SUB\148\ETX If set true, then the Java code generator will generate a separate .java\n\
+    \\STX\STX\DC2\EOT\235\STX\STX;\SUB\148\ETX If set true, then the Java code generator will generate a separate .java\n\
     \ file for each top-level message, enum, and service defined in the .proto\n\
     \ file.  Thus, these types will *not* be nested inside the outer class\n\
     \ named by java_outer_classname.  However, the outer class will still be\n\
@@ -11687,62 +11725,49 @@ packedFileDescriptor
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\STX\EOT\DC2\EOT\211\STX\STX\n\
+    \\STX\STX\EOT\DC2\EOT\235\STX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\STX\ENQ\DC2\EOT\211\STX\v\SI\n\
+    \\STX\STX\ENQ\DC2\EOT\235\STX\v\SI\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\STX\SOH\DC2\EOT\211\STX\DLE#\n\
+    \\STX\STX\SOH\DC2\EOT\235\STX\DLE#\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\STX\ETX\DC2\EOT\211\STX&(\n\
+    \\STX\STX\ETX\DC2\EOT\235\STX&(\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\STX\b\DC2\EOT\211\STX)8\n\
+    \\STX\STX\b\DC2\EOT\235\STX):\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\STX\a\DC2\EOT\211\STX27\n\
+    \\STX\STX\a\DC2\EOT\235\STX49\n\
     \)\n\
     \\EOT\EOT\n\
-    \\STX\ETX\DC2\EOT\214\STX\STXE\SUB\ESC This option does nothing.\n\
+    \\STX\ETX\DC2\EOT\238\STX\STXE\SUB\ESC This option does nothing.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ETX\EOT\DC2\EOT\214\STX\STX\n\
+    \\STX\ETX\EOT\DC2\EOT\238\STX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ETX\ENQ\DC2\EOT\214\STX\v\SI\n\
+    \\STX\ETX\ENQ\DC2\EOT\238\STX\v\SI\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ETX\SOH\DC2\EOT\214\STX\DLE-\n\
+    \\STX\ETX\SOH\DC2\EOT\238\STX\DLE-\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ETX\ETX\DC2\EOT\214\STX02\n\
+    \\STX\ETX\ETX\DC2\EOT\238\STX02\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ETX\b\DC2\EOT\214\STX3D\n\
-    \\DLE\n\
-    \\b\EOT\n\
-    \\STX\ETX\b\231\a\NUL\DC2\EOT\214\STX4C\n\
-    \\DC1\n\
-    \\t\EOT\n\
-    \\STX\ETX\b\231\a\NUL\STX\DC2\EOT\214\STX4>\n\
-    \\DC2\n\
-    \\n\
-    \\EOT\n\
-    \\STX\ETX\b\231\a\NUL\STX\NUL\DC2\EOT\214\STX4>\n\
-    \\DC3\n\
-    \\v\EOT\n\
-    \\STX\ETX\b\231\a\NUL\STX\NUL\SOH\DC2\EOT\214\STX4>\n\
-    \\DC1\n\
-    \\t\EOT\n\
-    \\STX\ETX\b\231\a\NUL\ETX\DC2\EOT\214\STX?C\n\
+    \\STX\ETX\b\DC2\EOT\238\STX3D\n\
+    \\SO\n\
+    \\ACK\EOT\n\
+    \\STX\ETX\b\ETX\DC2\EOT\238\STX4C\n\
     \\230\STX\n\
     \\EOT\EOT\n\
-    \\STX\EOT\DC2\EOT\222\STX\STX<\SUB\215\STX If set true, then the Java2 code generator will generate code that\n\
+    \\STX\EOT\DC2\EOT\246\STX\STX>\SUB\215\STX If set true, then the Java2 code generator will generate code that\n\
     \ throws an exception whenever an attempt is made to assign a non-UTF-8\n\
     \ byte sequence to a string field.\n\
     \ Message reflection will do the same.\n\
@@ -11751,86 +11776,86 @@ packedFileDescriptor
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\EOT\EOT\DC2\EOT\222\STX\STX\n\
+    \\STX\EOT\EOT\DC2\EOT\246\STX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\EOT\ENQ\DC2\EOT\222\STX\v\SI\n\
+    \\STX\EOT\ENQ\DC2\EOT\246\STX\v\SI\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\EOT\SOH\DC2\EOT\222\STX\DLE&\n\
+    \\STX\EOT\SOH\DC2\EOT\246\STX\DLE&\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\EOT\ETX\DC2\EOT\222\STX)+\n\
+    \\STX\EOT\ETX\DC2\EOT\246\STX)+\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\EOT\b\DC2\EOT\222\STX,;\n\
+    \\STX\EOT\b\DC2\EOT\246\STX,=\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\EOT\a\DC2\EOT\222\STX5:\n\
+    \\STX\EOT\a\DC2\EOT\246\STX7<\n\
     \L\n\
     \\EOT\EOT\n\
-    \\EOT\NUL\DC2\ACK\226\STX\STX\231\STX\ETX\SUB< Generated classes can be optimized for speed or code size.\n\
+    \\EOT\NUL\DC2\ACK\250\STX\STX\255\STX\ETX\SUB< Generated classes can be optimized for speed or code size.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\EOT\NUL\SOH\DC2\EOT\226\STX\a\DC3\n\
+    \\EOT\NUL\SOH\DC2\EOT\250\STX\a\DC3\n\
     \D\n\
     \\ACK\EOT\n\
-    \\EOT\NUL\STX\NUL\DC2\EOT\227\STX\EOT\SO\"4 Generate complete code for parsing, serialization,\n\
+    \\EOT\NUL\STX\NUL\DC2\EOT\251\STX\EOT\SO\"4 Generate complete code for parsing, serialization,\n\
     \\n\
     \\SI\n\
     \\a\EOT\n\
-    \\EOT\NUL\STX\NUL\SOH\DC2\EOT\227\STX\EOT\t\n\
+    \\EOT\NUL\STX\NUL\SOH\DC2\EOT\251\STX\EOT\t\n\
     \\SI\n\
     \\a\EOT\n\
-    \\EOT\NUL\STX\NUL\STX\DC2\EOT\227\STX\f\r\n\
+    \\EOT\NUL\STX\NUL\STX\DC2\EOT\251\STX\f\r\n\
     \G\n\
     \\ACK\EOT\n\
-    \\EOT\NUL\STX\SOH\DC2\EOT\229\STX\EOT\DC2\SUB\ACK etc.\n\
+    \\EOT\NUL\STX\SOH\DC2\EOT\253\STX\EOT\DC2\SUB\ACK etc.\n\
     \\"/ Use ReflectionOps to implement these methods.\n\
     \\n\
     \\SI\n\
     \\a\EOT\n\
-    \\EOT\NUL\STX\SOH\SOH\DC2\EOT\229\STX\EOT\r\n\
+    \\EOT\NUL\STX\SOH\SOH\DC2\EOT\253\STX\EOT\r\n\
     \\SI\n\
     \\a\EOT\n\
-    \\EOT\NUL\STX\SOH\STX\DC2\EOT\229\STX\DLE\DC1\n\
+    \\EOT\NUL\STX\SOH\STX\DC2\EOT\253\STX\DLE\DC1\n\
     \G\n\
     \\ACK\EOT\n\
-    \\EOT\NUL\STX\STX\DC2\EOT\230\STX\EOT\NAK\"7 Generate code using MessageLite and the lite runtime.\n\
+    \\EOT\NUL\STX\STX\DC2\EOT\254\STX\EOT\NAK\"7 Generate code using MessageLite and the lite runtime.\n\
     \\n\
     \\SI\n\
     \\a\EOT\n\
-    \\EOT\NUL\STX\STX\SOH\DC2\EOT\230\STX\EOT\DLE\n\
+    \\EOT\NUL\STX\STX\SOH\DC2\EOT\254\STX\EOT\DLE\n\
     \\SI\n\
     \\a\EOT\n\
-    \\EOT\NUL\STX\STX\STX\DC2\EOT\230\STX\DC3\DC4\n\
+    \\EOT\NUL\STX\STX\STX\DC2\EOT\254\STX\DC3\DC4\n\
     \\f\n\
     \\EOT\EOT\n\
-    \\STX\ENQ\DC2\EOT\232\STX\STX9\n\
+    \\STX\ENQ\DC2\EOT\128\ETX\STX;\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ENQ\EOT\DC2\EOT\232\STX\STX\n\
+    \\STX\ENQ\EOT\DC2\EOT\128\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ENQ\ACK\DC2\EOT\232\STX\v\ETB\n\
+    \\STX\ENQ\ACK\DC2\EOT\128\ETX\v\ETB\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ENQ\SOH\DC2\EOT\232\STX\CAN$\n\
+    \\STX\ENQ\SOH\DC2\EOT\128\ETX\CAN$\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ENQ\ETX\DC2\EOT\232\STX'(\n\
+    \\STX\ENQ\ETX\DC2\EOT\128\ETX'(\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ENQ\b\DC2\EOT\232\STX)8\n\
+    \\STX\ENQ\b\DC2\EOT\128\ETX):\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ENQ\a\DC2\EOT\232\STX27\n\
+    \\STX\ENQ\a\DC2\EOT\128\ETX49\n\
     \\226\STX\n\
     \\EOT\EOT\n\
-    \\STX\ACK\DC2\EOT\239\STX\STX\"\SUB\211\STX Sets the Go package where structs generated from this .proto will be\n\
+    \\STX\ACK\DC2\EOT\135\ETX\STX\"\SUB\211\STX Sets the Go package where structs generated from this .proto will be\n\
     \ placed. If omitted, the Go package will be derived from the following:\n\
     \   - The basename of the package import path, if provided.\n\
     \   - Otherwise, the package statement in the .proto file, if present.\n\
@@ -11838,20 +11863,20 @@ packedFileDescriptor
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ACK\EOT\DC2\EOT\239\STX\STX\n\
+    \\STX\ACK\EOT\DC2\EOT\135\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ACK\ENQ\DC2\EOT\239\STX\v\DC1\n\
+    \\STX\ACK\ENQ\DC2\EOT\135\ETX\v\DC1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ACK\SOH\DC2\EOT\239\STX\DC2\FS\n\
+    \\STX\ACK\SOH\DC2\EOT\135\ETX\DC2\FS\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\ACK\ETX\DC2\EOT\239\STX\US!\n\
+    \\STX\ACK\ETX\DC2\EOT\135\ETX\US!\n\
     \\212\EOT\n\
     \\EOT\EOT\n\
-    \\STX\a\DC2\EOT\253\STX\STX9\SUB\197\EOT Should generic services be generated in each language?  \"Generic\" services\n\
+    \\STX\a\DC2\EOT\150\ETX\STX;\SUB\197\EOT Should generic services be generated in each language?  \"Generic\" services\n\
     \ are not specific to any particular RPC system.  They are generated by the\n\
     \ main code generators in each language (without additional plugins).\n\
     \ Generic services were the only kind of service generation supported by\n\
@@ -11864,326 +11889,326 @@ packedFileDescriptor
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\a\EOT\DC2\EOT\253\STX\STX\n\
+    \\STX\a\EOT\DC2\EOT\150\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\a\ENQ\DC2\EOT\253\STX\v\SI\n\
+    \\STX\a\ENQ\DC2\EOT\150\ETX\v\SI\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\a\SOH\DC2\EOT\253\STX\DLE#\n\
+    \\STX\a\SOH\DC2\EOT\150\ETX\DLE#\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\a\ETX\DC2\EOT\253\STX&(\n\
+    \\STX\a\ETX\DC2\EOT\150\ETX&(\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\a\b\DC2\EOT\253\STX)8\n\
+    \\STX\a\b\DC2\EOT\150\ETX):\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\a\a\DC2\EOT\253\STX27\n\
+    \\STX\a\a\DC2\EOT\150\ETX49\n\
     \\f\n\
     \\EOT\EOT\n\
-    \\STX\b\DC2\EOT\254\STX\STX;\n\
+    \\STX\b\DC2\EOT\151\ETX\STX=\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\b\EOT\DC2\EOT\254\STX\STX\n\
+    \\STX\b\EOT\DC2\EOT\151\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\b\ENQ\DC2\EOT\254\STX\v\SI\n\
+    \\STX\b\ENQ\DC2\EOT\151\ETX\v\SI\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\b\SOH\DC2\EOT\254\STX\DLE%\n\
+    \\STX\b\SOH\DC2\EOT\151\ETX\DLE%\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\b\ETX\DC2\EOT\254\STX(*\n\
+    \\STX\b\ETX\DC2\EOT\151\ETX(*\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\b\b\DC2\EOT\254\STX+:\n\
+    \\STX\b\b\DC2\EOT\151\ETX+<\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\b\a\DC2\EOT\254\STX49\n\
+    \\STX\b\a\DC2\EOT\151\ETX6;\n\
     \\f\n\
     \\EOT\EOT\n\
-    \\STX\t\DC2\EOT\255\STX\STX9\n\
+    \\STX\t\DC2\EOT\152\ETX\STX;\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\t\EOT\DC2\EOT\255\STX\STX\n\
+    \\STX\t\EOT\DC2\EOT\152\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\t\ENQ\DC2\EOT\255\STX\v\SI\n\
+    \\STX\t\ENQ\DC2\EOT\152\ETX\v\SI\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\t\SOH\DC2\EOT\255\STX\DLE#\n\
+    \\STX\t\SOH\DC2\EOT\152\ETX\DLE#\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\t\ETX\DC2\EOT\255\STX&(\n\
+    \\STX\t\ETX\DC2\EOT\152\ETX&(\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\t\b\DC2\EOT\255\STX)8\n\
+    \\STX\t\b\DC2\EOT\152\ETX):\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\t\a\DC2\EOT\255\STX27\n\
+    \\STX\t\a\DC2\EOT\152\ETX49\n\
     \\f\n\
     \\EOT\EOT\n\
     \\STX\n\
-    \\DC2\EOT\128\ETX\STX:\n\
+    \\DC2\EOT\153\ETX\STX<\n\
     \\r\n\
     \\ENQ\EOT\n\
     \\STX\n\
-    \\EOT\DC2\EOT\128\ETX\STX\n\
+    \\EOT\DC2\EOT\153\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
     \\STX\n\
-    \\ENQ\DC2\EOT\128\ETX\v\SI\n\
+    \\ENQ\DC2\EOT\153\ETX\v\SI\n\
     \\r\n\
     \\ENQ\EOT\n\
     \\STX\n\
-    \\SOH\DC2\EOT\128\ETX\DLE$\n\
+    \\SOH\DC2\EOT\153\ETX\DLE$\n\
     \\r\n\
     \\ENQ\EOT\n\
     \\STX\n\
-    \\ETX\DC2\EOT\128\ETX')\n\
+    \\ETX\DC2\EOT\153\ETX')\n\
     \\r\n\
     \\ENQ\EOT\n\
     \\STX\n\
-    \\b\DC2\EOT\128\ETX*9\n\
+    \\b\DC2\EOT\153\ETX*;\n\
     \\r\n\
     \\ENQ\EOT\n\
     \\STX\n\
-    \\a\DC2\EOT\128\ETX38\n\
+    \\a\DC2\EOT\153\ETX5:\n\
     \\243\SOH\n\
     \\EOT\EOT\n\
-    \\STX\v\DC2\EOT\134\ETX\STX0\SUB\228\SOH Is this file deprecated?\n\
+    \\STX\v\DC2\EOT\159\ETX\STX2\SUB\228\SOH Is this file deprecated?\n\
     \ Depending on the target platform, this can emit Deprecated annotations\n\
     \ for everything in the file, or it will be completely ignored; in the very\n\
     \ least, this is a formalization for deprecating files.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\v\EOT\DC2\EOT\134\ETX\STX\n\
+    \\STX\v\EOT\DC2\EOT\159\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\v\ENQ\DC2\EOT\134\ETX\v\SI\n\
+    \\STX\v\ENQ\DC2\EOT\159\ETX\v\SI\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\v\SOH\DC2\EOT\134\ETX\DLE\SUB\n\
+    \\STX\v\SOH\DC2\EOT\159\ETX\DLE\SUB\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\v\ETX\DC2\EOT\134\ETX\GS\US\n\
+    \\STX\v\ETX\DC2\EOT\159\ETX\GS\US\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\v\b\DC2\EOT\134\ETX /\n\
+    \\STX\v\b\DC2\EOT\159\ETX 1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\v\a\DC2\EOT\134\ETX).\n\
+    \\STX\v\a\DC2\EOT\159\ETX+0\n\
     \\DEL\n\
     \\EOT\EOT\n\
-    \\STX\f\DC2\EOT\138\ETX\STX6\SUBq Enables the use of arenas for the proto messages in this file. This applies\n\
+    \\STX\f\DC2\EOT\163\ETX\STX7\SUBq Enables the use of arenas for the proto messages in this file. This applies\n\
     \ only to generated classes for C++.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\f\EOT\DC2\EOT\138\ETX\STX\n\
+    \\STX\f\EOT\DC2\EOT\163\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\f\ENQ\DC2\EOT\138\ETX\v\SI\n\
+    \\STX\f\ENQ\DC2\EOT\163\ETX\v\SI\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\f\SOH\DC2\EOT\138\ETX\DLE \n\
+    \\STX\f\SOH\DC2\EOT\163\ETX\DLE \n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\f\ETX\DC2\EOT\138\ETX#%\n\
+    \\STX\f\ETX\DC2\EOT\163\ETX#%\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\f\b\DC2\EOT\138\ETX&5\n\
+    \\STX\f\b\DC2\EOT\163\ETX&6\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\f\a\DC2\EOT\138\ETX/4\n\
+    \\STX\f\a\DC2\EOT\163\ETX15\n\
     \\146\SOH\n\
     \\EOT\EOT\n\
-    \\STX\r\DC2\EOT\143\ETX\STX)\SUB\131\SOH Sets the objective c class prefix which is prepended to all objective c\n\
+    \\STX\r\DC2\EOT\168\ETX\STX)\SUB\131\SOH Sets the objective c class prefix which is prepended to all objective c\n\
     \ generated classes from this .proto. There is no default.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\r\EOT\DC2\EOT\143\ETX\STX\n\
+    \\STX\r\EOT\DC2\EOT\168\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\r\ENQ\DC2\EOT\143\ETX\v\DC1\n\
+    \\STX\r\ENQ\DC2\EOT\168\ETX\v\DC1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\r\SOH\DC2\EOT\143\ETX\DC2#\n\
+    \\STX\r\SOH\DC2\EOT\168\ETX\DC2#\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\r\ETX\DC2\EOT\143\ETX&(\n\
+    \\STX\r\ETX\DC2\EOT\168\ETX&(\n\
     \I\n\
     \\EOT\EOT\n\
-    \\STX\SO\DC2\EOT\146\ETX\STX(\SUB; Namespace for generated classes; defaults to the package.\n\
+    \\STX\SO\DC2\EOT\171\ETX\STX(\SUB; Namespace for generated classes; defaults to the package.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SO\EOT\DC2\EOT\146\ETX\STX\n\
+    \\STX\SO\EOT\DC2\EOT\171\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SO\ENQ\DC2\EOT\146\ETX\v\DC1\n\
+    \\STX\SO\ENQ\DC2\EOT\171\ETX\v\DC1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SO\SOH\DC2\EOT\146\ETX\DC2\"\n\
+    \\STX\SO\SOH\DC2\EOT\171\ETX\DC2\"\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SO\ETX\DC2\EOT\146\ETX%'\n\
+    \\STX\SO\ETX\DC2\EOT\171\ETX%'\n\
     \\145\STX\n\
     \\EOT\EOT\n\
-    \\STX\SI\DC2\EOT\152\ETX\STX$\SUB\130\STX By default Swift generators will take the proto package and CamelCase it\n\
+    \\STX\SI\DC2\EOT\177\ETX\STX$\SUB\130\STX By default Swift generators will take the proto package and CamelCase it\n\
     \ replacing '.' with underscore and use that to prefix the types/symbols\n\
     \ defined. When this options is provided, they will use this value instead\n\
     \ to prefix the types/symbols defined.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SI\EOT\DC2\EOT\152\ETX\STX\n\
+    \\STX\SI\EOT\DC2\EOT\177\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SI\ENQ\DC2\EOT\152\ETX\v\DC1\n\
+    \\STX\SI\ENQ\DC2\EOT\177\ETX\v\DC1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SI\SOH\DC2\EOT\152\ETX\DC2\RS\n\
+    \\STX\SI\SOH\DC2\EOT\177\ETX\DC2\RS\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\SI\ETX\DC2\EOT\152\ETX!#\n\
+    \\STX\SI\ETX\DC2\EOT\177\ETX!#\n\
     \~\n\
     \\EOT\EOT\n\
-    \\STX\DLE\DC2\EOT\156\ETX\STX(\SUBp Sets the php class prefix which is prepended to all php generated classes\n\
+    \\STX\DLE\DC2\EOT\181\ETX\STX(\SUBp Sets the php class prefix which is prepended to all php generated classes\n\
     \ from this .proto. Default is empty.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DLE\EOT\DC2\EOT\156\ETX\STX\n\
+    \\STX\DLE\EOT\DC2\EOT\181\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DLE\ENQ\DC2\EOT\156\ETX\v\DC1\n\
+    \\STX\DLE\ENQ\DC2\EOT\181\ETX\v\DC1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DLE\SOH\DC2\EOT\156\ETX\DC2\"\n\
+    \\STX\DLE\SOH\DC2\EOT\181\ETX\DC2\"\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DLE\ETX\DC2\EOT\156\ETX%'\n\
+    \\STX\DLE\ETX\DC2\EOT\181\ETX%'\n\
     \\190\SOH\n\
     \\EOT\EOT\n\
-    \\STX\DC1\DC2\EOT\161\ETX\STX%\SUB\175\SOH Use this option to change the namespace of php generated classes. Default\n\
+    \\STX\DC1\DC2\EOT\186\ETX\STX%\SUB\175\SOH Use this option to change the namespace of php generated classes. Default\n\
     \ is empty. When this option is empty, the package name will be used for\n\
     \ determining the namespace.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC1\EOT\DC2\EOT\161\ETX\STX\n\
+    \\STX\DC1\EOT\DC2\EOT\186\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC1\ENQ\DC2\EOT\161\ETX\v\DC1\n\
+    \\STX\DC1\ENQ\DC2\EOT\186\ETX\v\DC1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC1\SOH\DC2\EOT\161\ETX\DC2\US\n\
+    \\STX\DC1\SOH\DC2\EOT\186\ETX\DC2\US\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC1\ETX\DC2\EOT\161\ETX\"$\n\
+    \\STX\DC1\ETX\DC2\EOT\186\ETX\"$\n\
     \\202\SOH\n\
     \\EOT\EOT\n\
-    \\STX\DC2\DC2\EOT\167\ETX\STX.\SUB\187\SOH Use this option to change the namespace of php generated metadata classes.\n\
-    \ Default is empty. When this option is empty, the proto file name will be used\n\
-    \ for determining the namespace.\n\
+    \\STX\DC2\DC2\EOT\191\ETX\STX.\SUB\187\SOH Use this option to change the namespace of php generated metadata classes.\n\
+    \ Default is empty. When this option is empty, the proto file name will be\n\
+    \ used for determining the namespace.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC2\EOT\DC2\EOT\167\ETX\STX\n\
+    \\STX\DC2\EOT\DC2\EOT\191\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC2\ENQ\DC2\EOT\167\ETX\v\DC1\n\
+    \\STX\DC2\ENQ\DC2\EOT\191\ETX\v\DC1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC2\SOH\DC2\EOT\167\ETX\DC2(\n\
+    \\STX\DC2\SOH\DC2\EOT\191\ETX\DC2(\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC2\ETX\DC2\EOT\167\ETX+-\n\
+    \\STX\DC2\ETX\DC2\EOT\191\ETX+-\n\
     \\194\SOH\n\
     \\EOT\EOT\n\
-    \\STX\DC3\DC2\EOT\172\ETX\STX$\SUB\179\SOH Use this option to change the package of ruby generated classes. Default\n\
+    \\STX\DC3\DC2\EOT\196\ETX\STX$\SUB\179\SOH Use this option to change the package of ruby generated classes. Default\n\
     \ is empty. When this option is not set, the package name will be used for\n\
     \ determining the ruby package.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC3\EOT\DC2\EOT\172\ETX\STX\n\
+    \\STX\DC3\EOT\DC2\EOT\196\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC3\ENQ\DC2\EOT\172\ETX\v\DC1\n\
+    \\STX\DC3\ENQ\DC2\EOT\196\ETX\v\DC1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC3\SOH\DC2\EOT\172\ETX\DC2\RS\n\
+    \\STX\DC3\SOH\DC2\EOT\196\ETX\DC2\RS\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC3\ETX\DC2\EOT\172\ETX!#\n\
+    \\STX\DC3\ETX\DC2\EOT\196\ETX!#\n\
     \|\n\
     \\EOT\EOT\n\
-    \\STX\DC4\DC2\EOT\176\ETX\STX:\SUBn The parser stores options it doesn't recognize here.\n\
+    \\STX\DC4\DC2\EOT\201\ETX\STX:\SUBn The parser stores options it doesn't recognize here.\n\
     \ See the documentation for the \"Options\" section above.\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC4\EOT\DC2\EOT\176\ETX\STX\n\
+    \\STX\DC4\EOT\DC2\EOT\201\ETX\STX\n\
     \\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC4\ACK\DC2\EOT\176\ETX\v\RS\n\
+    \\STX\DC4\ACK\DC2\EOT\201\ETX\v\RS\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC4\SOH\DC2\EOT\176\ETX\US3\n\
+    \\STX\DC4\SOH\DC2\EOT\201\ETX\US3\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\STX\DC4\ETX\DC2\EOT\176\ETX69\n\
+    \\STX\DC4\ETX\DC2\EOT\201\ETX69\n\
     \\135\SOH\n\
     \\ETX\EOT\n\
-    \\ENQ\DC2\EOT\180\ETX\STX\EM\SUBz Clients can define custom options in extensions of this message.\n\
+    \\ENQ\DC2\EOT\205\ETX\STX\EM\SUBz Clients can define custom options in extensions of this message.\n\
     \ See the documentation for the \"Options\" section above.\n\
     \\n\
     \\f\n\
     \\EOT\EOT\n\
-    \\ENQ\NUL\DC2\EOT\180\ETX\r\CAN\n\
+    \\ENQ\NUL\DC2\EOT\205\ETX\r\CAN\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\ENQ\NUL\SOH\DC2\EOT\180\ETX\r\DC1\n\
+    \\ENQ\NUL\SOH\DC2\EOT\205\ETX\r\DC1\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\ENQ\NUL\STX\DC2\EOT\180\ETX\NAK\CAN\n\
+    \\ENQ\NUL\STX\DC2\EOT\205\ETX\NAK\CAN\n\
     \\v\n\
     \\ETX\EOT\n\
-    \\t\DC2\EOT\182\ETX\v\SO\n\
+    \\t\DC2\EOT\207\ETX\STX\SO\n\
     \\f\n\
     \\EOT\EOT\n\
-    \\t\NUL\DC2\EOT\182\ETX\v\r\n\
+    \\t\NUL\DC2\EOT\207\ETX\v\r\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\t\NUL\SOH\DC2\EOT\182\ETX\v\r\n\
+    \\t\NUL\SOH\DC2\EOT\207\ETX\v\r\n\
     \\r\n\
     \\ENQ\EOT\n\
-    \\t\NUL\STX\DC2\EOT\182\ETX\v\r\n\
+    \\t\NUL\STX\DC2\EOT\207\ETX\v\r\n\
     \\f\n\
-    \\STX\EOT\v\DC2\ACK\185\ETX\NUL\248\ETX\SOH\n\
+    \\STX\EOT\v\DC2\ACK\210\ETX\NUL\146\EOT\SOH\n\
     \\v\n\
-    \\ETX\EOT\v\SOH\DC2\EOT\185\ETX\b\SYN\n\
+    \\ETX\EOT\v\SOH\DC2\EOT\210\ETX\b\SYN\n\
     \\216\ENQ\n\
-    \\EOT\EOT\v\STX\NUL\DC2\EOT\204\ETX\STX<\SUB\201\ENQ Set true to use the old proto1 MessageSet wire format for extensions.\n\
+    \\EOT\EOT\v\STX\NUL\DC2\EOT\229\ETX\STX>\SUB\201\ENQ Set true to use the old proto1 MessageSet wire format for extensions.\n\
     \ This is provided for backwards-compatibility with the MessageSet wire\n\
     \ format.  You should not use this for any other reason:  It's less\n\
     \ efficient, has fewer features, and is more complicated.\n\
@@ -12203,57 +12228,57 @@ packedFileDescriptor
     \ the protocol compiler.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\NUL\EOT\DC2\EOT\204\ETX\STX\n\
+    \\ENQ\EOT\v\STX\NUL\EOT\DC2\EOT\229\ETX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\NUL\ENQ\DC2\EOT\204\ETX\v\SI\n\
+    \\ENQ\EOT\v\STX\NUL\ENQ\DC2\EOT\229\ETX\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\NUL\SOH\DC2\EOT\204\ETX\DLE'\n\
+    \\ENQ\EOT\v\STX\NUL\SOH\DC2\EOT\229\ETX\DLE'\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\NUL\ETX\DC2\EOT\204\ETX*+\n\
+    \\ENQ\EOT\v\STX\NUL\ETX\DC2\EOT\229\ETX*+\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\NUL\b\DC2\EOT\204\ETX,;\n\
+    \\ENQ\EOT\v\STX\NUL\b\DC2\EOT\229\ETX,=\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\NUL\a\DC2\EOT\204\ETX5:\n\
+    \\ENQ\EOT\v\STX\NUL\a\DC2\EOT\229\ETX7<\n\
     \\235\SOH\n\
-    \\EOT\EOT\v\STX\SOH\DC2\EOT\209\ETX\STXD\SUB\220\SOH Disables the generation of the standard \"descriptor()\" accessor, which can\n\
+    \\EOT\EOT\v\STX\SOH\DC2\EOT\234\ETX\STXF\SUB\220\SOH Disables the generation of the standard \"descriptor()\" accessor, which can\n\
     \ conflict with a field of the same name.  This is meant to make migration\n\
     \ from proto1 easier; new code should avoid fields named \"descriptor\".\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\SOH\EOT\DC2\EOT\209\ETX\STX\n\
+    \\ENQ\EOT\v\STX\SOH\EOT\DC2\EOT\234\ETX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\SOH\ENQ\DC2\EOT\209\ETX\v\SI\n\
+    \\ENQ\EOT\v\STX\SOH\ENQ\DC2\EOT\234\ETX\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\SOH\SOH\DC2\EOT\209\ETX\DLE/\n\
+    \\ENQ\EOT\v\STX\SOH\SOH\DC2\EOT\234\ETX\DLE/\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\SOH\ETX\DC2\EOT\209\ETX23\n\
+    \\ENQ\EOT\v\STX\SOH\ETX\DC2\EOT\234\ETX23\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\SOH\b\DC2\EOT\209\ETX4C\n\
+    \\ENQ\EOT\v\STX\SOH\b\DC2\EOT\234\ETX4E\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\SOH\a\DC2\EOT\209\ETX=B\n\
+    \\ENQ\EOT\v\STX\SOH\a\DC2\EOT\234\ETX?D\n\
     \\238\SOH\n\
-    \\EOT\EOT\v\STX\STX\DC2\EOT\215\ETX\STX/\SUB\223\SOH Is this message deprecated?\n\
+    \\EOT\EOT\v\STX\STX\DC2\EOT\240\ETX\STX1\SUB\223\SOH Is this message deprecated?\n\
     \ Depending on the target platform, this can emit Deprecated annotations\n\
     \ for the message, or it will be completely ignored; in the very least,\n\
     \ this is a formalization for deprecating messages.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\STX\EOT\DC2\EOT\215\ETX\STX\n\
+    \\ENQ\EOT\v\STX\STX\EOT\DC2\EOT\240\ETX\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\STX\ENQ\DC2\EOT\215\ETX\v\SI\n\
+    \\ENQ\EOT\v\STX\STX\ENQ\DC2\EOT\240\ETX\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\STX\SOH\DC2\EOT\215\ETX\DLE\SUB\n\
+    \\ENQ\EOT\v\STX\STX\SOH\DC2\EOT\240\ETX\DLE\SUB\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\STX\ETX\DC2\EOT\215\ETX\GS\RS\n\
+    \\ENQ\EOT\v\STX\STX\ETX\DC2\EOT\240\ETX\GS\RS\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\STX\b\DC2\EOT\215\ETX\US.\n\
+    \\ENQ\EOT\v\STX\STX\b\DC2\EOT\240\ETX\US0\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\STX\a\DC2\EOT\215\ETX(-\n\
-    \\158\ACK\n\
-    \\EOT\EOT\v\STX\ETX\DC2\EOT\238\ETX\STX\RS\SUB\143\ACK Whether the message is an automatically generated map entry type for the\n\
+    \\ENQ\EOT\v\STX\STX\a\DC2\EOT\240\ETX*/\n\
+    \\160\ACK\n\
+    \\EOT\EOT\v\STX\ETX\DC2\EOT\135\EOT\STX\RS\SUB\145\ACK Whether the message is an automatically generated map entry type for the\n\
     \ maps field.\n\
     \\n\
     \ For maps fields:\n\
@@ -12268,7 +12293,7 @@ packedFileDescriptor
     \\n\
     \ Implementations may choose not to generate the map_entry=true message, but\n\
     \ use a native map in the target language to hold the keys and values.\n\
-    \ The reflection APIs in such implementions still need to work as\n\
+    \ The reflection APIs in such implementations still need to work as\n\
     \ if the field is a repeated message field.\n\
     \\n\
     \ NOTE: Do not set the option in .proto files. Always use the maps syntax\n\
@@ -12276,118 +12301,118 @@ packedFileDescriptor
     \ parser.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\ETX\EOT\DC2\EOT\238\ETX\STX\n\
+    \\ENQ\EOT\v\STX\ETX\EOT\DC2\EOT\135\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\ETX\ENQ\DC2\EOT\238\ETX\v\SI\n\
+    \\ENQ\EOT\v\STX\ETX\ENQ\DC2\EOT\135\EOT\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\ETX\SOH\DC2\EOT\238\ETX\DLE\EM\n\
+    \\ENQ\EOT\v\STX\ETX\SOH\DC2\EOT\135\EOT\DLE\EM\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\ETX\ETX\DC2\EOT\238\ETX\FS\GS\n\
+    \\ENQ\EOT\v\STX\ETX\ETX\DC2\EOT\135\EOT\FS\GS\n\
     \$\n\
-    \\ETX\EOT\v\t\DC2\EOT\240\ETX\v\r\"\ETB javalite_serializable\n\
+    \\ETX\EOT\v\t\DC2\EOT\137\EOT\STX\r\"\ETB javalite_serializable\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\v\t\NUL\DC2\EOT\240\ETX\v\f\n\
+    \\EOT\EOT\v\t\NUL\DC2\EOT\137\EOT\v\f\n\
     \\r\n\
-    \\ENQ\EOT\v\t\NUL\SOH\DC2\EOT\240\ETX\v\f\n\
+    \\ENQ\EOT\v\t\NUL\SOH\DC2\EOT\137\EOT\v\f\n\
     \\r\n\
-    \\ENQ\EOT\v\t\NUL\STX\DC2\EOT\240\ETX\v\f\n\
+    \\ENQ\EOT\v\t\NUL\STX\DC2\EOT\137\EOT\v\f\n\
     \\US\n\
-    \\ETX\EOT\v\t\DC2\EOT\241\ETX\v\r\"\DC2 javanano_as_lite\n\
+    \\ETX\EOT\v\t\DC2\EOT\138\EOT\STX\r\"\DC2 javanano_as_lite\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\v\t\SOH\DC2\EOT\241\ETX\v\f\n\
+    \\EOT\EOT\v\t\SOH\DC2\EOT\138\EOT\v\f\n\
     \\r\n\
-    \\ENQ\EOT\v\t\SOH\SOH\DC2\EOT\241\ETX\v\f\n\
+    \\ENQ\EOT\v\t\SOH\SOH\DC2\EOT\138\EOT\v\f\n\
     \\r\n\
-    \\ENQ\EOT\v\t\SOH\STX\DC2\EOT\241\ETX\v\f\n\
+    \\ENQ\EOT\v\t\SOH\STX\DC2\EOT\138\EOT\v\f\n\
     \O\n\
-    \\EOT\EOT\v\STX\EOT\DC2\EOT\244\ETX\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\EOT\EOT\v\STX\EOT\DC2\EOT\142\EOT\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\EOT\EOT\DC2\EOT\244\ETX\STX\n\
+    \\ENQ\EOT\v\STX\EOT\EOT\DC2\EOT\142\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\EOT\ACK\DC2\EOT\244\ETX\v\RS\n\
+    \\ENQ\EOT\v\STX\EOT\ACK\DC2\EOT\142\EOT\v\RS\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\EOT\SOH\DC2\EOT\244\ETX\US3\n\
+    \\ENQ\EOT\v\STX\EOT\SOH\DC2\EOT\142\EOT\US3\n\
     \\r\n\
-    \\ENQ\EOT\v\STX\EOT\ETX\DC2\EOT\244\ETX69\n\
+    \\ENQ\EOT\v\STX\EOT\ETX\DC2\EOT\142\EOT69\n\
     \Z\n\
-    \\ETX\EOT\v\ENQ\DC2\EOT\247\ETX\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\ETX\EOT\v\ENQ\DC2\EOT\145\EOT\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\v\ENQ\NUL\DC2\EOT\247\ETX\r\CAN\n\
+    \\EOT\EOT\v\ENQ\NUL\DC2\EOT\145\EOT\r\CAN\n\
     \\r\n\
-    \\ENQ\EOT\v\ENQ\NUL\SOH\DC2\EOT\247\ETX\r\DC1\n\
+    \\ENQ\EOT\v\ENQ\NUL\SOH\DC2\EOT\145\EOT\r\DC1\n\
     \\r\n\
-    \\ENQ\EOT\v\ENQ\NUL\STX\DC2\EOT\247\ETX\NAK\CAN\n\
+    \\ENQ\EOT\v\ENQ\NUL\STX\DC2\EOT\145\EOT\NAK\CAN\n\
     \\f\n\
-    \\STX\EOT\f\DC2\ACK\250\ETX\NUL\213\EOT\SOH\n\
+    \\STX\EOT\f\DC2\ACK\148\EOT\NUL\239\EOT\SOH\n\
     \\v\n\
-    \\ETX\EOT\f\SOH\DC2\EOT\250\ETX\b\DC4\n\
+    \\ETX\EOT\f\SOH\DC2\EOT\148\EOT\b\DC4\n\
     \\163\STX\n\
-    \\EOT\EOT\f\STX\NUL\DC2\EOT\255\ETX\STX.\SUB\148\STX The ctype option instructs the C++ code generator to use a different\n\
+    \\EOT\EOT\f\STX\NUL\DC2\EOT\153\EOT\STX.\SUB\148\STX The ctype option instructs the C++ code generator to use a different\n\
     \ representation of the field than it normally would.  See the specific\n\
     \ options below.  This option is not yet implemented in the open source\n\
     \ release -- sorry, we'll try to include it in a future version!\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\NUL\EOT\DC2\EOT\255\ETX\STX\n\
+    \\ENQ\EOT\f\STX\NUL\EOT\DC2\EOT\153\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\NUL\ACK\DC2\EOT\255\ETX\v\DLE\n\
+    \\ENQ\EOT\f\STX\NUL\ACK\DC2\EOT\153\EOT\v\DLE\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\NUL\SOH\DC2\EOT\255\ETX\DC1\SYN\n\
+    \\ENQ\EOT\f\STX\NUL\SOH\DC2\EOT\153\EOT\DC1\SYN\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\NUL\ETX\DC2\EOT\255\ETX\EM\SUB\n\
+    \\ENQ\EOT\f\STX\NUL\ETX\DC2\EOT\153\EOT\EM\SUB\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\NUL\b\DC2\EOT\255\ETX\ESC-\n\
+    \\ENQ\EOT\f\STX\NUL\b\DC2\EOT\153\EOT\ESC-\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\NUL\a\DC2\EOT\255\ETX&,\n\
+    \\ENQ\EOT\f\STX\NUL\a\DC2\EOT\153\EOT&,\n\
     \\SO\n\
-    \\EOT\EOT\f\EOT\NUL\DC2\ACK\128\EOT\STX\135\EOT\ETX\n\
+    \\EOT\EOT\f\EOT\NUL\DC2\ACK\154\EOT\STX\161\EOT\ETX\n\
     \\r\n\
-    \\ENQ\EOT\f\EOT\NUL\SOH\DC2\EOT\128\EOT\a\f\n\
+    \\ENQ\EOT\f\EOT\NUL\SOH\DC2\EOT\154\EOT\a\f\n\
     \\US\n\
-    \\ACK\EOT\f\EOT\NUL\STX\NUL\DC2\EOT\130\EOT\EOT\SI\SUB\SI Default mode.\n\
+    \\ACK\EOT\f\EOT\NUL\STX\NUL\DC2\EOT\156\EOT\EOT\SI\SUB\SI Default mode.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\f\EOT\NUL\STX\NUL\SOH\DC2\EOT\130\EOT\EOT\n\
+    \\a\EOT\f\EOT\NUL\STX\NUL\SOH\DC2\EOT\156\EOT\EOT\n\
     \\n\
     \\SI\n\
-    \\a\EOT\f\EOT\NUL\STX\NUL\STX\DC2\EOT\130\EOT\r\SO\n\
+    \\a\EOT\f\EOT\NUL\STX\NUL\STX\DC2\EOT\156\EOT\r\SO\n\
     \\SO\n\
-    \\ACK\EOT\f\EOT\NUL\STX\SOH\DC2\EOT\132\EOT\EOT\r\n\
+    \\ACK\EOT\f\EOT\NUL\STX\SOH\DC2\EOT\158\EOT\EOT\r\n\
     \\SI\n\
-    \\a\EOT\f\EOT\NUL\STX\SOH\SOH\DC2\EOT\132\EOT\EOT\b\n\
+    \\a\EOT\f\EOT\NUL\STX\SOH\SOH\DC2\EOT\158\EOT\EOT\b\n\
     \\SI\n\
-    \\a\EOT\f\EOT\NUL\STX\SOH\STX\DC2\EOT\132\EOT\v\f\n\
+    \\a\EOT\f\EOT\NUL\STX\SOH\STX\DC2\EOT\158\EOT\v\f\n\
     \\SO\n\
-    \\ACK\EOT\f\EOT\NUL\STX\STX\DC2\EOT\134\EOT\EOT\NAK\n\
+    \\ACK\EOT\f\EOT\NUL\STX\STX\DC2\EOT\160\EOT\EOT\NAK\n\
     \\SI\n\
-    \\a\EOT\f\EOT\NUL\STX\STX\SOH\DC2\EOT\134\EOT\EOT\DLE\n\
+    \\a\EOT\f\EOT\NUL\STX\STX\SOH\DC2\EOT\160\EOT\EOT\DLE\n\
     \\SI\n\
-    \\a\EOT\f\EOT\NUL\STX\STX\STX\DC2\EOT\134\EOT\DC3\DC4\n\
+    \\a\EOT\f\EOT\NUL\STX\STX\STX\DC2\EOT\160\EOT\DC3\DC4\n\
     \\218\STX\n\
-    \\EOT\EOT\f\STX\SOH\DC2\EOT\141\EOT\STX\ESC\SUB\203\STX The packed option can be enabled for repeated primitive fields to enable\n\
+    \\EOT\EOT\f\STX\SOH\DC2\EOT\167\EOT\STX\ESC\SUB\203\STX The packed option can be enabled for repeated primitive fields to enable\n\
     \ a more efficient representation on the wire. Rather than repeatedly\n\
     \ writing the tag and type for each element, the entire array is encoded as\n\
     \ a single length-delimited blob. In proto3, only explicit setting it to\n\
     \ false will avoid using packed encoding.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\SOH\EOT\DC2\EOT\141\EOT\STX\n\
+    \\ENQ\EOT\f\STX\SOH\EOT\DC2\EOT\167\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\SOH\ENQ\DC2\EOT\141\EOT\v\SI\n\
+    \\ENQ\EOT\f\STX\SOH\ENQ\DC2\EOT\167\EOT\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\SOH\SOH\DC2\EOT\141\EOT\DLE\SYN\n\
+    \\ENQ\EOT\f\STX\SOH\SOH\DC2\EOT\167\EOT\DLE\SYN\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\SOH\ETX\DC2\EOT\141\EOT\EM\SUB\n\
+    \\ENQ\EOT\f\STX\SOH\ETX\DC2\EOT\167\EOT\EM\SUB\n\
     \\154\ENQ\n\
-    \\EOT\EOT\f\STX\STX\DC2\EOT\154\EOT\STX3\SUB\139\ENQ The jstype option determines the JavaScript type used for values of the\n\
+    \\EOT\EOT\f\STX\STX\DC2\EOT\180\EOT\STX3\SUB\139\ENQ The jstype option determines the JavaScript type used for values of the\n\
     \ field.  The option is permitted only for 64 bit integral and fixed types\n\
     \ (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING\n\
     \ is represented as JavaScript string, which avoids loss of precision that\n\
@@ -12400,45 +12425,45 @@ packedFileDescriptor
     \ goog.math.Integer.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\STX\EOT\DC2\EOT\154\EOT\STX\n\
+    \\ENQ\EOT\f\STX\STX\EOT\DC2\EOT\180\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\STX\ACK\DC2\EOT\154\EOT\v\DC1\n\
+    \\ENQ\EOT\f\STX\STX\ACK\DC2\EOT\180\EOT\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\STX\SOH\DC2\EOT\154\EOT\DC2\CAN\n\
+    \\ENQ\EOT\f\STX\STX\SOH\DC2\EOT\180\EOT\DC2\CAN\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\STX\ETX\DC2\EOT\154\EOT\ESC\FS\n\
+    \\ENQ\EOT\f\STX\STX\ETX\DC2\EOT\180\EOT\ESC\FS\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\STX\b\DC2\EOT\154\EOT\GS2\n\
+    \\ENQ\EOT\f\STX\STX\b\DC2\EOT\180\EOT\GS2\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\STX\a\DC2\EOT\154\EOT(1\n\
+    \\ENQ\EOT\f\STX\STX\a\DC2\EOT\180\EOT(1\n\
     \\SO\n\
-    \\EOT\EOT\f\EOT\SOH\DC2\ACK\155\EOT\STX\164\EOT\ETX\n\
+    \\EOT\EOT\f\EOT\SOH\DC2\ACK\181\EOT\STX\190\EOT\ETX\n\
     \\r\n\
-    \\ENQ\EOT\f\EOT\SOH\SOH\DC2\EOT\155\EOT\a\r\n\
+    \\ENQ\EOT\f\EOT\SOH\SOH\DC2\EOT\181\EOT\a\r\n\
     \'\n\
-    \\ACK\EOT\f\EOT\SOH\STX\NUL\DC2\EOT\157\EOT\EOT\DC2\SUB\ETB Use the default type.\n\
+    \\ACK\EOT\f\EOT\SOH\STX\NUL\DC2\EOT\183\EOT\EOT\DC2\SUB\ETB Use the default type.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\f\EOT\SOH\STX\NUL\SOH\DC2\EOT\157\EOT\EOT\r\n\
+    \\a\EOT\f\EOT\SOH\STX\NUL\SOH\DC2\EOT\183\EOT\EOT\r\n\
     \\SI\n\
-    \\a\EOT\f\EOT\SOH\STX\NUL\STX\DC2\EOT\157\EOT\DLE\DC1\n\
+    \\a\EOT\f\EOT\SOH\STX\NUL\STX\DC2\EOT\183\EOT\DLE\DC1\n\
     \)\n\
-    \\ACK\EOT\f\EOT\SOH\STX\SOH\DC2\EOT\160\EOT\EOT\DC2\SUB\EM Use JavaScript strings.\n\
+    \\ACK\EOT\f\EOT\SOH\STX\SOH\DC2\EOT\186\EOT\EOT\DC2\SUB\EM Use JavaScript strings.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\f\EOT\SOH\STX\SOH\SOH\DC2\EOT\160\EOT\EOT\r\n\
+    \\a\EOT\f\EOT\SOH\STX\SOH\SOH\DC2\EOT\186\EOT\EOT\r\n\
     \\SI\n\
-    \\a\EOT\f\EOT\SOH\STX\SOH\STX\DC2\EOT\160\EOT\DLE\DC1\n\
+    \\a\EOT\f\EOT\SOH\STX\SOH\STX\DC2\EOT\186\EOT\DLE\DC1\n\
     \)\n\
-    \\ACK\EOT\f\EOT\SOH\STX\STX\DC2\EOT\163\EOT\EOT\DC2\SUB\EM Use JavaScript numbers.\n\
+    \\ACK\EOT\f\EOT\SOH\STX\STX\DC2\EOT\189\EOT\EOT\DC2\SUB\EM Use JavaScript numbers.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\f\EOT\SOH\STX\STX\SOH\DC2\EOT\163\EOT\EOT\r\n\
+    \\a\EOT\f\EOT\SOH\STX\STX\SOH\DC2\EOT\189\EOT\EOT\r\n\
     \\SI\n\
-    \\a\EOT\f\EOT\SOH\STX\STX\STX\DC2\EOT\163\EOT\DLE\DC1\n\
+    \\a\EOT\f\EOT\SOH\STX\STX\STX\DC2\EOT\189\EOT\DLE\DC1\n\
     \\239\f\n\
-    \\EOT\EOT\f\STX\ETX\DC2\EOT\194\EOT\STX)\SUB\224\f Should this field be parsed lazily?  Lazy applies only to message-type\n\
+    \\EOT\EOT\f\STX\ETX\DC2\EOT\220\EOT\STX+\SUB\224\f Should this field be parsed lazily?  Lazy applies only to message-type\n\
     \ fields.  It means that when the outer message is initially parsed, the\n\
     \ inner message's contents will not be parsed but instead stored in encoded\n\
     \ form.  The inner message will actually be parsed when it is first accessed.\n\
@@ -12468,224 +12493,224 @@ packedFileDescriptor
     \ been parsed.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ETX\EOT\DC2\EOT\194\EOT\STX\n\
+    \\ENQ\EOT\f\STX\ETX\EOT\DC2\EOT\220\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ETX\ENQ\DC2\EOT\194\EOT\v\SI\n\
+    \\ENQ\EOT\f\STX\ETX\ENQ\DC2\EOT\220\EOT\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ETX\SOH\DC2\EOT\194\EOT\DLE\DC4\n\
+    \\ENQ\EOT\f\STX\ETX\SOH\DC2\EOT\220\EOT\DLE\DC4\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ETX\ETX\DC2\EOT\194\EOT\ETB\CAN\n\
+    \\ENQ\EOT\f\STX\ETX\ETX\DC2\EOT\220\EOT\ETB\CAN\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ETX\b\DC2\EOT\194\EOT\EM(\n\
+    \\ENQ\EOT\f\STX\ETX\b\DC2\EOT\220\EOT\EM*\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ETX\a\DC2\EOT\194\EOT\"'\n\
+    \\ENQ\EOT\f\STX\ETX\a\DC2\EOT\220\EOT$)\n\
     \\232\SOH\n\
-    \\EOT\EOT\f\STX\EOT\DC2\EOT\200\EOT\STX/\SUB\217\SOH Is this field deprecated?\n\
+    \\EOT\EOT\f\STX\EOT\DC2\EOT\226\EOT\STX1\SUB\217\SOH Is this field deprecated?\n\
     \ Depending on the target platform, this can emit Deprecated annotations\n\
     \ for accessors, or it will be completely ignored; in the very least, this\n\
     \ is a formalization for deprecating fields.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\EOT\EOT\DC2\EOT\200\EOT\STX\n\
+    \\ENQ\EOT\f\STX\EOT\EOT\DC2\EOT\226\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\EOT\ENQ\DC2\EOT\200\EOT\v\SI\n\
+    \\ENQ\EOT\f\STX\EOT\ENQ\DC2\EOT\226\EOT\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\EOT\SOH\DC2\EOT\200\EOT\DLE\SUB\n\
+    \\ENQ\EOT\f\STX\EOT\SOH\DC2\EOT\226\EOT\DLE\SUB\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\EOT\ETX\DC2\EOT\200\EOT\GS\RS\n\
+    \\ENQ\EOT\f\STX\EOT\ETX\DC2\EOT\226\EOT\GS\RS\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\EOT\b\DC2\EOT\200\EOT\US.\n\
+    \\ENQ\EOT\f\STX\EOT\b\DC2\EOT\226\EOT\US0\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\EOT\a\DC2\EOT\200\EOT(-\n\
+    \\ENQ\EOT\f\STX\EOT\a\DC2\EOT\226\EOT*/\n\
     \?\n\
-    \\EOT\EOT\f\STX\ENQ\DC2\EOT\203\EOT\STX*\SUB1 For Google-internal migration only. Do not use.\n\
+    \\EOT\EOT\f\STX\ENQ\DC2\EOT\229\EOT\STX,\SUB1 For Google-internal migration only. Do not use.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ENQ\EOT\DC2\EOT\203\EOT\STX\n\
+    \\ENQ\EOT\f\STX\ENQ\EOT\DC2\EOT\229\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ENQ\ENQ\DC2\EOT\203\EOT\v\SI\n\
+    \\ENQ\EOT\f\STX\ENQ\ENQ\DC2\EOT\229\EOT\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ENQ\SOH\DC2\EOT\203\EOT\DLE\DC4\n\
+    \\ENQ\EOT\f\STX\ENQ\SOH\DC2\EOT\229\EOT\DLE\DC4\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ENQ\ETX\DC2\EOT\203\EOT\ETB\EM\n\
+    \\ENQ\EOT\f\STX\ENQ\ETX\DC2\EOT\229\EOT\ETB\EM\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ENQ\b\DC2\EOT\203\EOT\SUB)\n\
+    \\ENQ\EOT\f\STX\ENQ\b\DC2\EOT\229\EOT\SUB+\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ENQ\a\DC2\EOT\203\EOT#(\n\
+    \\ENQ\EOT\f\STX\ENQ\a\DC2\EOT\229\EOT%*\n\
     \O\n\
-    \\EOT\EOT\f\STX\ACK\DC2\EOT\207\EOT\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\EOT\EOT\f\STX\ACK\DC2\EOT\233\EOT\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ACK\EOT\DC2\EOT\207\EOT\STX\n\
+    \\ENQ\EOT\f\STX\ACK\EOT\DC2\EOT\233\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ACK\ACK\DC2\EOT\207\EOT\v\RS\n\
+    \\ENQ\EOT\f\STX\ACK\ACK\DC2\EOT\233\EOT\v\RS\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ACK\SOH\DC2\EOT\207\EOT\US3\n\
+    \\ENQ\EOT\f\STX\ACK\SOH\DC2\EOT\233\EOT\US3\n\
     \\r\n\
-    \\ENQ\EOT\f\STX\ACK\ETX\DC2\EOT\207\EOT69\n\
+    \\ENQ\EOT\f\STX\ACK\ETX\DC2\EOT\233\EOT69\n\
     \Z\n\
-    \\ETX\EOT\f\ENQ\DC2\EOT\210\EOT\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\ETX\EOT\f\ENQ\DC2\EOT\236\EOT\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\f\ENQ\NUL\DC2\EOT\210\EOT\r\CAN\n\
+    \\EOT\EOT\f\ENQ\NUL\DC2\EOT\236\EOT\r\CAN\n\
     \\r\n\
-    \\ENQ\EOT\f\ENQ\NUL\SOH\DC2\EOT\210\EOT\r\DC1\n\
+    \\ENQ\EOT\f\ENQ\NUL\SOH\DC2\EOT\236\EOT\r\DC1\n\
     \\r\n\
-    \\ENQ\EOT\f\ENQ\NUL\STX\DC2\EOT\210\EOT\NAK\CAN\n\
+    \\ENQ\EOT\f\ENQ\NUL\STX\DC2\EOT\236\EOT\NAK\CAN\n\
     \\FS\n\
-    \\ETX\EOT\f\t\DC2\EOT\212\EOT\v\r\"\SI removed jtype\n\
+    \\ETX\EOT\f\t\DC2\EOT\238\EOT\STX\r\"\SI removed jtype\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\f\t\NUL\DC2\EOT\212\EOT\v\f\n\
+    \\EOT\EOT\f\t\NUL\DC2\EOT\238\EOT\v\f\n\
     \\r\n\
-    \\ENQ\EOT\f\t\NUL\SOH\DC2\EOT\212\EOT\v\f\n\
+    \\ENQ\EOT\f\t\NUL\SOH\DC2\EOT\238\EOT\v\f\n\
     \\r\n\
-    \\ENQ\EOT\f\t\NUL\STX\DC2\EOT\212\EOT\v\f\n\
+    \\ENQ\EOT\f\t\NUL\STX\DC2\EOT\238\EOT\v\f\n\
     \\f\n\
-    \\STX\EOT\r\DC2\ACK\215\EOT\NUL\221\EOT\SOH\n\
+    \\STX\EOT\r\DC2\ACK\241\EOT\NUL\247\EOT\SOH\n\
     \\v\n\
-    \\ETX\EOT\r\SOH\DC2\EOT\215\EOT\b\DC4\n\
+    \\ETX\EOT\r\SOH\DC2\EOT\241\EOT\b\DC4\n\
     \O\n\
-    \\EOT\EOT\r\STX\NUL\DC2\EOT\217\EOT\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\EOT\EOT\r\STX\NUL\DC2\EOT\243\EOT\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\r\STX\NUL\EOT\DC2\EOT\217\EOT\STX\n\
+    \\ENQ\EOT\r\STX\NUL\EOT\DC2\EOT\243\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\r\STX\NUL\ACK\DC2\EOT\217\EOT\v\RS\n\
+    \\ENQ\EOT\r\STX\NUL\ACK\DC2\EOT\243\EOT\v\RS\n\
     \\r\n\
-    \\ENQ\EOT\r\STX\NUL\SOH\DC2\EOT\217\EOT\US3\n\
+    \\ENQ\EOT\r\STX\NUL\SOH\DC2\EOT\243\EOT\US3\n\
     \\r\n\
-    \\ENQ\EOT\r\STX\NUL\ETX\DC2\EOT\217\EOT69\n\
+    \\ENQ\EOT\r\STX\NUL\ETX\DC2\EOT\243\EOT69\n\
     \Z\n\
-    \\ETX\EOT\r\ENQ\DC2\EOT\220\EOT\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\ETX\EOT\r\ENQ\DC2\EOT\246\EOT\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\r\ENQ\NUL\DC2\EOT\220\EOT\r\CAN\n\
+    \\EOT\EOT\r\ENQ\NUL\DC2\EOT\246\EOT\r\CAN\n\
     \\r\n\
-    \\ENQ\EOT\r\ENQ\NUL\SOH\DC2\EOT\220\EOT\r\DC1\n\
+    \\ENQ\EOT\r\ENQ\NUL\SOH\DC2\EOT\246\EOT\r\DC1\n\
     \\r\n\
-    \\ENQ\EOT\r\ENQ\NUL\STX\DC2\EOT\220\EOT\NAK\CAN\n\
+    \\ENQ\EOT\r\ENQ\NUL\STX\DC2\EOT\246\EOT\NAK\CAN\n\
     \\f\n\
-    \\STX\EOT\SO\DC2\ACK\223\EOT\NUL\242\EOT\SOH\n\
+    \\STX\EOT\SO\DC2\ACK\249\EOT\NUL\140\ENQ\SOH\n\
     \\v\n\
-    \\ETX\EOT\SO\SOH\DC2\EOT\223\EOT\b\DC3\n\
+    \\ETX\EOT\SO\SOH\DC2\EOT\249\EOT\b\DC3\n\
     \`\n\
-    \\EOT\EOT\SO\STX\NUL\DC2\EOT\227\EOT\STX \SUBR Set this option to true to allow mapping different tag names to the same\n\
+    \\EOT\EOT\SO\STX\NUL\DC2\EOT\253\EOT\STX \SUBR Set this option to true to allow mapping different tag names to the same\n\
     \ value.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\NUL\EOT\DC2\EOT\227\EOT\STX\n\
+    \\ENQ\EOT\SO\STX\NUL\EOT\DC2\EOT\253\EOT\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\NUL\ENQ\DC2\EOT\227\EOT\v\SI\n\
+    \\ENQ\EOT\SO\STX\NUL\ENQ\DC2\EOT\253\EOT\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\NUL\SOH\DC2\EOT\227\EOT\DLE\ESC\n\
+    \\ENQ\EOT\SO\STX\NUL\SOH\DC2\EOT\253\EOT\DLE\ESC\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\NUL\ETX\DC2\EOT\227\EOT\RS\US\n\
+    \\ENQ\EOT\SO\STX\NUL\ETX\DC2\EOT\253\EOT\RS\US\n\
     \\229\SOH\n\
-    \\EOT\EOT\SO\STX\SOH\DC2\EOT\233\EOT\STX/\SUB\214\SOH Is this enum deprecated?\n\
+    \\EOT\EOT\SO\STX\SOH\DC2\EOT\131\ENQ\STX1\SUB\214\SOH Is this enum deprecated?\n\
     \ Depending on the target platform, this can emit Deprecated annotations\n\
     \ for the enum, or it will be completely ignored; in the very least, this\n\
     \ is a formalization for deprecating enums.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\SOH\EOT\DC2\EOT\233\EOT\STX\n\
+    \\ENQ\EOT\SO\STX\SOH\EOT\DC2\EOT\131\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\SOH\ENQ\DC2\EOT\233\EOT\v\SI\n\
+    \\ENQ\EOT\SO\STX\SOH\ENQ\DC2\EOT\131\ENQ\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\SOH\SOH\DC2\EOT\233\EOT\DLE\SUB\n\
+    \\ENQ\EOT\SO\STX\SOH\SOH\DC2\EOT\131\ENQ\DLE\SUB\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\SOH\ETX\DC2\EOT\233\EOT\GS\RS\n\
+    \\ENQ\EOT\SO\STX\SOH\ETX\DC2\EOT\131\ENQ\GS\RS\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\SOH\b\DC2\EOT\233\EOT\US.\n\
+    \\ENQ\EOT\SO\STX\SOH\b\DC2\EOT\131\ENQ\US0\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\SOH\a\DC2\EOT\233\EOT(-\n\
+    \\ENQ\EOT\SO\STX\SOH\a\DC2\EOT\131\ENQ*/\n\
     \\US\n\
-    \\ETX\EOT\SO\t\DC2\EOT\235\EOT\v\r\"\DC2 javanano_as_lite\n\
+    \\ETX\EOT\SO\t\DC2\EOT\133\ENQ\STX\r\"\DC2 javanano_as_lite\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\SO\t\NUL\DC2\EOT\235\EOT\v\f\n\
+    \\EOT\EOT\SO\t\NUL\DC2\EOT\133\ENQ\v\f\n\
     \\r\n\
-    \\ENQ\EOT\SO\t\NUL\SOH\DC2\EOT\235\EOT\v\f\n\
+    \\ENQ\EOT\SO\t\NUL\SOH\DC2\EOT\133\ENQ\v\f\n\
     \\r\n\
-    \\ENQ\EOT\SO\t\NUL\STX\DC2\EOT\235\EOT\v\f\n\
+    \\ENQ\EOT\SO\t\NUL\STX\DC2\EOT\133\ENQ\v\f\n\
     \O\n\
-    \\EOT\EOT\SO\STX\STX\DC2\EOT\238\EOT\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\EOT\EOT\SO\STX\STX\DC2\EOT\136\ENQ\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\STX\EOT\DC2\EOT\238\EOT\STX\n\
+    \\ENQ\EOT\SO\STX\STX\EOT\DC2\EOT\136\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\STX\ACK\DC2\EOT\238\EOT\v\RS\n\
+    \\ENQ\EOT\SO\STX\STX\ACK\DC2\EOT\136\ENQ\v\RS\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\STX\SOH\DC2\EOT\238\EOT\US3\n\
+    \\ENQ\EOT\SO\STX\STX\SOH\DC2\EOT\136\ENQ\US3\n\
     \\r\n\
-    \\ENQ\EOT\SO\STX\STX\ETX\DC2\EOT\238\EOT69\n\
+    \\ENQ\EOT\SO\STX\STX\ETX\DC2\EOT\136\ENQ69\n\
     \Z\n\
-    \\ETX\EOT\SO\ENQ\DC2\EOT\241\EOT\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\ETX\EOT\SO\ENQ\DC2\EOT\139\ENQ\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\SO\ENQ\NUL\DC2\EOT\241\EOT\r\CAN\n\
+    \\EOT\EOT\SO\ENQ\NUL\DC2\EOT\139\ENQ\r\CAN\n\
     \\r\n\
-    \\ENQ\EOT\SO\ENQ\NUL\SOH\DC2\EOT\241\EOT\r\DC1\n\
+    \\ENQ\EOT\SO\ENQ\NUL\SOH\DC2\EOT\139\ENQ\r\DC1\n\
     \\r\n\
-    \\ENQ\EOT\SO\ENQ\NUL\STX\DC2\EOT\241\EOT\NAK\CAN\n\
+    \\ENQ\EOT\SO\ENQ\NUL\STX\DC2\EOT\139\ENQ\NAK\CAN\n\
     \\f\n\
-    \\STX\EOT\SI\DC2\ACK\244\EOT\NUL\128\ENQ\SOH\n\
+    \\STX\EOT\SI\DC2\ACK\142\ENQ\NUL\154\ENQ\SOH\n\
     \\v\n\
-    \\ETX\EOT\SI\SOH\DC2\EOT\244\EOT\b\CAN\n\
+    \\ETX\EOT\SI\SOH\DC2\EOT\142\ENQ\b\CAN\n\
     \\247\SOH\n\
-    \\EOT\EOT\SI\STX\NUL\DC2\EOT\249\EOT\STX/\SUB\232\SOH Is this enum value deprecated?\n\
+    \\EOT\EOT\SI\STX\NUL\DC2\EOT\147\ENQ\STX1\SUB\232\SOH Is this enum value deprecated?\n\
     \ Depending on the target platform, this can emit Deprecated annotations\n\
     \ for the enum value, or it will be completely ignored; in the very least,\n\
     \ this is a formalization for deprecating enum values.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\SI\STX\NUL\EOT\DC2\EOT\249\EOT\STX\n\
+    \\ENQ\EOT\SI\STX\NUL\EOT\DC2\EOT\147\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\SI\STX\NUL\ENQ\DC2\EOT\249\EOT\v\SI\n\
+    \\ENQ\EOT\SI\STX\NUL\ENQ\DC2\EOT\147\ENQ\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\SI\STX\NUL\SOH\DC2\EOT\249\EOT\DLE\SUB\n\
+    \\ENQ\EOT\SI\STX\NUL\SOH\DC2\EOT\147\ENQ\DLE\SUB\n\
     \\r\n\
-    \\ENQ\EOT\SI\STX\NUL\ETX\DC2\EOT\249\EOT\GS\RS\n\
+    \\ENQ\EOT\SI\STX\NUL\ETX\DC2\EOT\147\ENQ\GS\RS\n\
     \\r\n\
-    \\ENQ\EOT\SI\STX\NUL\b\DC2\EOT\249\EOT\US.\n\
+    \\ENQ\EOT\SI\STX\NUL\b\DC2\EOT\147\ENQ\US0\n\
     \\r\n\
-    \\ENQ\EOT\SI\STX\NUL\a\DC2\EOT\249\EOT(-\n\
+    \\ENQ\EOT\SI\STX\NUL\a\DC2\EOT\147\ENQ*/\n\
     \O\n\
-    \\EOT\EOT\SI\STX\SOH\DC2\EOT\252\EOT\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\EOT\EOT\SI\STX\SOH\DC2\EOT\150\ENQ\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\SI\STX\SOH\EOT\DC2\EOT\252\EOT\STX\n\
+    \\ENQ\EOT\SI\STX\SOH\EOT\DC2\EOT\150\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\SI\STX\SOH\ACK\DC2\EOT\252\EOT\v\RS\n\
+    \\ENQ\EOT\SI\STX\SOH\ACK\DC2\EOT\150\ENQ\v\RS\n\
     \\r\n\
-    \\ENQ\EOT\SI\STX\SOH\SOH\DC2\EOT\252\EOT\US3\n\
+    \\ENQ\EOT\SI\STX\SOH\SOH\DC2\EOT\150\ENQ\US3\n\
     \\r\n\
-    \\ENQ\EOT\SI\STX\SOH\ETX\DC2\EOT\252\EOT69\n\
+    \\ENQ\EOT\SI\STX\SOH\ETX\DC2\EOT\150\ENQ69\n\
     \Z\n\
-    \\ETX\EOT\SI\ENQ\DC2\EOT\255\EOT\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\ETX\EOT\SI\ENQ\DC2\EOT\153\ENQ\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\SI\ENQ\NUL\DC2\EOT\255\EOT\r\CAN\n\
+    \\EOT\EOT\SI\ENQ\NUL\DC2\EOT\153\ENQ\r\CAN\n\
     \\r\n\
-    \\ENQ\EOT\SI\ENQ\NUL\SOH\DC2\EOT\255\EOT\r\DC1\n\
+    \\ENQ\EOT\SI\ENQ\NUL\SOH\DC2\EOT\153\ENQ\r\DC1\n\
     \\r\n\
-    \\ENQ\EOT\SI\ENQ\NUL\STX\DC2\EOT\255\EOT\NAK\CAN\n\
+    \\ENQ\EOT\SI\ENQ\NUL\STX\DC2\EOT\153\ENQ\NAK\CAN\n\
     \\f\n\
-    \\STX\EOT\DLE\DC2\ACK\130\ENQ\NUL\148\ENQ\SOH\n\
+    \\STX\EOT\DLE\DC2\ACK\156\ENQ\NUL\174\ENQ\SOH\n\
     \\v\n\
-    \\ETX\EOT\DLE\SOH\DC2\EOT\130\ENQ\b\SYN\n\
+    \\ETX\EOT\DLE\SOH\DC2\EOT\156\ENQ\b\SYN\n\
     \\217\ETX\n\
-    \\EOT\EOT\DLE\STX\NUL\DC2\EOT\141\ENQ\STX0\SUB\223\SOH Is this service deprecated?\n\
+    \\EOT\EOT\DLE\STX\NUL\DC2\EOT\167\ENQ\STX2\SUB\223\SOH Is this service deprecated?\n\
     \ Depending on the target platform, this can emit Deprecated annotations\n\
     \ for the service, or it will be completely ignored; in the very least,\n\
     \ this is a formalization for deprecating services.\n\
@@ -12695,45 +12720,45 @@ packedFileDescriptor
     \   Buffers.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DLE\STX\NUL\EOT\DC2\EOT\141\ENQ\STX\n\
+    \\ENQ\EOT\DLE\STX\NUL\EOT\DC2\EOT\167\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DLE\STX\NUL\ENQ\DC2\EOT\141\ENQ\v\SI\n\
+    \\ENQ\EOT\DLE\STX\NUL\ENQ\DC2\EOT\167\ENQ\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\DLE\STX\NUL\SOH\DC2\EOT\141\ENQ\DLE\SUB\n\
+    \\ENQ\EOT\DLE\STX\NUL\SOH\DC2\EOT\167\ENQ\DLE\SUB\n\
     \\r\n\
-    \\ENQ\EOT\DLE\STX\NUL\ETX\DC2\EOT\141\ENQ\GS\US\n\
+    \\ENQ\EOT\DLE\STX\NUL\ETX\DC2\EOT\167\ENQ\GS\US\n\
     \\r\n\
-    \\ENQ\EOT\DLE\STX\NUL\b\DC2\EOT\141\ENQ /\n\
+    \\ENQ\EOT\DLE\STX\NUL\b\DC2\EOT\167\ENQ 1\n\
     \\r\n\
-    \\ENQ\EOT\DLE\STX\NUL\a\DC2\EOT\141\ENQ).\n\
+    \\ENQ\EOT\DLE\STX\NUL\a\DC2\EOT\167\ENQ+0\n\
     \O\n\
-    \\EOT\EOT\DLE\STX\SOH\DC2\EOT\144\ENQ\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\EOT\EOT\DLE\STX\SOH\DC2\EOT\170\ENQ\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DLE\STX\SOH\EOT\DC2\EOT\144\ENQ\STX\n\
+    \\ENQ\EOT\DLE\STX\SOH\EOT\DC2\EOT\170\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DLE\STX\SOH\ACK\DC2\EOT\144\ENQ\v\RS\n\
+    \\ENQ\EOT\DLE\STX\SOH\ACK\DC2\EOT\170\ENQ\v\RS\n\
     \\r\n\
-    \\ENQ\EOT\DLE\STX\SOH\SOH\DC2\EOT\144\ENQ\US3\n\
+    \\ENQ\EOT\DLE\STX\SOH\SOH\DC2\EOT\170\ENQ\US3\n\
     \\r\n\
-    \\ENQ\EOT\DLE\STX\SOH\ETX\DC2\EOT\144\ENQ69\n\
+    \\ENQ\EOT\DLE\STX\SOH\ETX\DC2\EOT\170\ENQ69\n\
     \Z\n\
-    \\ETX\EOT\DLE\ENQ\DC2\EOT\147\ENQ\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\ETX\EOT\DLE\ENQ\DC2\EOT\173\ENQ\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\DLE\ENQ\NUL\DC2\EOT\147\ENQ\r\CAN\n\
+    \\EOT\EOT\DLE\ENQ\NUL\DC2\EOT\173\ENQ\r\CAN\n\
     \\r\n\
-    \\ENQ\EOT\DLE\ENQ\NUL\SOH\DC2\EOT\147\ENQ\r\DC1\n\
+    \\ENQ\EOT\DLE\ENQ\NUL\SOH\DC2\EOT\173\ENQ\r\DC1\n\
     \\r\n\
-    \\ENQ\EOT\DLE\ENQ\NUL\STX\DC2\EOT\147\ENQ\NAK\CAN\n\
+    \\ENQ\EOT\DLE\ENQ\NUL\STX\DC2\EOT\173\ENQ\NAK\CAN\n\
     \\f\n\
-    \\STX\EOT\DC1\DC2\ACK\150\ENQ\NUL\179\ENQ\SOH\n\
+    \\STX\EOT\DC1\DC2\ACK\176\ENQ\NUL\205\ENQ\SOH\n\
     \\v\n\
-    \\ETX\EOT\DC1\SOH\DC2\EOT\150\ENQ\b\NAK\n\
+    \\ETX\EOT\DC1\SOH\DC2\EOT\176\ENQ\b\NAK\n\
     \\214\ETX\n\
-    \\EOT\EOT\DC1\STX\NUL\DC2\EOT\161\ENQ\STX0\SUB\220\SOH Is this method deprecated?\n\
+    \\EOT\EOT\DC1\STX\NUL\DC2\EOT\187\ENQ\STX2\SUB\220\SOH Is this method deprecated?\n\
     \ Depending on the target platform, this can emit Deprecated annotations\n\
     \ for the method, or it will be completely ignored; in the very least,\n\
     \ this is a formalization for deprecating methods.\n\
@@ -12743,83 +12768,83 @@ packedFileDescriptor
     \   Buffers.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\NUL\EOT\DC2\EOT\161\ENQ\STX\n\
+    \\ENQ\EOT\DC1\STX\NUL\EOT\DC2\EOT\187\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\NUL\ENQ\DC2\EOT\161\ENQ\v\SI\n\
+    \\ENQ\EOT\DC1\STX\NUL\ENQ\DC2\EOT\187\ENQ\v\SI\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\NUL\SOH\DC2\EOT\161\ENQ\DLE\SUB\n\
+    \\ENQ\EOT\DC1\STX\NUL\SOH\DC2\EOT\187\ENQ\DLE\SUB\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\NUL\ETX\DC2\EOT\161\ENQ\GS\US\n\
+    \\ENQ\EOT\DC1\STX\NUL\ETX\DC2\EOT\187\ENQ\GS\US\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\NUL\b\DC2\EOT\161\ENQ /\n\
+    \\ENQ\EOT\DC1\STX\NUL\b\DC2\EOT\187\ENQ 1\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\NUL\a\DC2\EOT\161\ENQ).\n\
+    \\ENQ\EOT\DC1\STX\NUL\a\DC2\EOT\187\ENQ+0\n\
     \\240\SOH\n\
-    \\EOT\EOT\DC1\EOT\NUL\DC2\ACK\166\ENQ\STX\170\ENQ\ETX\SUB\223\SOH Is this method side-effect-free (or safe in HTTP parlance), or idempotent,\n\
+    \\EOT\EOT\DC1\EOT\NUL\DC2\ACK\192\ENQ\STX\196\ENQ\ETX\SUB\223\SOH Is this method side-effect-free (or safe in HTTP parlance), or idempotent,\n\
     \ or neither? HTTP based RPC implementation may choose GET verb for safe\n\
     \ methods, and PUT verb for idempotent methods instead of the default POST.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC1\EOT\NUL\SOH\DC2\EOT\166\ENQ\a\ETB\n\
+    \\ENQ\EOT\DC1\EOT\NUL\SOH\DC2\EOT\192\ENQ\a\ETB\n\
     \\SO\n\
-    \\ACK\EOT\DC1\EOT\NUL\STX\NUL\DC2\EOT\167\ENQ\EOT\FS\n\
+    \\ACK\EOT\DC1\EOT\NUL\STX\NUL\DC2\EOT\193\ENQ\EOT\FS\n\
     \\SI\n\
-    \\a\EOT\DC1\EOT\NUL\STX\NUL\SOH\DC2\EOT\167\ENQ\EOT\ETB\n\
+    \\a\EOT\DC1\EOT\NUL\STX\NUL\SOH\DC2\EOT\193\ENQ\EOT\ETB\n\
     \\SI\n\
-    \\a\EOT\DC1\EOT\NUL\STX\NUL\STX\DC2\EOT\167\ENQ\SUB\ESC\n\
+    \\a\EOT\DC1\EOT\NUL\STX\NUL\STX\DC2\EOT\193\ENQ\SUB\ESC\n\
     \$\n\
-    \\ACK\EOT\DC1\EOT\NUL\STX\SOH\DC2\EOT\168\ENQ\EOT\FS\"\DC4 implies idempotent\n\
+    \\ACK\EOT\DC1\EOT\NUL\STX\SOH\DC2\EOT\194\ENQ\EOT\CAN\"\DC4 implies idempotent\n\
     \\n\
     \\SI\n\
-    \\a\EOT\DC1\EOT\NUL\STX\SOH\SOH\DC2\EOT\168\ENQ\EOT\DC3\n\
+    \\a\EOT\DC1\EOT\NUL\STX\SOH\SOH\DC2\EOT\194\ENQ\EOT\DC3\n\
     \\SI\n\
-    \\a\EOT\DC1\EOT\NUL\STX\SOH\STX\DC2\EOT\168\ENQ\SUB\ESC\n\
+    \\a\EOT\DC1\EOT\NUL\STX\SOH\STX\DC2\EOT\194\ENQ\SYN\ETB\n\
     \7\n\
-    \\ACK\EOT\DC1\EOT\NUL\STX\STX\DC2\EOT\169\ENQ\EOT\FS\"' idempotent, but may have side effects\n\
+    \\ACK\EOT\DC1\EOT\NUL\STX\STX\DC2\EOT\195\ENQ\EOT\DC3\"' idempotent, but may have side effects\n\
     \\n\
     \\SI\n\
-    \\a\EOT\DC1\EOT\NUL\STX\STX\SOH\DC2\EOT\169\ENQ\EOT\SO\n\
+    \\a\EOT\DC1\EOT\NUL\STX\STX\SOH\DC2\EOT\195\ENQ\EOT\SO\n\
     \\SI\n\
-    \\a\EOT\DC1\EOT\NUL\STX\STX\STX\DC2\EOT\169\ENQ\SUB\ESC\n\
+    \\a\EOT\DC1\EOT\NUL\STX\STX\STX\DC2\EOT\195\ENQ\DC1\DC2\n\
     \\SO\n\
-    \\EOT\EOT\DC1\STX\SOH\DC2\ACK\171\ENQ\STX\172\ENQ'\n\
+    \\EOT\EOT\DC1\STX\SOH\DC2\ACK\197\ENQ\STX\198\ENQ&\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\SOH\EOT\DC2\EOT\171\ENQ\STX\n\
+    \\ENQ\EOT\DC1\STX\SOH\EOT\DC2\EOT\197\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\SOH\ACK\DC2\EOT\171\ENQ\v\ESC\n\
+    \\ENQ\EOT\DC1\STX\SOH\ACK\DC2\EOT\197\ENQ\v\ESC\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\SOH\SOH\DC2\EOT\171\ENQ\FS-\n\
+    \\ENQ\EOT\DC1\STX\SOH\SOH\DC2\EOT\197\ENQ\FS-\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\SOH\ETX\DC2\EOT\172\ENQ\ACK\b\n\
+    \\ENQ\EOT\DC1\STX\SOH\ETX\DC2\EOT\197\ENQ02\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\SOH\b\DC2\EOT\172\ENQ\t&\n\
+    \\ENQ\EOT\DC1\STX\SOH\b\DC2\EOT\198\ENQ\ACK%\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\SOH\a\DC2\EOT\172\ENQ\DC2%\n\
+    \\ENQ\EOT\DC1\STX\SOH\a\DC2\EOT\198\ENQ\DC1$\n\
     \O\n\
-    \\EOT\EOT\DC1\STX\STX\DC2\EOT\175\ENQ\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
+    \\EOT\EOT\DC1\STX\STX\DC2\EOT\201\ENQ\STX:\SUBA The parser stores options it doesn't recognize here. See above.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\STX\EOT\DC2\EOT\175\ENQ\STX\n\
+    \\ENQ\EOT\DC1\STX\STX\EOT\DC2\EOT\201\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\STX\ACK\DC2\EOT\175\ENQ\v\RS\n\
+    \\ENQ\EOT\DC1\STX\STX\ACK\DC2\EOT\201\ENQ\v\RS\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\STX\SOH\DC2\EOT\175\ENQ\US3\n\
+    \\ENQ\EOT\DC1\STX\STX\SOH\DC2\EOT\201\ENQ\US3\n\
     \\r\n\
-    \\ENQ\EOT\DC1\STX\STX\ETX\DC2\EOT\175\ENQ69\n\
+    \\ENQ\EOT\DC1\STX\STX\ETX\DC2\EOT\201\ENQ69\n\
     \Z\n\
-    \\ETX\EOT\DC1\ENQ\DC2\EOT\178\ENQ\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
+    \\ETX\EOT\DC1\ENQ\DC2\EOT\204\ENQ\STX\EM\SUBM Clients can define custom options in extensions of this message. See above.\n\
     \\n\
     \\f\n\
-    \\EOT\EOT\DC1\ENQ\NUL\DC2\EOT\178\ENQ\r\CAN\n\
+    \\EOT\EOT\DC1\ENQ\NUL\DC2\EOT\204\ENQ\r\CAN\n\
     \\r\n\
-    \\ENQ\EOT\DC1\ENQ\NUL\SOH\DC2\EOT\178\ENQ\r\DC1\n\
+    \\ENQ\EOT\DC1\ENQ\NUL\SOH\DC2\EOT\204\ENQ\r\DC1\n\
     \\r\n\
-    \\ENQ\EOT\DC1\ENQ\NUL\STX\DC2\EOT\178\ENQ\NAK\CAN\n\
+    \\ENQ\EOT\DC1\ENQ\NUL\STX\DC2\EOT\204\ENQ\NAK\CAN\n\
     \\139\ETX\n\
-    \\STX\EOT\DC2\DC2\ACK\188\ENQ\NUL\208\ENQ\SOH\SUB\252\STX A message representing a option the parser does not recognize. This only\n\
+    \\STX\EOT\DC2\DC2\ACK\214\ENQ\NUL\234\ENQ\SOH\SUB\252\STX A message representing a option the parser does not recognize. This only\n\
     \ appears in options protos created by the compiler::Parser class.\n\
     \ DescriptorPool resolves these when building Descriptor objects. Therefore,\n\
     \ options protos in descriptor objects (e.g. returned by Descriptor::options(),\n\
@@ -12827,126 +12852,126 @@ packedFileDescriptor
     \ in them.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\DC2\SOH\DC2\EOT\188\ENQ\b\ESC\n\
+    \\ETX\EOT\DC2\SOH\DC2\EOT\214\ENQ\b\ESC\n\
     \\203\STX\n\
-    \\EOT\EOT\DC2\ETX\NUL\DC2\ACK\194\ENQ\STX\197\ENQ\ETX\SUB\186\STX The name of the uninterpreted option.  Each string represents a segment in\n\
+    \\EOT\EOT\DC2\ETX\NUL\DC2\ACK\220\ENQ\STX\223\ENQ\ETX\SUB\186\STX The name of the uninterpreted option.  Each string represents a segment in\n\
     \ a dot-separated name.  is_extension is true iff a segment represents an\n\
     \ extension (denoted with parentheses in options specs in .proto files).\n\
     \ E.g.,{ [\"foo\", false], [\"bar.baz\", true], [\"qux\", false] } represents\n\
     \ \"foo.(bar.baz).qux\".\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC2\ETX\NUL\SOH\DC2\EOT\194\ENQ\n\
+    \\ENQ\EOT\DC2\ETX\NUL\SOH\DC2\EOT\220\ENQ\n\
     \\DC2\n\
     \\SO\n\
-    \\ACK\EOT\DC2\ETX\NUL\STX\NUL\DC2\EOT\195\ENQ\EOT\"\n\
+    \\ACK\EOT\DC2\ETX\NUL\STX\NUL\DC2\EOT\221\ENQ\EOT\"\n\
     \\SI\n\
-    \\a\EOT\DC2\ETX\NUL\STX\NUL\EOT\DC2\EOT\195\ENQ\EOT\f\n\
+    \\a\EOT\DC2\ETX\NUL\STX\NUL\EOT\DC2\EOT\221\ENQ\EOT\f\n\
     \\SI\n\
-    \\a\EOT\DC2\ETX\NUL\STX\NUL\ENQ\DC2\EOT\195\ENQ\r\DC3\n\
+    \\a\EOT\DC2\ETX\NUL\STX\NUL\ENQ\DC2\EOT\221\ENQ\r\DC3\n\
     \\SI\n\
-    \\a\EOT\DC2\ETX\NUL\STX\NUL\SOH\DC2\EOT\195\ENQ\DC4\GS\n\
+    \\a\EOT\DC2\ETX\NUL\STX\NUL\SOH\DC2\EOT\221\ENQ\DC4\GS\n\
     \\SI\n\
-    \\a\EOT\DC2\ETX\NUL\STX\NUL\ETX\DC2\EOT\195\ENQ !\n\
+    \\a\EOT\DC2\ETX\NUL\STX\NUL\ETX\DC2\EOT\221\ENQ !\n\
     \\SO\n\
-    \\ACK\EOT\DC2\ETX\NUL\STX\SOH\DC2\EOT\196\ENQ\EOT#\n\
+    \\ACK\EOT\DC2\ETX\NUL\STX\SOH\DC2\EOT\222\ENQ\EOT#\n\
     \\SI\n\
-    \\a\EOT\DC2\ETX\NUL\STX\SOH\EOT\DC2\EOT\196\ENQ\EOT\f\n\
+    \\a\EOT\DC2\ETX\NUL\STX\SOH\EOT\DC2\EOT\222\ENQ\EOT\f\n\
     \\SI\n\
-    \\a\EOT\DC2\ETX\NUL\STX\SOH\ENQ\DC2\EOT\196\ENQ\r\DC1\n\
+    \\a\EOT\DC2\ETX\NUL\STX\SOH\ENQ\DC2\EOT\222\ENQ\r\DC1\n\
     \\SI\n\
-    \\a\EOT\DC2\ETX\NUL\STX\SOH\SOH\DC2\EOT\196\ENQ\DC2\RS\n\
+    \\a\EOT\DC2\ETX\NUL\STX\SOH\SOH\DC2\EOT\222\ENQ\DC2\RS\n\
     \\SI\n\
-    \\a\EOT\DC2\ETX\NUL\STX\SOH\ETX\DC2\EOT\196\ENQ!\"\n\
+    \\a\EOT\DC2\ETX\NUL\STX\SOH\ETX\DC2\EOT\222\ENQ!\"\n\
     \\f\n\
-    \\EOT\EOT\DC2\STX\NUL\DC2\EOT\198\ENQ\STX\GS\n\
+    \\EOT\EOT\DC2\STX\NUL\DC2\EOT\224\ENQ\STX\GS\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\NUL\EOT\DC2\EOT\198\ENQ\STX\n\
+    \\ENQ\EOT\DC2\STX\NUL\EOT\DC2\EOT\224\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\NUL\ACK\DC2\EOT\198\ENQ\v\DC3\n\
+    \\ENQ\EOT\DC2\STX\NUL\ACK\DC2\EOT\224\ENQ\v\DC3\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\NUL\SOH\DC2\EOT\198\ENQ\DC4\CAN\n\
+    \\ENQ\EOT\DC2\STX\NUL\SOH\DC2\EOT\224\ENQ\DC4\CAN\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\NUL\ETX\DC2\EOT\198\ENQ\ESC\FS\n\
+    \\ENQ\EOT\DC2\STX\NUL\ETX\DC2\EOT\224\ENQ\ESC\FS\n\
     \\156\SOH\n\
-    \\EOT\EOT\DC2\STX\SOH\DC2\EOT\202\ENQ\STX'\SUB\141\SOH The value of the uninterpreted option, in whatever type the tokenizer\n\
+    \\EOT\EOT\DC2\STX\SOH\DC2\EOT\228\ENQ\STX'\SUB\141\SOH The value of the uninterpreted option, in whatever type the tokenizer\n\
     \ identified it as during parsing. Exactly one of these should be set.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\SOH\EOT\DC2\EOT\202\ENQ\STX\n\
+    \\ENQ\EOT\DC2\STX\SOH\EOT\DC2\EOT\228\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\SOH\ENQ\DC2\EOT\202\ENQ\v\DC1\n\
+    \\ENQ\EOT\DC2\STX\SOH\ENQ\DC2\EOT\228\ENQ\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\SOH\SOH\DC2\EOT\202\ENQ\DC2\"\n\
+    \\ENQ\EOT\DC2\STX\SOH\SOH\DC2\EOT\228\ENQ\DC2\"\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\SOH\ETX\DC2\EOT\202\ENQ%&\n\
+    \\ENQ\EOT\DC2\STX\SOH\ETX\DC2\EOT\228\ENQ%&\n\
     \\f\n\
-    \\EOT\EOT\DC2\STX\STX\DC2\EOT\203\ENQ\STX)\n\
+    \\EOT\EOT\DC2\STX\STX\DC2\EOT\229\ENQ\STX)\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\STX\EOT\DC2\EOT\203\ENQ\STX\n\
+    \\ENQ\EOT\DC2\STX\STX\EOT\DC2\EOT\229\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\STX\ENQ\DC2\EOT\203\ENQ\v\DC1\n\
+    \\ENQ\EOT\DC2\STX\STX\ENQ\DC2\EOT\229\ENQ\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\STX\SOH\DC2\EOT\203\ENQ\DC2$\n\
+    \\ENQ\EOT\DC2\STX\STX\SOH\DC2\EOT\229\ENQ\DC2$\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\STX\ETX\DC2\EOT\203\ENQ'(\n\
+    \\ENQ\EOT\DC2\STX\STX\ETX\DC2\EOT\229\ENQ'(\n\
     \\f\n\
-    \\EOT\EOT\DC2\STX\ETX\DC2\EOT\204\ENQ\STX(\n\
+    \\EOT\EOT\DC2\STX\ETX\DC2\EOT\230\ENQ\STX(\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ETX\EOT\DC2\EOT\204\ENQ\STX\n\
+    \\ENQ\EOT\DC2\STX\ETX\EOT\DC2\EOT\230\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ETX\ENQ\DC2\EOT\204\ENQ\v\DLE\n\
+    \\ENQ\EOT\DC2\STX\ETX\ENQ\DC2\EOT\230\ENQ\v\DLE\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ETX\SOH\DC2\EOT\204\ENQ\DC1#\n\
+    \\ENQ\EOT\DC2\STX\ETX\SOH\DC2\EOT\230\ENQ\DC1#\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ETX\ETX\DC2\EOT\204\ENQ&'\n\
+    \\ENQ\EOT\DC2\STX\ETX\ETX\DC2\EOT\230\ENQ&'\n\
     \\f\n\
-    \\EOT\EOT\DC2\STX\EOT\DC2\EOT\205\ENQ\STX#\n\
+    \\EOT\EOT\DC2\STX\EOT\DC2\EOT\231\ENQ\STX#\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\EOT\EOT\DC2\EOT\205\ENQ\STX\n\
+    \\ENQ\EOT\DC2\STX\EOT\EOT\DC2\EOT\231\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\EOT\ENQ\DC2\EOT\205\ENQ\v\DC1\n\
+    \\ENQ\EOT\DC2\STX\EOT\ENQ\DC2\EOT\231\ENQ\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\EOT\SOH\DC2\EOT\205\ENQ\DC2\RS\n\
+    \\ENQ\EOT\DC2\STX\EOT\SOH\DC2\EOT\231\ENQ\DC2\RS\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\EOT\ETX\DC2\EOT\205\ENQ!\"\n\
+    \\ENQ\EOT\DC2\STX\EOT\ETX\DC2\EOT\231\ENQ!\"\n\
     \\f\n\
-    \\EOT\EOT\DC2\STX\ENQ\DC2\EOT\206\ENQ\STX\"\n\
+    \\EOT\EOT\DC2\STX\ENQ\DC2\EOT\232\ENQ\STX\"\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ENQ\EOT\DC2\EOT\206\ENQ\STX\n\
+    \\ENQ\EOT\DC2\STX\ENQ\EOT\DC2\EOT\232\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ENQ\ENQ\DC2\EOT\206\ENQ\v\DLE\n\
+    \\ENQ\EOT\DC2\STX\ENQ\ENQ\DC2\EOT\232\ENQ\v\DLE\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ENQ\SOH\DC2\EOT\206\ENQ\DC1\GS\n\
+    \\ENQ\EOT\DC2\STX\ENQ\SOH\DC2\EOT\232\ENQ\DC1\GS\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ENQ\ETX\DC2\EOT\206\ENQ !\n\
+    \\ENQ\EOT\DC2\STX\ENQ\ETX\DC2\EOT\232\ENQ !\n\
     \\f\n\
-    \\EOT\EOT\DC2\STX\ACK\DC2\EOT\207\ENQ\STX&\n\
+    \\EOT\EOT\DC2\STX\ACK\DC2\EOT\233\ENQ\STX&\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ACK\EOT\DC2\EOT\207\ENQ\STX\n\
+    \\ENQ\EOT\DC2\STX\ACK\EOT\DC2\EOT\233\ENQ\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ACK\ENQ\DC2\EOT\207\ENQ\v\DC1\n\
+    \\ENQ\EOT\DC2\STX\ACK\ENQ\DC2\EOT\233\ENQ\v\DC1\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ACK\SOH\DC2\EOT\207\ENQ\DC2!\n\
+    \\ENQ\EOT\DC2\STX\ACK\SOH\DC2\EOT\233\ENQ\DC2!\n\
     \\r\n\
-    \\ENQ\EOT\DC2\STX\ACK\ETX\DC2\EOT\207\ENQ$%\n\
+    \\ENQ\EOT\DC2\STX\ACK\ETX\DC2\EOT\233\ENQ$%\n\
     \\218\SOH\n\
-    \\STX\EOT\DC3\DC2\ACK\215\ENQ\NUL\216\ACK\SOH\SUBj Encapsulates information about the original source file from which a\n\
+    \\STX\EOT\DC3\DC2\ACK\241\ENQ\NUL\242\ACK\SOH\SUBj Encapsulates information about the original source file from which a\n\
     \ FileDescriptorProto was generated.\n\
     \2` ===================================================================\n\
     \ Optional source code info\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\DC3\SOH\DC2\EOT\215\ENQ\b\SYN\n\
+    \\ETX\EOT\DC3\SOH\DC2\EOT\241\ENQ\b\SYN\n\
     \\130\DC1\n\
-    \\EOT\EOT\DC3\STX\NUL\DC2\EOT\131\ACK\STX!\SUB\243\DLE A Location identifies a piece of source code in a .proto file which\n\
+    \\EOT\EOT\DC3\STX\NUL\DC2\EOT\157\ACK\STX!\SUB\243\DLE A Location identifies a piece of source code in a .proto file which\n\
     \ corresponds to a particular definition.  This information is intended\n\
     \ to be useful to IDEs, code indexers, documentation generators, and similar\n\
     \ tools.\n\
@@ -12983,7 +13008,7 @@ packedFileDescriptor
     \   beginning of the \"extend\" block and is shared by all extensions within\n\
     \   the block.\n\
     \ - Just because a location's span is a subset of some other location's span\n\
-    \   does not mean that it is a descendent.  For example, a \"group\" defines\n\
+    \   does not mean that it is a descendant.  For example, a \"group\" defines\n\
     \   both a type and a field in a single declaration.  Thus, the locations\n\
     \   corresponding to the type and field and their components will overlap.\n\
     \ - Code which tries to interpret locations should probably be designed to\n\
@@ -12991,21 +13016,21 @@ packedFileDescriptor
     \   be recorded in the future.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC3\STX\NUL\EOT\DC2\EOT\131\ACK\STX\n\
+    \\ENQ\EOT\DC3\STX\NUL\EOT\DC2\EOT\157\ACK\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC3\STX\NUL\ACK\DC2\EOT\131\ACK\v\DC3\n\
+    \\ENQ\EOT\DC3\STX\NUL\ACK\DC2\EOT\157\ACK\v\DC3\n\
     \\r\n\
-    \\ENQ\EOT\DC3\STX\NUL\SOH\DC2\EOT\131\ACK\DC4\FS\n\
+    \\ENQ\EOT\DC3\STX\NUL\SOH\DC2\EOT\157\ACK\DC4\FS\n\
     \\r\n\
-    \\ENQ\EOT\DC3\STX\NUL\ETX\DC2\EOT\131\ACK\US \n\
+    \\ENQ\EOT\DC3\STX\NUL\ETX\DC2\EOT\157\ACK\US \n\
     \\SO\n\
-    \\EOT\EOT\DC3\ETX\NUL\DC2\ACK\132\ACK\STX\215\ACK\ETX\n\
+    \\EOT\EOT\DC3\ETX\NUL\DC2\ACK\158\ACK\STX\241\ACK\ETX\n\
     \\r\n\
-    \\ENQ\EOT\DC3\ETX\NUL\SOH\DC2\EOT\132\ACK\n\
+    \\ENQ\EOT\DC3\ETX\NUL\SOH\DC2\EOT\158\ACK\n\
     \\DC2\n\
     \\131\a\n\
-    \\ACK\EOT\DC3\ETX\NUL\STX\NUL\DC2\EOT\156\ACK\EOT*\SUB\242\ACK Identifies which part of the FileDescriptorProto was defined at this\n\
+    \\ACK\EOT\DC3\ETX\NUL\STX\NUL\DC2\EOT\182\ACK\EOT,\SUB\242\ACK Identifies which part of the FileDescriptorProto was defined at this\n\
     \ location.\n\
     \\n\
     \ Each element is a field number or an index.  They form a path from\n\
@@ -13030,56 +13055,38 @@ packedFileDescriptor
     \ of the label to the terminating semicolon).\n\
     \\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\NUL\EOT\DC2\EOT\156\ACK\EOT\f\n\
+    \\a\EOT\DC3\ETX\NUL\STX\NUL\EOT\DC2\EOT\182\ACK\EOT\f\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\NUL\ENQ\DC2\EOT\156\ACK\r\DC2\n\
+    \\a\EOT\DC3\ETX\NUL\STX\NUL\ENQ\DC2\EOT\182\ACK\r\DC2\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\NUL\SOH\DC2\EOT\156\ACK\DC3\ETB\n\
+    \\a\EOT\DC3\ETX\NUL\STX\NUL\SOH\DC2\EOT\182\ACK\DC3\ETB\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\NUL\ETX\DC2\EOT\156\ACK\SUB\ESC\n\
+    \\a\EOT\DC3\ETX\NUL\STX\NUL\ETX\DC2\EOT\182\ACK\SUB\ESC\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\NUL\b\DC2\EOT\156\ACK\FS)\n\
-    \\DC2\n\
-    \\n\
-    \\EOT\DC3\ETX\NUL\STX\NUL\b\231\a\NUL\DC2\EOT\156\ACK\GS(\n\
-    \\DC3\n\
-    \\v\EOT\DC3\ETX\NUL\STX\NUL\b\231\a\NUL\STX\DC2\EOT\156\ACK\GS#\n\
-    \\DC4\n\
-    \\f\EOT\DC3\ETX\NUL\STX\NUL\b\231\a\NUL\STX\NUL\DC2\EOT\156\ACK\GS#\n\
-    \\NAK\n\
-    \\r\EOT\DC3\ETX\NUL\STX\NUL\b\231\a\NUL\STX\NUL\SOH\DC2\EOT\156\ACK\GS#\n\
-    \\DC3\n\
-    \\v\EOT\DC3\ETX\NUL\STX\NUL\b\231\a\NUL\ETX\DC2\EOT\156\ACK$(\n\
+    \\a\EOT\DC3\ETX\NUL\STX\NUL\b\DC2\EOT\182\ACK\FS+\n\
+    \\DLE\n\
+    \\b\EOT\DC3\ETX\NUL\STX\NUL\b\STX\DC2\EOT\182\ACK\GS*\n\
     \\210\STX\n\
-    \\ACK\EOT\DC3\ETX\NUL\STX\SOH\DC2\EOT\163\ACK\EOT*\SUB\193\STX Always has exactly three or four elements: start line, start column,\n\
+    \\ACK\EOT\DC3\ETX\NUL\STX\SOH\DC2\EOT\189\ACK\EOT,\SUB\193\STX Always has exactly three or four elements: start line, start column,\n\
     \ end line (optional, otherwise assumed same as start line), end column.\n\
     \ These are packed into a single field for efficiency.  Note that line\n\
     \ and column numbers are zero-based -- typically you will want to add\n\
     \ 1 to each before displaying to a user.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\SOH\EOT\DC2\EOT\163\ACK\EOT\f\n\
+    \\a\EOT\DC3\ETX\NUL\STX\SOH\EOT\DC2\EOT\189\ACK\EOT\f\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\SOH\ENQ\DC2\EOT\163\ACK\r\DC2\n\
+    \\a\EOT\DC3\ETX\NUL\STX\SOH\ENQ\DC2\EOT\189\ACK\r\DC2\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\SOH\SOH\DC2\EOT\163\ACK\DC3\ETB\n\
+    \\a\EOT\DC3\ETX\NUL\STX\SOH\SOH\DC2\EOT\189\ACK\DC3\ETB\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\SOH\ETX\DC2\EOT\163\ACK\SUB\ESC\n\
+    \\a\EOT\DC3\ETX\NUL\STX\SOH\ETX\DC2\EOT\189\ACK\SUB\ESC\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\SOH\b\DC2\EOT\163\ACK\FS)\n\
-    \\DC2\n\
-    \\n\
-    \\EOT\DC3\ETX\NUL\STX\SOH\b\231\a\NUL\DC2\EOT\163\ACK\GS(\n\
-    \\DC3\n\
-    \\v\EOT\DC3\ETX\NUL\STX\SOH\b\231\a\NUL\STX\DC2\EOT\163\ACK\GS#\n\
-    \\DC4\n\
-    \\f\EOT\DC3\ETX\NUL\STX\SOH\b\231\a\NUL\STX\NUL\DC2\EOT\163\ACK\GS#\n\
-    \\NAK\n\
-    \\r\EOT\DC3\ETX\NUL\STX\SOH\b\231\a\NUL\STX\NUL\SOH\DC2\EOT\163\ACK\GS#\n\
-    \\DC3\n\
-    \\v\EOT\DC3\ETX\NUL\STX\SOH\b\231\a\NUL\ETX\DC2\EOT\163\ACK$(\n\
+    \\a\EOT\DC3\ETX\NUL\STX\SOH\b\DC2\EOT\189\ACK\FS+\n\
+    \\DLE\n\
+    \\b\EOT\DC3\ETX\NUL\STX\SOH\b\STX\DC2\EOT\189\ACK\GS*\n\
     \\165\f\n\
-    \\ACK\EOT\DC3\ETX\NUL\STX\STX\DC2\EOT\212\ACK\EOT)\SUB\148\f If this SourceCodeInfo represents a complete declaration, these are any\n\
+    \\ACK\EOT\DC3\ETX\NUL\STX\STX\DC2\EOT\238\ACK\EOT)\SUB\148\f If this SourceCodeInfo represents a complete declaration, these are any\n\
     \ comments appearing before and after the declaration which appear to be\n\
     \ attached to the declaration.\n\
     \\n\
@@ -13128,116 +13135,107 @@ packedFileDescriptor
     \   // ignored detached comments.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\STX\EOT\DC2\EOT\212\ACK\EOT\f\n\
+    \\a\EOT\DC3\ETX\NUL\STX\STX\EOT\DC2\EOT\238\ACK\EOT\f\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\STX\ENQ\DC2\EOT\212\ACK\r\DC3\n\
+    \\a\EOT\DC3\ETX\NUL\STX\STX\ENQ\DC2\EOT\238\ACK\r\DC3\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\STX\SOH\DC2\EOT\212\ACK\DC4$\n\
+    \\a\EOT\DC3\ETX\NUL\STX\STX\SOH\DC2\EOT\238\ACK\DC4$\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\STX\ETX\DC2\EOT\212\ACK'(\n\
+    \\a\EOT\DC3\ETX\NUL\STX\STX\ETX\DC2\EOT\238\ACK'(\n\
     \\SO\n\
-    \\ACK\EOT\DC3\ETX\NUL\STX\ETX\DC2\EOT\213\ACK\EOT*\n\
+    \\ACK\EOT\DC3\ETX\NUL\STX\ETX\DC2\EOT\239\ACK\EOT*\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\ETX\EOT\DC2\EOT\213\ACK\EOT\f\n\
+    \\a\EOT\DC3\ETX\NUL\STX\ETX\EOT\DC2\EOT\239\ACK\EOT\f\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\ETX\ENQ\DC2\EOT\213\ACK\r\DC3\n\
+    \\a\EOT\DC3\ETX\NUL\STX\ETX\ENQ\DC2\EOT\239\ACK\r\DC3\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\ETX\SOH\DC2\EOT\213\ACK\DC4%\n\
+    \\a\EOT\DC3\ETX\NUL\STX\ETX\SOH\DC2\EOT\239\ACK\DC4%\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\ETX\ETX\DC2\EOT\213\ACK()\n\
+    \\a\EOT\DC3\ETX\NUL\STX\ETX\ETX\DC2\EOT\239\ACK()\n\
     \\SO\n\
-    \\ACK\EOT\DC3\ETX\NUL\STX\EOT\DC2\EOT\214\ACK\EOT2\n\
+    \\ACK\EOT\DC3\ETX\NUL\STX\EOT\DC2\EOT\240\ACK\EOT2\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\EOT\EOT\DC2\EOT\214\ACK\EOT\f\n\
+    \\a\EOT\DC3\ETX\NUL\STX\EOT\EOT\DC2\EOT\240\ACK\EOT\f\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\EOT\ENQ\DC2\EOT\214\ACK\r\DC3\n\
+    \\a\EOT\DC3\ETX\NUL\STX\EOT\ENQ\DC2\EOT\240\ACK\r\DC3\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\EOT\SOH\DC2\EOT\214\ACK\DC4-\n\
+    \\a\EOT\DC3\ETX\NUL\STX\EOT\SOH\DC2\EOT\240\ACK\DC4-\n\
     \\SI\n\
-    \\a\EOT\DC3\ETX\NUL\STX\EOT\ETX\DC2\EOT\214\ACK01\n\
+    \\a\EOT\DC3\ETX\NUL\STX\EOT\ETX\DC2\EOT\240\ACK01\n\
     \\238\SOH\n\
-    \\STX\EOT\DC4\DC2\ACK\221\ACK\NUL\242\ACK\SOH\SUB\223\SOH Describes the relationship between generated code and its original source\n\
+    \\STX\EOT\DC4\DC2\ACK\247\ACK\NUL\140\a\SOH\SUB\223\SOH Describes the relationship between generated code and its original source\n\
     \ file. A GeneratedCodeInfo message is associated with only one generated\n\
     \ source file, but may contain references to different source .proto files.\n\
     \\n\
     \\v\n\
-    \\ETX\EOT\DC4\SOH\DC2\EOT\221\ACK\b\EM\n\
+    \\ETX\EOT\DC4\SOH\DC2\EOT\247\ACK\b\EM\n\
     \x\n\
-    \\EOT\EOT\DC4\STX\NUL\DC2\EOT\224\ACK\STX%\SUBj An Annotation connects some span of text in generated code to an element\n\
+    \\EOT\EOT\DC4\STX\NUL\DC2\EOT\250\ACK\STX%\SUBj An Annotation connects some span of text in generated code to an element\n\
     \ of its generating .proto file.\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC4\STX\NUL\EOT\DC2\EOT\224\ACK\STX\n\
+    \\ENQ\EOT\DC4\STX\NUL\EOT\DC2\EOT\250\ACK\STX\n\
     \\n\
     \\r\n\
-    \\ENQ\EOT\DC4\STX\NUL\ACK\DC2\EOT\224\ACK\v\NAK\n\
+    \\ENQ\EOT\DC4\STX\NUL\ACK\DC2\EOT\250\ACK\v\NAK\n\
     \\r\n\
-    \\ENQ\EOT\DC4\STX\NUL\SOH\DC2\EOT\224\ACK\SYN \n\
+    \\ENQ\EOT\DC4\STX\NUL\SOH\DC2\EOT\250\ACK\SYN \n\
     \\r\n\
-    \\ENQ\EOT\DC4\STX\NUL\ETX\DC2\EOT\224\ACK#$\n\
+    \\ENQ\EOT\DC4\STX\NUL\ETX\DC2\EOT\250\ACK#$\n\
     \\SO\n\
-    \\EOT\EOT\DC4\ETX\NUL\DC2\ACK\225\ACK\STX\241\ACK\ETX\n\
+    \\EOT\EOT\DC4\ETX\NUL\DC2\ACK\251\ACK\STX\139\a\ETX\n\
     \\r\n\
-    \\ENQ\EOT\DC4\ETX\NUL\SOH\DC2\EOT\225\ACK\n\
+    \\ENQ\EOT\DC4\ETX\NUL\SOH\DC2\EOT\251\ACK\n\
     \\DC4\n\
     \\143\SOH\n\
-    \\ACK\EOT\DC4\ETX\NUL\STX\NUL\DC2\EOT\228\ACK\EOT*\SUB\DEL Identifies the element in the original source .proto file. This field\n\
+    \\ACK\EOT\DC4\ETX\NUL\STX\NUL\DC2\EOT\254\ACK\EOT,\SUB\DEL Identifies the element in the original source .proto file. This field\n\
     \ is formatted the same as SourceCodeInfo.Location.path.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\NUL\EOT\DC2\EOT\228\ACK\EOT\f\n\
+    \\a\EOT\DC4\ETX\NUL\STX\NUL\EOT\DC2\EOT\254\ACK\EOT\f\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\NUL\ENQ\DC2\EOT\228\ACK\r\DC2\n\
+    \\a\EOT\DC4\ETX\NUL\STX\NUL\ENQ\DC2\EOT\254\ACK\r\DC2\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\NUL\SOH\DC2\EOT\228\ACK\DC3\ETB\n\
+    \\a\EOT\DC4\ETX\NUL\STX\NUL\SOH\DC2\EOT\254\ACK\DC3\ETB\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\NUL\ETX\DC2\EOT\228\ACK\SUB\ESC\n\
+    \\a\EOT\DC4\ETX\NUL\STX\NUL\ETX\DC2\EOT\254\ACK\SUB\ESC\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\NUL\b\DC2\EOT\228\ACK\FS)\n\
-    \\DC2\n\
-    \\n\
-    \\EOT\DC4\ETX\NUL\STX\NUL\b\231\a\NUL\DC2\EOT\228\ACK\GS(\n\
-    \\DC3\n\
-    \\v\EOT\DC4\ETX\NUL\STX\NUL\b\231\a\NUL\STX\DC2\EOT\228\ACK\GS#\n\
-    \\DC4\n\
-    \\f\EOT\DC4\ETX\NUL\STX\NUL\b\231\a\NUL\STX\NUL\DC2\EOT\228\ACK\GS#\n\
-    \\NAK\n\
-    \\r\EOT\DC4\ETX\NUL\STX\NUL\b\231\a\NUL\STX\NUL\SOH\DC2\EOT\228\ACK\GS#\n\
-    \\DC3\n\
-    \\v\EOT\DC4\ETX\NUL\STX\NUL\b\231\a\NUL\ETX\DC2\EOT\228\ACK$(\n\
+    \\a\EOT\DC4\ETX\NUL\STX\NUL\b\DC2\EOT\254\ACK\FS+\n\
+    \\DLE\n\
+    \\b\EOT\DC4\ETX\NUL\STX\NUL\b\STX\DC2\EOT\254\ACK\GS*\n\
     \O\n\
-    \\ACK\EOT\DC4\ETX\NUL\STX\SOH\DC2\EOT\231\ACK\EOT$\SUB? Identifies the filesystem path to the original source .proto.\n\
+    \\ACK\EOT\DC4\ETX\NUL\STX\SOH\DC2\EOT\129\a\EOT$\SUB? Identifies the filesystem path to the original source .proto.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\SOH\EOT\DC2\EOT\231\ACK\EOT\f\n\
+    \\a\EOT\DC4\ETX\NUL\STX\SOH\EOT\DC2\EOT\129\a\EOT\f\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\SOH\ENQ\DC2\EOT\231\ACK\r\DC3\n\
+    \\a\EOT\DC4\ETX\NUL\STX\SOH\ENQ\DC2\EOT\129\a\r\DC3\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\SOH\SOH\DC2\EOT\231\ACK\DC4\US\n\
+    \\a\EOT\DC4\ETX\NUL\STX\SOH\SOH\DC2\EOT\129\a\DC4\US\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\SOH\ETX\DC2\EOT\231\ACK\"#\n\
+    \\a\EOT\DC4\ETX\NUL\STX\SOH\ETX\DC2\EOT\129\a\"#\n\
     \w\n\
-    \\ACK\EOT\DC4\ETX\NUL\STX\STX\DC2\EOT\235\ACK\EOT\GS\SUBg Identifies the starting offset in bytes in the generated code\n\
+    \\ACK\EOT\DC4\ETX\NUL\STX\STX\DC2\EOT\133\a\EOT\GS\SUBg Identifies the starting offset in bytes in the generated code\n\
     \ that relates to the identified object.\n\
     \\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\STX\EOT\DC2\EOT\235\ACK\EOT\f\n\
+    \\a\EOT\DC4\ETX\NUL\STX\STX\EOT\DC2\EOT\133\a\EOT\f\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\STX\ENQ\DC2\EOT\235\ACK\r\DC2\n\
+    \\a\EOT\DC4\ETX\NUL\STX\STX\ENQ\DC2\EOT\133\a\r\DC2\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\STX\SOH\DC2\EOT\235\ACK\DC3\CAN\n\
+    \\a\EOT\DC4\ETX\NUL\STX\STX\SOH\DC2\EOT\133\a\DC3\CAN\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\STX\ETX\DC2\EOT\235\ACK\ESC\FS\n\
+    \\a\EOT\DC4\ETX\NUL\STX\STX\ETX\DC2\EOT\133\a\ESC\FS\n\
     \\219\SOH\n\
-    \\ACK\EOT\DC4\ETX\NUL\STX\ETX\DC2\EOT\240\ACK\EOT\ESC\SUB\202\SOH Identifies the ending offset in bytes in the generated code that\n\
+    \\ACK\EOT\DC4\ETX\NUL\STX\ETX\DC2\EOT\138\a\EOT\ESC\SUB\202\SOH Identifies the ending offset in bytes in the generated code that\n\
     \ relates to the identified offset. The end offset should be one past\n\
     \ the last relevant byte (so the length of the text = end - begin).\n\
     \\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\ETX\EOT\DC2\EOT\240\ACK\EOT\f\n\
+    \\a\EOT\DC4\ETX\NUL\STX\ETX\EOT\DC2\EOT\138\a\EOT\f\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\ETX\ENQ\DC2\EOT\240\ACK\r\DC2\n\
+    \\a\EOT\DC4\ETX\NUL\STX\ETX\ENQ\DC2\EOT\138\a\r\DC2\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\ETX\SOH\DC2\EOT\240\ACK\DC3\SYN\n\
+    \\a\EOT\DC4\ETX\NUL\STX\ETX\SOH\DC2\EOT\138\a\DC3\SYN\n\
     \\SI\n\
-    \\a\EOT\DC4\ETX\NUL\STX\ETX\ETX\DC2\EOT\240\ACK\EM\SUB"
+    \\a\EOT\DC4\ETX\NUL\STX\ETX\ETX\DC2\EOT\138\a\EM\SUB"

--- a/proto-lens-protoc/app/Proto/Google/Protobuf/Descriptor_Fields.hs
+++ b/proto-lens-protoc/app/Proto/Google/Protobuf/Descriptor_Fields.hs
@@ -557,6 +557,13 @@ maybe'positiveIntValue ::
   Lens.Family2.LensLike' f s a
 maybe'positiveIntValue
   = Data.ProtoLens.Field.field @"maybe'positiveIntValue"
+maybe'proto3Optional ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "maybe'proto3Optional" a) =>
+  Lens.Family2.LensLike' f s a
+maybe'proto3Optional
+  = Data.ProtoLens.Field.field @"maybe'proto3Optional"
 maybe'pyGenericServices ::
   forall f s a.
   (Prelude.Functor f,
@@ -774,6 +781,12 @@ positiveIntValue ::
    Data.ProtoLens.Field.HasField s "positiveIntValue" a) =>
   Lens.Family2.LensLike' f s a
 positiveIntValue = Data.ProtoLens.Field.field @"positiveIntValue"
+proto3Optional ::
+  forall f s a.
+  (Prelude.Functor f,
+   Data.ProtoLens.Field.HasField s "proto3Optional" a) =>
+  Lens.Family2.LensLike' f s a
+proto3Optional = Data.ProtoLens.Field.field @"proto3Optional"
 publicDependency ::
   forall f s a.
   (Prelude.Functor f,

--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -18,6 +18,7 @@ import Data.Semigroup ((<>))
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import Data.Text (Text, pack)
+import Data.Bits
 import Data.ProtoLens (defMessage, decodeMessage, encodeMessage)
 -- Force the use of the Reflected API when decoding DescriptorProto
 -- so that we can run the test suite against the Generated API.
@@ -27,6 +28,7 @@ import Lens.Family2
 import Proto.Google.Protobuf.Compiler.Plugin
     ( CodeGeneratorRequest
     , CodeGeneratorResponse
+    , CodeGeneratorResponse'Feature(..)
     )
 import Proto.Google.Protobuf.Descriptor (FileDescriptorProto)
 import System.Environment (getProgName)
@@ -63,7 +65,10 @@ makeResponse dflags prog request = let
     header f = "{- This file was auto-generated from "
                 <> (f ^. #name)
                 <> " by the " <> pack prog <> " program. -}\n"
+    features = [CodeGeneratorResponse'FEATURE_PROTO3_OPTIONAL]
     in defMessage
+           & #supportedFeatures .~
+               (foldl (.|.) zeroBits $ fmap (toEnum . fromEnum) features)
            & #file .~ [ defMessage
                             & #name .~ outputName
                             & #content .~ outputContent

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -105,6 +105,7 @@ tests:
     main: proto3_optional_test.hs
     source-dirs: tests
     dependencies:
+      - proto-lens-protobuf-types
       - proto-lens-tests
     generated-other-modules:
       - Proto.TestProto3Optional

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -101,6 +101,15 @@ tests:
       - Proto.Proto3
       - Proto.Proto3_Fields
 
+  proto3_optional_test:
+    main: proto3_optional_test.hs
+    source-dirs: tests
+    dependencies:
+      - proto-lens-tests
+    generated-other-modules:
+      - Proto.TestProto3Optional
+      - Proto.TestProto3Optional_Fields
+
   repeated_test:
     main: repeated_test.hs
     source-dirs: tests

--- a/proto-lens-tests/tests/proto3_optional_test.hs
+++ b/proto-lens-tests/tests/proto3_optional_test.hs
@@ -3,15 +3,28 @@
 -- Use of this source code is governed by a BSD-style
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Main (main) where
 
 import Proto.TestProto3Optional
 import Proto.TestProto3Optional_Fields
+import Data.Int
 import Data.ProtoLens
-import Lens.Family2 ((&), (.~), (^.))
+import Data.ProtoLens.Encoding.Parser (Parser, runParser)
+import Data.ProtoLens.Field (HasField, fieldOf)
+import Data.ProtoLens.Labels ()
+import Data.Proxy
+import Lens.Family2 ((&), (.~), (^.), (^..))
+import Lens.Family2.Unchecked (lens)
+import Proto.Google.Protobuf.Descriptor
 import Test.Tasty (testGroup)
-import Test.Tasty.HUnit (testCase, (@=?))
+import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
 
 import Data.ProtoLens.TestUtil
 
@@ -32,18 +45,81 @@ main = testMain
         , serializeTo "alternative-default" (defFoo & alternative .~ 0)
               (keyed "alternative" "0")
               $ tagged 3 $ VarInt 0
+        , serializeTo "tracked-unset"
+              (defFoo & tracked .~ 17 & maybe'tracked .~ Nothing)
+              "" mempty
         ]
     , testGroup "lens"
-        [ testCase "unset" $ defFoo ^. tracked @=? 0
-        , testCase "default" $ (defFoo & tracked .~ 0) ^. tracked @=? 0
+        [ testCase "unset" $ defFoo ^. tracked @?= 0
+        , testCase "default" $ (defFoo & tracked .~ 0) ^. tracked @?= 0
         ]
     , testGroup "maybe'lens"
-        [ testCase "unset" $ defFoo ^. maybe'tracked @=? Nothing
-        , testCase "default" $ (defFoo & tracked .~ 0) ^. maybe'tracked
-          @=? Just 0
+        [ testCase "unset" $ defFoo ^. maybe'tracked @?= Nothing
+        , testCase "default"
+          $ (defFoo & tracked .~ 0) ^. maybe'tracked @?= Just 0
         ]
-    -- TODO(gagern): Check that the generated file doesn't contain
-    -- code for a oneof. Not sure what the best way is to do this.
+    , testCase "oneof-names" $ do
+        -- Ensure that the defined oneofs (synthetic and actual) have
+        -- the expected names, since the tests for absence of oneof
+        -- API depend on this assumption.
+        let descBytes = packedMessageDescriptor (Proxy :: Proxy Foo)
+        let parser = parseMessage :: Parser DescriptorProto
+        let descEither = runParser parser descBytes
+        desc <- case descEither of
+          Left err -> assertFailure err
+          Right desc -> return desc
+        desc ^.. #oneofDecl . traverse . #name @?= ["_nonsynth", "_tracked"]
+    , testGroup "compile-time"
+        -- These tests tend to verify the ABSENCE of some API. They do
+        -- so at compile time, by forcing a name conflict if the API
+        -- in question were present. See definitions below these
+        -- tests. The tests here exercise the definitions to trigger
+        -- the conflict reporting. They should never fail at run-time.
+        [ testCase "maybe-untracked" $ defFoo ^. #maybe'untracked @?= Nothing
+        , testCase "maybe-tracked" $ defFoo ^. #maybe'tracked @?= Nothing
+        , testCase "maybe-_tracked" $ defFoo ^. #maybe'_tracked @?= Nothing
+        , testCase "maybe-_nonsynth" $ defFoo ^. #maybe'_nonsynth @?= Nothing
+        , testCase "data-tracked" $ discard (Proxy :: Proxy Foo'_tracked)
+        , testCase "data-nonsynth" $ discard (Proxy :: Proxy Foo'_nonsynth)
+        , testCase "ctor-tracked" $ discard (Foo'Alternative 1)
+        , testCase "ctor-nonsynth" $ discard (Foo'Tracked 1)
+        ]
     ]
 
+-- Like the discard from Control.Monad.Extra.
+discard :: Monad m => a -> m ()
+discard _ = return ()
 
+-- The code below establishes conflicts with things that should NOT
+-- have been generated. Most of them come with a matching definition
+-- for something that we DO expect to be generated. By enabling the
+-- #if for each block you can verify those actually lead to the
+-- expected conflicts.
+--
+-- TODO(gagern): Come up with a way to run these comparisons
+-- automatically, i.e. invoke Haskell compiler as part of test.
+
+-- We should not generate a maybe lens for a non-optional field.
+instance HasField Foo "maybe'untracked" (Maybe ()) where
+    fieldOf _ = lens (const Nothing) const
+#if 0
+-- We should generate a maybe lens for an optional field.
+instance HasField Foo "maybe'tracked" (Maybe ()) where
+    fieldOf _ = lens (const Nothing) const
+#endif
+
+-- We should not generate a maybe lens for a synthetic oneof.
+instance HasField Foo "maybe'_tracked" (Maybe ()) where
+    fieldOf _ = lens (const Nothing) const
+#if 0
+-- We should not generate a maybe lens for an actual oneof.
+instance HasField Foo "maybe'_nonsynth" (Maybe ()) where
+    fieldOf _ = lens (const Nothing) const
+#endif
+
+-- We should not generate a data type or constructor for the synthetic oneof.
+data Foo'_tracked = Foo'Tracked Int32
+#if 0
+-- We should generate a data type and constructor for the actual oneof.
+data Foo'_nonsynth = Foo'Alternative Int32
+#endif

--- a/proto-lens-tests/tests/proto3_optional_test.hs
+++ b/proto-lens-tests/tests/proto3_optional_test.hs
@@ -1,0 +1,49 @@
+-- Copyright 2020 Google Inc. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+
+import Proto.TestProto3Optional
+import Proto.TestProto3Optional_Fields
+import Data.ProtoLens
+import Lens.Family2 ((&), (.~), (^.))
+import Test.Tasty (testGroup)
+import Test.Tasty.HUnit (testCase, (@=?))
+
+import Data.ProtoLens.TestUtil
+
+defFoo :: Foo
+defFoo = defMessage
+
+main :: IO ()
+main = testMain
+    [ testGroup "serialize"
+        [ serializeTo "unset" defFoo "" mempty
+        , serializeTo "tracked-default" (defFoo & tracked .~ 0)
+              (keyed "tracked" "0")
+              $ tagged 2 $ VarInt 0
+        , serializeTo "tracked-nondefault" (defFoo & tracked .~ 17)
+              (keyed "tracked" "17")
+              $ tagged 2 $ VarInt 17
+        , serializeTo "untracked-default" (defFoo & untracked .~ 0) "" mempty
+        , serializeTo "alternative-default" (defFoo & alternative .~ 0)
+              (keyed "alternative" "0")
+              $ tagged 3 $ VarInt 0
+        ]
+    , testGroup "lens"
+        [ testCase "unset" $ defFoo ^. tracked @=? 0
+        , testCase "default" $ (defFoo & tracked .~ 0) ^. tracked @=? 0
+        ]
+    , testGroup "maybe'lens"
+        [ testCase "unset" $ defFoo ^. maybe'tracked @=? Nothing
+        , testCase "default" $ (defFoo & tracked .~ 0) ^. maybe'tracked
+          @=? Just 0
+        ]
+    -- TODO(gagern): Check that the generated file doesn't contain
+    -- code for a oneof. Not sure what the best way is to do this.
+    ]
+
+

--- a/proto-lens-tests/tests/test_proto3_optional.proto
+++ b/proto-lens-tests/tests/test_proto3_optional.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package proto3_optional;
+
+message Foo {
+  int32 untracked = 1;
+  optional int32 tracked = 2;
+  oneof nonsynth {
+    int32 alternative = 3;
+  }
+}

--- a/proto-lens-tests/tests/test_proto3_optional.proto
+++ b/proto-lens-tests/tests/test_proto3_optional.proto
@@ -5,7 +5,7 @@ package proto3_optional;
 message Foo {
   int32 untracked = 1;
   optional int32 tracked = 2;
-  oneof nonsynth {
+  oneof _nonsynth {
     int32 alternative = 3;
   }
 }


### PR DESCRIPTION
Fixes #380 following [instructions](https://github.com/protocolbuffers/protobuf/blob/e2cc2de/docs/implementing_proto3_presence.md) recommended in https://github.com/google/proto-lens/issues/380#issuecomment-619569960.

The main change here is to take the proto3 descriptor message but convert it to an internal representation more in line with what we'd generate for proto2. We treat the field as an `OptionalMaybeField` and drop the synthetic `oneof`. The serialization already works out of the box, since a `oneof` member is converted into an `OptionalMaybeField` as well.

For this to work, the descriptor proto needs to be updated to include the `FieldDescriptorProto.proto3_optional` field. We also need the `FEATURE_PROTO3_OPTIONAL` enum constant available so this plugin can tell `protoc` that it does support the new feature.