### PR TITLE
Allow ghc-9.6

### DIFF
--- a/.github/workflows/cabal-ci.yml
+++ b/.github/workflows/cabal-ci.yml
@@ -1,7 +1,7 @@
 on:
   - push
   - pull_request
-name: cabal build with ghc 9.4
+name: cabal build with ghc 9.6
 jobs:
   runhaskell:
     name: cabal test
@@ -12,8 +12,8 @@ jobs:
           submodules: true
       - uses: haskell/actions/setup@v2
         with:
-          ghc-version: '9.4.2'
+          ghc-version: '9.6.1'
           cabal-version: '3.8.1.0'
-      - run: cabal build --dependencies-only --project-file ghc94.cabal.project all
-      - run: cabal build                     --project-file ghc94.cabal.project all
-      - run: cabal test                      --project-file ghc94.cabal.project all
+      - run: cabal build --dependencies-only --project-file ghc96.cabal.project all
+      - run: cabal build                     --project-file ghc96.cabal.project all
+      - run: cabal test                      --project-file ghc96.cabal.project all

--- a/ghc96.cabal.project
+++ b/ghc96.cabal.project
@@ -1,3 +1,4 @@
  packages:
    proto-lens
    proto-lens-runtime
+   proto-lens-optparse

--- a/proto-lens-optparse/package.yaml
+++ b/proto-lens-optparse/package.yaml
@@ -16,7 +16,7 @@ extra-source-files:
 
 dependencies:
   - proto-lens >= 0.1 && < 0.8
-  - base >= 4.10 && < 4.17
+  - base >= 4.10 && < 4.19
   - optparse-applicative >= 0.13 && < 0.18
   - text >= 1.2 && < 2.1
 

--- a/proto-lens-optparse/proto-lens-optparse.cabal
+++ b/proto-lens-optparse/proto-lens-optparse.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -33,7 +33,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.10 && <4.17
+      base >=4.10 && <4.19
     , optparse-applicative >=0.13 && <0.18
     , proto-lens >=0.1 && <0.8
     , text >=1.2 && <2.1

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -16,7 +16,7 @@ extra-source-files:
 
 library:
   dependencies:
-    - base >= 4.10 && < 4.18
+    - base >= 4.10 && < 4.19
     - bytestring >= 0.10 && < 0.12
     - containers >= 0.5 && < 0.7
     - deepseq == 1.4.*

--- a/proto-lens-runtime/proto-lens-runtime.cabal
+++ b/proto-lens-runtime/proto-lens-runtime.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.22
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -53,7 +53,7 @@ library
     , Lens.Family2.Unchecked as Data.ProtoLens.Runtime.Lens.Family2.Unchecked
     , Text.Read as Data.ProtoLens.Runtime.Text.Read
   build-depends:
-      base >=4.10 && <4.18
+      base >=4.10 && <4.19
     , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , deepseq ==1.4.*

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -34,15 +34,15 @@ library:
     - Data.ProtoLens.Encoding.Parser.Internal
     - Data.ProtoLens.TextFormat.Parser
   dependencies:
-    - base >= 4.10 && < 4.18
+    - base >= 4.10 && < 4.19
     - bytestring >= 0.10 && < 0.12
     - containers >= 0.5 && < 0.7
     - deepseq == 1.4.*
-    - ghc-prim >= 0.4 && < 0.10
+    - ghc-prim >= 0.4 && < 0.11
     - lens-family >= 1.2 && < 2.2
     - parsec == 3.1.*
     - pretty == 1.1.*
-    - primitive >= 0.6 && < 0.8
+    - primitive >= 0.6 && < 0.9
     - profunctors >= 5.2 && < 6.0
     - tagged == 0.8.*
     - text >= 1.2 && < 2.1

--- a/proto-lens/proto-lens.cabal
+++ b/proto-lens/proto-lens.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -58,15 +58,15 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.10 && <4.18
+      base >=4.10 && <4.19
     , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , deepseq ==1.4.*
-    , ghc-prim >=0.4 && <0.10
+    , ghc-prim >=0.4 && <0.11
     , lens-family >=1.2 && <2.2
     , parsec ==3.1.*
     , pretty ==1.1.*
-    , primitive >=0.6 && <0.8
+    , primitive >=0.6 && <0.9
     , profunctors >=5.2 && <6.0
     , tagged ==0.8.*
     , text >=1.2 && <2.1


### PR DESCRIPTION
This adds cabal testing for the optparse package, since it doesn't depend on the codegen that doesn't work on GHC 9.2+ yet.
