### PR TITLE
Fixed parsing of UTF8 chars in text format proto string literals.

### DIFF
--- a/proto-lens-tests/tests/text_format_test.hs
+++ b/proto-lens-tests/tests/text_format_test.hs
@@ -47,6 +47,7 @@ main = testMain
     [ readFrom "spaces" (Just $ def1 & a .~ 5) "  a: \n5  "
     , readFrom "string concat" (Just $ def1 & b .~ "abcdef")
           "b: \"a\"\"bcd\" \n   \"ef\""
+    , readFrom "unicode" (Just $ def1 & b .~ "** † **") "b: \"** † **\""
     , readFrom "bad char" failed1 "a: 5="
     , readFrom "same line" (Just $ def1 & d .~ [1, 2, 3])
           "d: 1 d: 2    d: 3   "

--- a/proto-lens/src/Data/ProtoLens/TextFormat/Parser.hs
+++ b/proto-lens/src/Data/ProtoLens/TextFormat/Parser.hs
@@ -157,11 +157,13 @@ protoStringLiteral = do
     manyN _ (_, 0) = return []
     manyN p (0, max) = ((:) <$> p <*> manyN p (0, max - 1)) <|> pure []
     manyN p (min, max) = (:) <$> p <*> manyN p (min - 1, max - 1)
+
     -- | Parse a number in 'base' with between 'min' and 'max' digits.
     parseNum :: Parser Char -> Int -> (Int, Int) -> Parser Int
     parseNum p base range = do
       digits <- map digitToInt <$> manyN p range
       return $ foldl (\a d -> a * base + d) 0 digits
+
     -- | Parse a number and return a builder for the 8-bit char it represents.
     parse8BitToBuilder :: Parser Char -> Int -> (Int, Int) -> Parser Builder
     parse8BitToBuilder p base range = do


### PR DESCRIPTION
Parsing of UTF8 in string literals was broken.  See #418 

The current behavior is not 100% compatible with C++, but this at least expands the set of parseable messages.