### PR TITLE
optimize decoding time of string field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 # For "cabal sandbox"
 .cabal-sandbox
 cabal.sandbox.config
+dist-newstyle

--- a/proto-lens-benchmarks/benchmarks/LargeFields.hs
+++ b/proto-lens-benchmarks/benchmarks/LargeFields.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import           Criterion.Main               (Benchmark)
+import           Data.Int                     (Int32)
+import           Data.ProtoLens.BenchmarkUtil (benchmarkMain, protoBenchmark)
+import           Data.ProtoLens.Message       (defMessage)
+import           Data.Text                    (Text)
+import qualified Data.Text                    as Text
+import           Lens.Family                  ((&), (.~))
+
+import           Proto.LargeFields
+import           Proto.LargeFields_Fields
+
+defaultNumValues :: Int
+defaultNumValues = 1024
+
+strValue :: Text
+strValue = "x"
+
+populateFoo :: Int -> Foo
+populateFoo n = defMessage & (strField .~ Text.replicate n strValue)
+
+benchmaker :: Int -> [Benchmark]
+benchmaker size =
+    [ protoBenchmark "10K" (populateFoo $ 10 * size)
+    , protoBenchmark "100K" (populateFoo $ 100 * size)
+    , protoBenchmark "1M" (populateFoo $ 1024 * size)
+    , protoBenchmark "10M" (populateFoo $ 10240 * size)
+    ]
+
+main :: IO ()
+main = benchmarkMain defaultNumValues benchmaker

--- a/proto-lens-benchmarks/benchmarks/large_fields.proto
+++ b/proto-lens-benchmarks/benchmarks/large_fields.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package large_fields;
+
+message Foo {
+  string str_field = 1;
+}

--- a/proto-lens-benchmarks/package.yaml
+++ b/proto-lens-benchmarks/package.yaml
@@ -45,7 +45,8 @@ benchmarks:
     source-dirs: benchmarks
     dependencies:
       - proto-lens-benchmarks
-    other-modules:
+    other-modules: []
+    generated-other-modules:
       - Proto.Nested
       - Proto.Nested_Fields
 
@@ -54,7 +55,8 @@ benchmarks:
     source-dirs: benchmarks
     dependencies:
       - proto-lens-benchmarks
-    other-modules:
+    other-modules: []
+    generated-other-modules:
       - Proto.UnusedFields
       - Proto.UnusedFields_Fields
 
@@ -63,6 +65,17 @@ benchmarks:
     source-dirs: benchmarks
     dependencies:
       - proto-lens-benchmarks
-    other-modules:
+    other-modules: []
+    generated-other-modules:
       - Proto.Packing
       - Proto.Packing_Fields
+
+  large-fields:
+    main: LargeFields.hs
+    source-dirs: benchmarks
+    dependencies:
+      - proto-lens-benchmarks
+    other-modules: []
+    generated-other-modules:
+      - Proto.LargeFields
+      - Proto.LargeFields_Fields

--- a/proto-lens-benchmarks/proto-lens-benchmarks.cabal
+++ b/proto-lens-benchmarks/proto-lens-benchmarks.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.24
+cabal-version: 2.0
 
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
@@ -16,6 +16,7 @@ license:        BSD3
 license-file:   LICENSE
 build-type:     Custom
 extra-source-files:
+    benchmarks/large_fields.proto
     benchmarks/nested.proto
     benchmarks/packing.proto
     benchmarks/unused_fields.proto
@@ -47,10 +48,37 @@ library
     , text
   default-language: Haskell2010
 
+benchmark large-fields
+  type: exitcode-stdio-1.0
+  main-is: LargeFields.hs
+  other-modules:
+      Proto.LargeFields
+      Proto.LargeFields_Fields
+  autogen-modules:
+      Proto.LargeFields
+      Proto.LargeFields_Fields
+  hs-source-dirs:
+      benchmarks
+  ghc-options: -O2 -rtsopts
+  build-depends:
+      base
+    , criterion
+    , deepseq
+    , lens-family
+    , lens-family-core
+    , proto-lens
+    , proto-lens-benchmarks
+    , proto-lens-runtime
+    , text
+  default-language: Haskell2010
+
 benchmark nested
   type: exitcode-stdio-1.0
   main-is: Nested.hs
   other-modules:
+      Proto.Nested
+      Proto.Nested_Fields
+  autogen-modules:
       Proto.Nested
       Proto.Nested_Fields
   hs-source-dirs:
@@ -74,6 +102,9 @@ benchmark packing
   other-modules:
       Proto.Packing
       Proto.Packing_Fields
+  autogen-modules:
+      Proto.Packing
+      Proto.Packing_Fields
   hs-source-dirs:
       benchmarks
   ghc-options: -O2 -rtsopts
@@ -93,6 +124,9 @@ benchmark unused-fields
   type: exitcode-stdio-1.0
   main-is: UnusedFields.hs
   other-modules:
+      Proto.UnusedFields
+      Proto.UnusedFields_Fields
+  autogen-modules:
       Proto.UnusedFields
       Proto.UnusedFields_Fields
   hs-source-dirs:

--- a/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
+++ b/proto-lens/src/Data/ProtoLens/Encoding/Bytes.hs
@@ -22,6 +22,8 @@ module Data.ProtoLens.Encoding.Bytes(
     -- * Bytestrings
     getBytes,
     putBytes,
+    -- * Text
+    getText,
     -- * Integral types
     getVarInt,
     getVarIntH,


### PR DESCRIPTION
## Overview

I noticed a performance issue while I was decoding a large text. After profiling, I found the procedure of the current implementation for the paring string field seems inefficient, especially for a large string.

There are two steps for parsing string(text):

```
getText: getBytes -> decodeUtf8
```

And `getBytes` will call `packCStringLen` to copy the ByteString which seems redundant since `decodeUtf8` also makes a copy.

## Bechmark

### the head

```
benchmarking 10K(10kB)/encode
time                 4.486 μs   (4.472 μs .. 4.498 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.479 μs   (4.467 μs .. 4.493 μs)
std dev              45.67 ns   (35.00 ns .. 62.79 ns)

benchmarking 10K(10kB)/decode/whnf
time                 2.115 μs   (2.109 μs .. 2.124 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.120 μs   (2.116 μs .. 2.129 μs)
std dev              20.97 ns   (16.45 ns .. 27.18 ns)

benchmarking 10K(10kB)/decode/nf
time                 2.150 μs   (2.135 μs .. 2.171 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.181 μs   (2.169 μs .. 2.187 μs)
std dev              28.32 ns   (20.18 ns .. 36.69 ns)
variance introduced by outliers: 11% (moderately inflated)

benchmarking 100K(100kB)/encode
time                 40.90 μs   (40.89 μs .. 40.92 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 40.91 μs   (40.90 μs .. 40.92 μs)
std dev              38.75 ns   (33.94 ns .. 47.13 ns)

benchmarking 100K(100kB)/decode/whnf
time                 19.82 μs   (19.80 μs .. 19.82 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 19.70 μs   (19.63 μs .. 19.76 μs)
std dev              203.1 ns   (162.3 ns .. 226.8 ns)

benchmarking 100K(100kB)/decode/nf
time                 19.59 μs   (19.46 μs .. 19.67 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 19.50 μs   (19.43 μs .. 19.56 μs)
std dev              212.2 ns   (193.2 ns .. 235.7 ns)

benchmarking 1M(1024kB)/encode
time                 480.3 μs   (479.9 μs .. 480.8 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 479.7 μs   (479.3 μs .. 480.2 μs)
std dev              1.519 μs   (1.278 μs .. 1.872 μs)

benchmarking 1M(1024kB)/decode/whnf
time                 326.2 μs   (325.7 μs .. 326.6 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 326.9 μs   (326.3 μs .. 327.4 μs)
std dev              1.928 μs   (1.600 μs .. 2.415 μs)

benchmarking 1M(1024kB)/decode/nf
time                 328.3 μs   (326.1 μs .. 331.0 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 330.2 μs   (328.6 μs .. 331.8 μs)
std dev              5.231 μs   (4.622 μs .. 5.997 μs)

benchmarking 10M(10MB)/encode
time                 2.413 ms   (2.405 ms .. 2.421 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.412 ms   (2.403 ms .. 2.422 ms)
std dev              30.29 μs   (24.00 μs .. 38.44 μs)

benchmarking 10M(10MB)/decode/whnf
time                 2.724 ms   (2.620 ms .. 2.865 ms)
                     0.978 R²   (0.967 R² .. 0.986 R²)
mean                 3.134 ms   (2.969 ms .. 3.559 ms)
std dev              827.4 μs   (511.1 μs .. 1.399 ms)
variance introduced by outliers: 94% (severely inflated)

benchmarking 10M(10MB)/decode/nf
time                 2.861 ms   (2.759 ms .. 2.968 ms)
                     0.981 R²   (0.969 R² .. 0.987 R²)
mean                 3.154 ms   (2.966 ms .. 3.503 ms)
std dev              819.0 μs   (494.4 μs .. 1.381 ms)
variance introduced by outliers: 94% (severely inflated)

Benchmark large-fields: FINISH
```

### with this patch

```
benchmarking 10K(10kB)/encode
time                 4.472 μs   (4.461 μs .. 4.482 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 4.458 μs   (4.454 μs .. 4.463 μs)
std dev              16.15 ns   (12.55 ns .. 22.56 ns)

benchmarking 10K(10kB)/decode/whnf
time                 1.860 μs   (1.858 μs .. 1.862 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.860 μs   (1.856 μs .. 1.865 μs)
std dev              14.20 ns   (9.795 ns .. 21.07 ns)

benchmarking 10K(10kB)/decode/nf
time                 1.862 μs   (1.859 μs .. 1.865 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.865 μs   (1.861 μs .. 1.870 μs)
std dev              14.06 ns   (9.357 ns .. 19.73 ns)

benchmarking 100K(100kB)/encode
time                 41.36 μs   (41.28 μs .. 41.52 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 41.50 μs   (41.33 μs .. 41.83 μs)
std dev              765.3 ns   (207.4 ns .. 1.345 μs)
variance introduced by outliers: 15% (moderately inflated)

benchmarking 100K(100kB)/decode/whnf
time                 17.09 μs   (17.08 μs .. 17.10 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 17.10 μs   (17.09 μs .. 17.10 μs)
std dev              13.88 ns   (11.84 ns .. 18.95 ns)

benchmarking 100K(100kB)/decode/nf
time                 17.14 μs   (17.12 μs .. 17.17 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 17.19 μs   (17.17 μs .. 17.20 μs)
std dev              49.54 ns   (39.75 ns .. 58.73 ns)

benchmarking 1M(1024kB)/encode
time                 483.1 μs   (478.0 μs .. 488.3 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 478.4 μs   (476.8 μs .. 481.3 μs)
std dev              7.085 μs   (5.519 μs .. 8.609 μs)

benchmarking 1M(1024kB)/decode/whnf
time                 175.0 μs   (173.0 μs .. 176.7 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 173.5 μs   (172.7 μs .. 174.8 μs)
std dev              3.202 μs   (2.091 μs .. 4.539 μs)
variance introduced by outliers: 12% (moderately inflated)

benchmarking 1M(1024kB)/decode/nf
time                 173.2 μs   (172.4 μs .. 174.8 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 177.0 μs   (176.0 μs .. 178.0 μs)
std dev              3.297 μs   (2.766 μs .. 3.715 μs)
variance introduced by outliers: 12% (moderately inflated)

benchmarking 10M(10MB)/encode
time                 2.415 ms   (2.411 ms .. 2.419 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 2.408 ms   (2.403 ms .. 2.411 ms)
std dev              13.26 μs   (10.66 μs .. 16.38 μs)

benchmarking 10M(10MB)/decode/whnf
time                 1.792 ms   (1.785 ms .. 1.798 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.787 ms   (1.785 ms .. 1.791 ms)
std dev              9.594 μs   (6.021 μs .. 16.34 μs)

benchmarking 10M(10MB)/decode/nf
time                 1.781 ms   (1.779 ms .. 1.783 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.786 ms   (1.784 ms .. 1.788 ms)
std dev              6.782 μs   (4.895 μs .. 10.42 μs)

Benchmark large-fields: FINISH
```