### PR TITLE
Relax text bounds to allow text-2.0

### DIFF
--- a/proto-lens-arbitrary/Changelog.md
+++ b/proto-lens-arbitrary/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-arbitrary`
 
+## v0.1.2.10
+- Relax upper bounds for ghc-9.2
+
 ## v0.1.2.9
 - Bump upper bound to allow base-4.14.
 

--- a/proto-lens-arbitrary/package.yaml
+++ b/proto-lens-arbitrary/package.yaml
@@ -18,7 +18,7 @@ dependencies:
   - base >= 4.10 && < 4.17
   - bytestring >= 0.10 && < 0.12
   - containers >= 0.5 && < 0.7
-  - text == 1.2.*
+  - text >= 1.2 && < 2.1
   - lens-family >= 1.2 && < 2.2
   - QuickCheck >= 2.8 && < 2.15
 

--- a/proto-lens-arbitrary/proto-lens-arbitrary.cabal
+++ b/proto-lens-arbitrary/proto-lens-arbitrary.cabal
@@ -39,5 +39,5 @@ library
     , containers >=0.5 && <0.7
     , lens-family >=1.2 && <2.2
     , proto-lens >=0.4 && <0.8
-    , text ==1.2.*
+    , text >=1.2 && <2.1
   default-language: Haskell2010

--- a/proto-lens-discrimination/package.yaml
+++ b/proto-lens-discrimination/package.yaml
@@ -30,7 +30,7 @@ dependencies:
   - discrimination-ieee754 == 0.1.*
   - lens-family >= 1.2 && < 2.2
   - proto-lens >= 0.6 && < 0.8
-  - text == 1.2.*
+  - text >= 1.2 && < 2.1
 
 library:
   source-dirs: src

--- a/proto-lens-discrimination/proto-lens-discrimination.cabal
+++ b/proto-lens-discrimination/proto-lens-discrimination.cabal
@@ -52,7 +52,7 @@ library
     , discrimination-ieee754 ==0.1.*
     , lens-family >=1.2 && <2.2
     , proto-lens >=0.6 && <0.8
-    , text ==1.2.*
+    , text >=1.2 && <2.1
   default-language: Haskell2010
 
 test-suite discrimination_test
@@ -90,5 +90,5 @@ test-suite discrimination_test
     , test-framework ==0.8.*
     , test-framework-hunit ==0.3.*
     , test-framework-quickcheck2 ==0.3.*
-    , text ==1.2.*
+    , text >=1.2 && <2.1
   default-language: Haskell2010

--- a/proto-lens-protobuf-types/Changelog.md
+++ b/proto-lens-protobuf-types/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-protobuf-types`
 
+## v0.7.1.1
+- Relax upper bounds for ghc-9.2
+
 ## v0.7.1.0
 - Support GHC 9.0.
 - Add ServiceDescriptor to generated services (#409)

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-protobuf-types
-version: '0.7.1.0'
+version: '0.7.1.1'
 synopsis: Basic protocol buffer message types.
 description: >
   This package provides bindings standard protocol message types,
@@ -33,7 +33,7 @@ dependencies:
   - lens-family >= 1.2 && < 2.2
   - proto-lens == 0.7.*
   - proto-lens-runtime == 0.7.*
-  - text == 1.2.*
+  - text >= 1.2 && < 2.1
 
 library:
   source-dirs: src

--- a/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
+++ b/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           proto-lens-protobuf-types
-version:        0.7.1.0
+version:        0.7.1.1
 synopsis:       Basic protocol buffer message types.
 description:    This package provides bindings standard protocol message types, for use with the proto-lens library.
 category:       Data
@@ -80,5 +80,5 @@ library
     , lens-family >=1.2 && <2.2
     , proto-lens ==0.7.*
     , proto-lens-runtime ==0.7.*
-    , text ==1.2.*
+    , text >=1.2 && <2.1
   default-language: Haskell2010

--- a/proto-lens-protoc/Changelog.md
+++ b/proto-lens-protoc/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-protoc`
 
+## v0.7.1.1
+- Relax upper bounds for ghc-9.2
+
 ## v0.7.1.0
 - Support GHC 9.0.
 - Add ServiceDescriptor to generated services. (#409)

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-protoc
-version: '0.7.1.0'
+version: '0.7.1.1'
 synopsis: Protocol buffer compiler for the proto-lens library.
 description: >
   Turn protocol buffer files (.proto) into Haskell files (.hs) which
@@ -40,4 +40,4 @@ executables:
       - proto-lens == 0.7.*
       - proto-lens-protoc
       - proto-lens-runtime == 0.7.*
-      - text == 1.2.*
+      - text >= 1.2 && < 2.1

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           proto-lens-protoc
-version:        0.7.1.0
+version:        0.7.1.1
 synopsis:       Protocol buffer compiler for the proto-lens library.
 description:    Turn protocol buffer files (.proto) into Haskell files (.hs) which can be used with the proto-lens package.
                 The library component of this package contains compiler code (namely Data.ProtoLens.Compiler.*) is not guaranteed to have stable APIs.'
@@ -67,5 +67,5 @@ executable proto-lens-protoc
     , proto-lens ==0.7.*
     , proto-lens-protoc
     , proto-lens-runtime ==0.7.*
-    , text ==1.2.*
+    , text >=1.2 && <2.1
   default-language: Haskell2010

--- a/proto-lens-runtime/Changelog.md
+++ b/proto-lens-runtime/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-runtime`
 
+## v0.7.0.1
+- Relax upper bounds for ghc-9.2
+
 ## v0.7.0.0
 - Bump upper bound to allow base-4.14.
 

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -23,7 +23,7 @@ library:
     - filepath >= 1.4 && < 1.6
     - lens-family >= 1.2 && < 2.2
     - proto-lens == 0.7.*
-    - text == 1.2.*
+    - text >= 1.2 && < 2.1
     - vector >= 0.11 && < 0.13
 
 

--- a/proto-lens-runtime/proto-lens-runtime.cabal
+++ b/proto-lens-runtime/proto-lens-runtime.cabal
@@ -60,6 +60,6 @@ library
     , filepath >=1.4 && <1.6
     , lens-family >=1.2 && <2.2
     , proto-lens ==0.7.*
-    , text ==1.2.*
+    , text >=1.2 && <2.1
     , vector >=0.11 && <0.13
   default-language: Haskell2010

--- a/proto-lens-setup/Changelog.md
+++ b/proto-lens-setup/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-setup`
 
+## v0.4.0.5
+- Relax upper bounds for ghc-9.2
+
 ## v0.4.0.4
 - Bump upper bound to allow base-4.14.
 - Bump upper bound to allow Cabal-3.2.

--- a/proto-lens-setup/package.yaml
+++ b/proto-lens-setup/package.yaml
@@ -63,7 +63,7 @@ library:
     # make this a build-tool dependency.
     - proto-lens-protoc >= 0.4 && < 0.8
     - temporary >= 1.2 && < 1.4
-    - text == 1.2.*
+    - text >= 1.2 && < 2.1
   exposed-modules:
     - Data.ProtoLens.Setup
 

--- a/proto-lens-setup/proto-lens-setup.cabal
+++ b/proto-lens-setup/proto-lens-setup.cabal
@@ -78,5 +78,5 @@ library
     , process >=1.2 && <1.7
     , proto-lens-protoc >=0.4 && <0.8
     , temporary >=1.2 && <1.4
-    , text ==1.2.*
+    , text >=1.2 && <2.1
   default-language: Haskell2010

--- a/proto-lens/Changelog.md
+++ b/proto-lens/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog for `proto-lens`
 
+
+## v0.7.1.1
+- Relax upper bounds for ghc-9.2
+
 ## v0.7.1.0
 - Support GHC 9.0.
 - Fixed parsing of UTF8 chars in text format proto string literals.

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens
-version: "0.7.1.0"
+version: "0.7.1.1"
 synopsis: A lens-based implementation of protocol buffers in Haskell.
 description: >
   The proto-lens library provides an API for protocol buffers using modern
@@ -45,7 +45,7 @@ library:
     - primitive >= 0.6 && < 0.8
     - profunctors >= 5.2 && < 6.0
     - tagged == 0.8.*
-    - text == 1.2.*
+    - text >= 1.2 && < 2.1
     - transformers >= 0.4 && < 0.6
     - vector >= 0.11 && < 0.13
 

--- a/proto-lens/proto-lens.cabal
+++ b/proto-lens/proto-lens.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           proto-lens
-version:        0.7.1.0
+version:        0.7.1.1
 synopsis:       A lens-based implementation of protocol buffers in Haskell.
 description:    The proto-lens library provides an API for protocol buffers using modern Haskell language and library patterns.  Specifically, it provides:
                 .
@@ -69,7 +69,7 @@ library
     , primitive >=0.6 && <0.8
     , profunctors >=5.2 && <6.0
     , tagged ==0.8.*
-    , text ==1.2.*
+    , text >=1.2 && <2.1
     , transformers >=0.4 && <0.6
     , vector >=0.11 && <0.13
   default-language: Haskell2010


### PR DESCRIPTION
This was tested by using an explicit override with this diff:
```
--- a/stack-9.2.yaml
+++ b/stack-9.2.yaml
@@ -21,5 +21,10 @@ packages:
 - proto-lens-tests
 - proto-lens-tests-dep

+extra-deps:
+  - text-2.0
+  - Cabal-3.6.3.0@sha256:ff97c442b0c679c1c9876acd15f73ac4f602b973c45bde42b43ec28265ee48f4,12459
+  - parsec-3.1.15.0@sha256:a162d4cc8884014ba35192545cad293af0529fe11497aad8834bbaaa3dfffc26,4429
+
 ghc-options:
   "$locals": -Wall -Werror
```