### PR TITLE
Allow GHC 9.4 in more packages

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,3 @@ packages:
   proto-lens-setup
   proto-lens-tests
   proto-lens-tests-dep
-
-source-repository-package
-  type: git
-  location: https://github.com/google/ghc-source-gen.git
-  tag: master

--- a/cabal.project
+++ b/cabal.project
@@ -11,3 +11,8 @@ packages:
   proto-lens-setup
   proto-lens-tests
   proto-lens-tests-dep
+
+source-repository-package
+  type: git
+  location: https://github.com/google/ghc-source-gen.git
+  tag: master

--- a/discrimination-ieee754/discrimination-ieee754.cabal
+++ b/discrimination-ieee754/discrimination-ieee754.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -31,7 +31,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.10 && <4.17
+      base >=4.10 && <4.18
     , contravariant >=1.3 && <1.6
     , data-binary-ieee754 ==0.4.*
     , discrimination >=0.3 && <0.6
@@ -46,7 +46,7 @@ test-suite test
       test
   build-depends:
       QuickCheck
-    , base >=4.10 && <4.17
+    , base >=4.10 && <4.18
     , contravariant >=1.3 && <1.6
     , data-binary-ieee754 ==0.4.*
     , discrimination >=0.3 && <0.6

--- a/discrimination-ieee754/package.yaml
+++ b/discrimination-ieee754/package.yaml
@@ -12,7 +12,7 @@ license: BSD3
 github: google/proto-lens/discrimination-ieee754
 
 dependencies:
-  - base >= 4.10 && < 4.17
+  - base >= 4.10 && < 4.18
   - data-binary-ieee754 >= 0.4 && < 0.5
   - contravariant >= 1.3 && < 1.6
   - discrimination >= 0.3 && < 0.6

--- a/proto-lens-arbitrary/package.yaml
+++ b/proto-lens-arbitrary/package.yaml
@@ -15,10 +15,10 @@ extra-source-files:
 
 dependencies:
   - proto-lens >= 0.4 && < 0.8
-  - base >= 4.10 && < 4.17
+  - base >= 4.10 && < 4.18
   - bytestring >= 0.10 && < 0.12
   - containers >= 0.5 && < 0.7
-  - text >= 1.2 && < 2.1
+  - text >= 1.2 && < 2.2
   - lens-family >= 1.2 && < 2.2
   - QuickCheck >= 2.8 && < 2.15
 

--- a/proto-lens-arbitrary/proto-lens-arbitrary.cabal
+++ b/proto-lens-arbitrary/proto-lens-arbitrary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -34,10 +34,10 @@ library
       src
   build-depends:
       QuickCheck >=2.8 && <2.15
-    , base >=4.10 && <4.17
+    , base >=4.10 && <4.18
     , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , lens-family >=1.2 && <2.2
     , proto-lens >=0.4 && <0.8
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010

--- a/proto-lens-discrimination/package.yaml
+++ b/proto-lens-discrimination/package.yaml
@@ -15,14 +15,14 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.10 && < 4.17
+    - base >= 4.10 && < 4.18
     - Cabal
     - proto-lens-setup >= 0.4 && < 0.5
 
 build-tools: proto-lens-protoc:proto-lens-protoc
 
 dependencies:
-  - base >= 4.11 && < 4.17
+  - base >= 4.11 && < 4.18
   - bytestring >= 0.10 && < 0.12
   - contravariant >= 1.3 && < 1.6
   - containers >= 0.5 && < 0.7
@@ -30,7 +30,7 @@ dependencies:
   - discrimination-ieee754 == 0.1.*
   - lens-family >= 1.2 && < 2.2
   - proto-lens >= 0.6 && < 0.8
-  - text >= 1.2 && < 2.1
+  - text >= 1.2 && < 2.2
 
 library:
   source-dirs: src

--- a/proto-lens-discrimination/proto-lens-discrimination.cabal
+++ b/proto-lens-discrimination/proto-lens-discrimination.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -29,7 +29,7 @@ source-repository head
 custom-setup
   setup-depends:
       Cabal
-    , base >=4.10 && <4.17
+    , base >=4.10 && <4.18
     , proto-lens-setup ==0.4.*
 
 library
@@ -39,12 +39,14 @@ library
       Data.ProtoLens.Discrimination
   other-modules:
       Paths_proto_lens_discrimination
+  autogen-modules:
+      Paths_proto_lens_discrimination
   hs-source-dirs:
       src
   build-tool-depends:
       proto-lens-protoc:proto-lens-protoc
   build-depends:
-      base >=4.11 && <4.17
+      base >=4.11 && <4.18
     , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , contravariant >=1.3 && <1.6
@@ -52,7 +54,7 @@ library
     , discrimination-ieee754 ==0.1.*
     , lens-family >=1.2 && <2.2
     , proto-lens >=0.6 && <0.8
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010
 
 test-suite discrimination_test
@@ -65,6 +67,7 @@ test-suite discrimination_test
       Proto.Map
       Proto.Map_Fields
   autogen-modules:
+      Paths_proto_lens_discrimination
       Proto.Enum
       Proto.Enum_Fields
       Proto.Map
@@ -76,7 +79,7 @@ test-suite discrimination_test
   build-depends:
       HUnit >=1.3 && <1.7
     , QuickCheck >=2.8 && <2.15
-    , base >=4.11 && <4.17
+    , base >=4.11 && <4.18
     , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , contravariant >=1.3 && <1.6
@@ -90,5 +93,5 @@ test-suite discrimination_test
     , test-framework ==0.8.*
     , test-framework-hunit ==0.3.*
     , test-framework-quickcheck2 ==0.3.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010

--- a/proto-lens-optparse/package.yaml
+++ b/proto-lens-optparse/package.yaml
@@ -17,8 +17,8 @@ extra-source-files:
 dependencies:
   - proto-lens >= 0.1 && < 0.8
   - base >= 4.10 && < 4.19
-  - optparse-applicative >= 0.13 && < 0.18
-  - text >= 1.2 && < 2.1
+  - optparse-applicative >= 0.13 && < 0.19
+  - text >= 1.2 && < 2.2
 
 library:
   source-dirs: src

--- a/proto-lens-optparse/proto-lens-optparse.cabal
+++ b/proto-lens-optparse/proto-lens-optparse.cabal
@@ -34,7 +34,7 @@ library
       src
   build-depends:
       base >=4.10 && <4.19
-    , optparse-applicative >=0.13 && <0.18
+    , optparse-applicative >=0.13 && <0.19
     , proto-lens >=0.1 && <0.8
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -23,18 +23,18 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.10 && < 4.17
+    - base >= 4.10 && < 4.18
     - Cabal
     - proto-lens-setup == 0.4.*
 
 build-tools: proto-lens-protoc:proto-lens-protoc
 
 dependencies:
-  - base >= 4.10 && < 4.17
+  - base >= 4.10 && < 4.18
   - lens-family >= 1.2 && < 2.2
   - proto-lens == 0.7.*
   - proto-lens-runtime == 0.7.*
-  - text >= 1.2 && < 2.1
+  - text >= 1.2 && < 2.2
 
 library:
   source-dirs: src

--- a/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
+++ b/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.35.0.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -36,7 +36,7 @@ source-repository head
 custom-setup
   setup-depends:
       Cabal
-    , base >=4.10 && <4.17
+    , base >=4.10 && <4.18
     , proto-lens-setup ==0.4.*
 
 library
@@ -81,9 +81,9 @@ library
   build-tool-depends:
       proto-lens-protoc:proto-lens-protoc
   build-depends:
-      base >=4.10 && <4.17
+      base >=4.10 && <4.18
     , lens-family >=1.2 && <2.2
     , proto-lens ==0.7.*
     , proto-lens-runtime ==0.7.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -17,7 +17,7 @@ extra-source-files:
   - Changelog.md
 
 dependencies:
-  - base >= 4.9 && < 4.17
+  - base >= 4.9 && < 4.18
   - filepath >= 1.4 && < 1.6
 
 library:
@@ -32,7 +32,7 @@ executables:
     dependencies:
       - bytestring >= 0.10 && < 0.12
       - containers >= 0.5 && < 0.7
-      - ghc >= 8.2 && < 9.3
+      - ghc >= 8.2 && < 9.5
       - ghc-paths == 0.1.*
       - ghc-source-gen >= 0.4 && < 0.5
       - lens-family >= 1.2 && < 2.2
@@ -40,4 +40,4 @@ executables:
       - proto-lens == 0.7.*
       - proto-lens-protoc
       - proto-lens-runtime == 0.7.*
-      - text >= 1.2 && < 2.1
+      - text >= 1.2 && < 2.2

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -34,7 +34,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.9 && <4.17
+      base >=4.9 && <4.18
     , filepath >=1.4 && <1.6
   default-language: Haskell2010
 
@@ -55,11 +55,11 @@ executable proto-lens-protoc
   hs-source-dirs:
       app
   build-depends:
-      base >=4.9 && <4.17
+      base >=4.9 && <4.18
     , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , filepath >=1.4 && <1.6
-    , ghc >=8.2 && <9.3
+    , ghc >=8.2 && <9.5
     , ghc-paths ==0.1.*
     , ghc-source-gen ==0.4.*
     , lens-family >=1.2 && <2.2
@@ -67,5 +67,5 @@ executable proto-lens-protoc
     , proto-lens ==0.7.*
     , proto-lens-protoc
     , proto-lens-runtime ==0.7.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -23,7 +23,7 @@ library:
     - filepath >= 1.4 && < 1.6
     - lens-family >= 1.2 && < 2.2
     - proto-lens == 0.7.*
-    - text >= 1.2 && < 2.1
+    - text >= 1.2 && < 2.2
     - vector >= 0.11 && < 0.14
 
 

--- a/proto-lens-runtime/proto-lens-runtime.cabal
+++ b/proto-lens-runtime/proto-lens-runtime.cabal
@@ -60,6 +60,6 @@ library
     , filepath >=1.4 && <1.6
     , lens-family >=1.2 && <2.2
     , proto-lens ==0.7.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
     , vector >=0.11 && <0.14
   default-language: Haskell2010

--- a/proto-lens-setup/package.yaml
+++ b/proto-lens-setup/package.yaml
@@ -50,10 +50,10 @@ extra-source-files:
 library:
   source-dirs: src
   dependencies:
-    - base >= 4.10 && < 4.17
+    - base >= 4.10 && < 4.18
     - bytestring >= 0.10 && < 0.12
     - containers >= 0.5 && < 0.7
-    - Cabal >= 2.0 && < 3.7
+    - Cabal >= 2.0 && < 3.11
     - deepseq == 1.4.*
     - directory >= 1.2 && < 1.4
     - filepath >= 1.4 && < 1.6
@@ -63,7 +63,7 @@ library:
     # make this a build-tool dependency.
     - proto-lens-protoc >= 0.4 && < 0.8
     - temporary >= 1.2 && < 1.4
-    - text >= 1.2 && < 2.1
+    - text >= 1.2 && < 2.2
   exposed-modules:
     - Data.ProtoLens.Setup
 

--- a/proto-lens-setup/proto-lens-setup.cabal
+++ b/proto-lens-setup/proto-lens-setup.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -68,8 +68,8 @@ library
   hs-source-dirs:
       src
   build-depends:
-      Cabal >=2.0 && <3.7
-    , base >=4.10 && <4.17
+      Cabal >=2.0 && <3.11
+    , base >=4.10 && <4.18
     , bytestring >=0.10 && <0.12
     , containers >=0.5 && <0.7
     , deepseq ==1.4.*
@@ -78,5 +78,5 @@ library
     , process >=1.2 && <1.7
     , proto-lens-protoc >=0.4 && <0.8
     , temporary >=1.2 && <1.4
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -45,7 +45,7 @@ library:
     - primitive >= 0.6 && < 0.9
     - profunctors >= 5.2 && < 6.0
     - tagged == 0.8.*
-    - text >= 1.2 && < 2.1
+    - text >= 1.2 && < 2.2
     - transformers >= 0.4 && < 0.7
     - vector >= 0.11 && < 0.14
 

--- a/proto-lens/proto-lens.cabal
+++ b/proto-lens/proto-lens.cabal
@@ -69,7 +69,7 @@ library
     , primitive >=0.6 && <0.9
     , profunctors >=5.2 && <6.0
     , tagged ==0.8.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
     , transformers >=0.4 && <0.7
     , vector >=0.11 && <0.14
   default-language: Haskell2010


### PR DESCRIPTION
Now that ghc-source-gen supports GHC 9.4, we can support it here too.

Tested using

    cabal test -c 'text>=2.1' -w ghc-9.4

in proto-lens-protoc. With cabal-install v3.10.2.0.

Fixes #447.
