### PR TITLE
Allow GHC 9.4 (and CI) for `proto-lens` and `proto-lens-runtime`

### DIFF
--- a/.github/workflows/cabal-ci.yml
+++ b/.github/workflows/cabal-ci.yml
@@ -1,0 +1,19 @@
+on:
+  - push
+  - pull_request
+name: cabal build with ghc 9.4
+jobs:
+  runhaskell:
+    name: cabal test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: haskell/actions/setup@v2
+        with:
+          ghc-version: '9.4.2'
+          cabal-version: '3.8.1.0'
+      - run: cabal build --dependencies-only --project-file ghc94.cabal.project all
+      - run: cabal build                     --project-file ghc94.cabal.project all
+      - run: cabal test                      --project-file ghc94.cabal.project all

--- a/ghc94.cabal.project
+++ b/ghc94.cabal.project
@@ -1,0 +1,3 @@
+ packages:
+   proto-lens
+   proto-lens-runtime

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -16,7 +16,7 @@ extra-source-files:
 
 library:
   dependencies:
-    - base >= 4.10 && < 4.17
+    - base >= 4.10 && < 4.18
     - bytestring >= 0.10 && < 0.12
     - containers >= 0.5 && < 0.7
     - deepseq == 1.4.*
@@ -24,7 +24,7 @@ library:
     - lens-family >= 1.2 && < 2.2
     - proto-lens == 0.7.*
     - text >= 1.2 && < 2.1
-    - vector >= 0.11 && < 0.13
+    - vector >= 0.11 && < 0.14
 
 
   reexported-modules:

--- a/proto-lens-runtime/proto-lens-runtime.cabal
+++ b/proto-lens-runtime/proto-lens-runtime.cabal
@@ -53,7 +53,7 @@ library
     , Lens.Family2.Unchecked as Data.ProtoLens.Runtime.Lens.Family2.Unchecked
     , Text.Read as Data.ProtoLens.Runtime.Text.Read
   build-depends:
-      base >=4.10 && <4.17
+      base >=4.10 && <4.18
     , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , deepseq ==1.4.*
@@ -61,5 +61,5 @@ library
     , lens-family >=1.2 && <2.2
     , proto-lens ==0.7.*
     , text >=1.2 && <2.1
-    , vector >=0.11 && <0.13
+    , vector >=0.11 && <0.14
   default-language: Haskell2010

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -34,11 +34,11 @@ library:
     - Data.ProtoLens.Encoding.Parser.Internal
     - Data.ProtoLens.TextFormat.Parser
   dependencies:
-    - base >= 4.10 && < 4.17
+    - base >= 4.10 && < 4.18
     - bytestring >= 0.10 && < 0.12
     - containers >= 0.5 && < 0.7
     - deepseq == 1.4.*
-    - ghc-prim >= 0.4 && < 0.9
+    - ghc-prim >= 0.4 && < 0.10
     - lens-family >= 1.2 && < 2.2
     - parsec == 3.1.*
     - pretty == 1.1.*
@@ -47,7 +47,7 @@ library:
     - tagged == 0.8.*
     - text >= 1.2 && < 2.1
     - transformers >= 0.4 && < 0.6
-    - vector >= 0.11 && < 0.13
+    - vector >= 0.11 && < 0.14
 
 tests:
   parser_test:

--- a/proto-lens/proto-lens.cabal
+++ b/proto-lens/proto-lens.cabal
@@ -58,11 +58,11 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.10 && <4.17
+      base >=4.10 && <4.18
     , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , deepseq ==1.4.*
-    , ghc-prim >=0.4 && <0.9
+    , ghc-prim >=0.4 && <0.10
     , lens-family >=1.2 && <2.2
     , parsec ==3.1.*
     , pretty ==1.1.*
@@ -71,7 +71,7 @@ library
     , tagged ==0.8.*
     , text >=1.2 && <2.1
     , transformers >=0.4 && <0.6
-    , vector >=0.11 && <0.13
+    , vector >=0.11 && <0.14
   default-language: Haskell2010
 
 test-suite growing_test

--- a/proto-lens/src/Data/ProtoLens/Combinators.hs
+++ b/proto-lens/src/Data/ProtoLens/Combinators.hs
@@ -29,7 +29,7 @@ has = (. to isJust)
 
 -- | Sets the provided lens in @a@ to @Nothing@.
 clear :: Setter a a' b (Maybe b') -> a -> a'
-clear = (.~ Nothing)
+clear setter = setter .~ Nothing
 
 -- | Creates a 'Default' and then applies the provided `State` to it.  This is
 -- convenient for creating complicated structures.


### PR DESCRIPTION
With a little subsumption related change, `proto-lens` can be made to work with GHC 9.4.

Other packages have dependency trees that don't support GHC 9.4 yet, so I deliberately made this PR small to just add support to these two packages mentioned in the title.

Tested using

    cabal test -w ghc-9.4.1 --constraint='vector>=0.13'