### PR TITLE
Release proto-lens-protobuf-types-0.7.1.2

### DIFF
--- a/proto-lens-protobuf-types/Changelog.md
+++ b/proto-lens-protobuf-types/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog for `proto-lens-protobuf-types`
 
+## v0.7.1.2
+- Add protobuf struct types (#438)
+
 ## v0.7.1.1
 - Relax upper bounds for ghc-9.2
 

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -1,5 +1,5 @@
 name: proto-lens-protobuf-types
-version: '0.7.1.1'
+version: '0.7.1.2'
 synopsis: Basic protocol buffer message types.
 description: >
   This package provides bindings standard protocol message types,
@@ -62,5 +62,6 @@ library:
   # Otherwise, "cabal check" complains (preventing upload to Hackage)
   # because it expects it to be listed in autogen-modules.
   # For details, see https://github.com/sol/hpack/issues/303.
-  verbatim:
-    other-modules:
+  when:
+  - condition: false
+    other-modules: Paths_proto_lens_protobuf_types

--- a/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
+++ b/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
@@ -1,11 +1,11 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           proto-lens-protobuf-types
-version:        0.7.1.1
+version:        0.7.1.2
 synopsis:       Basic protocol buffer message types.
 description:    This package provides bindings standard protocol message types, for use with the proto-lens library.
 category:       Data


### PR DESCRIPTION
Minor tweaks to its package.yaml to work with newer hpack-0.35.