### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/stack-ci.yml
+++ b/.github/workflows/stack-ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           cat matrix.yaml
           CI_BUILDS=$(yq eval -o json -I 0 matrix.yaml)
-          echo "::set-output name=ci-builds::$CI_BUILDS"
+          echo "ci-builds=$CI_BUILDS" >> $GITHUB_OUTPUT
 
   build:
     name: Build and Test


### PR DESCRIPTION
## Description

Closes #453 

Update `.github/workflows/stack-ci.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=ci-builds::$CI_BUILDS"
```

**TO-BE**

```yaml
echo "ci-builds=$CI_BUILDS" >> $GITHUB_OUTPUT
```
