### PR TITLE
Bump some bounds for ghc-9.2.2 compatibility

### DIFF
--- a/matrix.yaml
+++ b/matrix.yaml
@@ -21,10 +21,10 @@ build:
     compiler: ghc-8.8.4
     stackyaml: stack-8.8.yaml
 
-  - resolver: nightly
-    compiler: ghc-9.0.1
+  - resolver: lts-19.2
+    compiler: ghc-9.0.2
     stackyaml: stack-9.0.yaml
 
   - resolver: nightly
-    compiler: ghc-9.2.1
+    compiler: ghc-9.2.2
     stackyaml: stack-9.2.yaml

--- a/proto-lens-optparse/Changelog.md
+++ b/proto-lens-optparse/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-optparse`
 
+## v0.1.1.8
+- Bump some bounds for ghc-9.2.2 compatibility.
+
 ## v0.1.1.7
 - Bump upper bound to allow base-4.14.
 

--- a/proto-lens-optparse/package.yaml
+++ b/proto-lens-optparse/package.yaml
@@ -17,8 +17,8 @@ extra-source-files:
 dependencies:
   - proto-lens >= 0.1 && < 0.8
   - base >= 4.10 && < 4.17
-  - optparse-applicative >= 0.13 && < 0.17
-  - text == 1.2.*
+  - optparse-applicative >= 0.13 && < 0.18
+  - text >= 1.2 && < 2.1
 
 library:
   source-dirs: src

--- a/proto-lens-optparse/proto-lens-optparse.cabal
+++ b/proto-lens-optparse/proto-lens-optparse.cabal
@@ -34,7 +34,7 @@ library
       src
   build-depends:
       base >=4.10 && <4.17
-    , optparse-applicative >=0.13 && <0.17
+    , optparse-applicative >=0.13 && <0.18
     , proto-lens >=0.1 && <0.8
-    , text ==1.2.*
+    , text >=1.2 && <2.1
   default-language: Haskell2010

--- a/stack-9.0.yaml
+++ b/stack-9.0.yaml
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-resolver: nightly-2021-10-07
+resolver: lts-19.2
 packages:
 - discrimination-ieee754
 - proto-lens

--- a/stack-9.2.yaml
+++ b/stack-9.2.yaml
@@ -4,8 +4,8 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-resolver: nightly-2021-11-28
-compiler: ghc-9.2.1
+resolver: nightly-2022-04-04
+compiler: ghc-9.2.2
 
 packages:
 - discrimination-ieee754
@@ -20,14 +20,6 @@ packages:
 - proto-lens-setup
 - proto-lens-tests
 - proto-lens-tests-dep
-
-extra-deps:
-- aeson-2.0.2.0
-- attoparsec-0.14.2
-- base-compat-0.12.1
-- base-compat-batteries-0.12.1
-- github: google/ghc-source-gen
-  commit: f6b9130d8f384be0ef7a02b371870d532090ccb6
 
 ghc-options:
   "$locals": -Wall -Werror


### PR DESCRIPTION
The relevant yaml file no longer has to enumerate extra-deps.