### PR TITLE
Fixed stack-9.0.yaml

### DIFF
--- a/stack-9.0.yaml
+++ b/stack-9.0.yaml
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-resolver: nightly
+resolver: nightly-2021-10-07
 packages:
 - discrimination-ieee754
 - proto-lens
@@ -19,15 +19,5 @@ packages:
 - proto-lens-tests
 - proto-lens-tests-dep
 
-flags:
-  cassava:
-    bytestring--lt-0_10_4: false
-
-extra-deps:
-  - github: google/ghc-source-gen
-    commit: c0a451bddf2f467e5d6598563d11abbf890e9034
-
 ghc-options:
   "$locals": -Wall -Werror
-
-allow-newer: true


### PR DESCRIPTION
- nightly resolver needs full name with date
- cassava is not a dependency of any of the packages, though an indirect
  dependency. In any case, the removed cassava flag is not applicable because
  nightly-2021-10-07 has bytestring-0.10.12.1.
- ghc-source-gen is in nightly-2021-10-07 so extra-deps is unnecessary
- allow-newer is unnecessary