### PR TITLE
fix source directory in person tutorial

### DIFF
--- a/proto-lens-tutorial/person/README.md
+++ b/proto-lens-tutorial/person/README.md
@@ -123,7 +123,7 @@ Then, we'll put it in an `executable` section to `package.yaml` that specifies i
 executables:
   person:
     main: Main.hs
-    source-dirs: '.'
+    source-dirs: 'src'
     dependencies:
       - base
       - person


### PR DESCRIPTION
in the package.yml snipped given in the Readme of the person tutorial,
the build directory was set to ".", which will fail with a Main.hs created
in the `src` directory (as described in the tutorial).

The actual code in the same directory appears to be fine.

(just noticed this while trying to follow the tutorial)