### PR TITLE
Support all valid text format boolean field values

### DIFF
--- a/proto-lens-tests/tests/text_format.proto
+++ b/proto-lens-tests/tests/text_format.proto
@@ -24,3 +24,7 @@ message AnyHolder {
   }
   optional Sub sub = 2;
 }
+
+message Booleans {
+  repeated bool a_bool = 1;
+}

--- a/proto-lens-tests/tests/text_format_test.hs
+++ b/proto-lens-tests/tests/text_format_test.hs
@@ -33,6 +33,9 @@ def2 = defMessage
 def3 :: AnyHolder
 def3 = defMessage
 
+defBooleans :: Booleans
+defBooleans = defMessage
+
 failed1 :: Maybe Test1
 failed1 = Nothing
 
@@ -53,6 +56,19 @@ main = testMain
     , readFrom "bracesColon" (Just $ def2 & c.a .~ 5) "c: {  a: 5\n}"
     , readFrom "angles" (Just $ def2 & c.a .~ 5) "c < a: 5 >"
     , readFrom "anglesMultiLine" (Just $ def2 & c.a .~ 5) "c \n<  a: 5\n>"
+    , readFrom "booleans"
+               (Just $ defBooleans & aBool .~
+                 [True, True, True, True, False, False, False, False])
+               (Data.Text.Lazy.unlines
+                 [ "a_bool: 1"
+                 , "a_bool: true"
+                 , "a_bool: True"
+                 , "a_bool: t"
+                 , "a_bool: 0"
+                 , "a_bool: false"
+                 , "a_bool: False"
+                 , "a_bool: f"
+                 ])
     -- TODO: Note that this test currently fails either way since
     -- extensions aren't implemented yet.  Keeping it around to make
     -- sure the test case still fails when they are.

--- a/proto-lens/src/Data/ProtoLens/TextFormat.hs
+++ b/proto-lens/src/Data/ProtoLens/TextFormat.hs
@@ -317,8 +317,8 @@ makeScalarValue BoolField (Parser.IntValue x)
 makeScalarValue DoubleField (Parser.DoubleValue x) = Right x
 makeScalarValue FloatField (Parser.DoubleValue x) = Right (realToFrac x)
 makeScalarValue BoolField (Parser.EnumValue x)
-    | x == "true" = Right True
-    | x == "false" = Right False
+    | x `elem` ["true", "True", "t"] = Right True
+    | x `elem` ["false", "False", "f"] = Right False
     | otherwise = Left $ "Unrecognized bool value " ++ show x
 makeScalarValue StringField (Parser.ByteStringValue x) = Right (Text.decodeUtf8 x)
 makeScalarValue BytesField (Parser.ByteStringValue x) = Right x


### PR DESCRIPTION
I'm not sure the text format is exactly "standardized", but this is the set supported by the official C++ parser (see #410).

Fixes #410 