### PR TITLE
Up version bounds, with for support ghc 9.8

### DIFF
--- a/discrimination-ieee754/discrimination-ieee754.cabal
+++ b/discrimination-ieee754/discrimination-ieee754.cabal
@@ -31,7 +31,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.10 && <4.19
+      base >=4.10 && <4.20
     , contravariant >=1.3 && <1.6
     , data-binary-ieee754 ==0.4.*
     , discrimination >=0.3 && <0.6
@@ -46,7 +46,7 @@ test-suite test
       test
   build-depends:
       QuickCheck
-    , base >=4.10 && <4.19
+    , base >=4.10 && <4.20
     , contravariant >=1.3 && <1.6
     , data-binary-ieee754 ==0.4.*
     , discrimination >=0.3 && <0.6

--- a/proto-lens-arbitrary/proto-lens-arbitrary.cabal
+++ b/proto-lens-arbitrary/proto-lens-arbitrary.cabal
@@ -34,9 +34,9 @@ library
       src
   build-depends:
       QuickCheck >=2.8 && <2.15
-    , base >=4.10 && <4.19
-    , bytestring >=0.10 && <0.12
-    , containers >=0.5 && <0.7
+    , base >=4.10 && <4.20
+    , bytestring >=0.10 && <0.13
+    , containers >=0.5 && <0.8
     , lens-family >=1.2 && <2.2
     , proto-lens >=0.4 && <0.8
     , text >=1.2 && <2.2

--- a/proto-lens-discrimination/proto-lens-discrimination.cabal
+++ b/proto-lens-discrimination/proto-lens-discrimination.cabal
@@ -29,7 +29,7 @@ source-repository head
 custom-setup
   setup-depends:
       Cabal
-    , base >=4.10 && <4.19
+    , base >=4.10 && <4.20
     , proto-lens-setup ==0.4.*
 
 library
@@ -46,9 +46,9 @@ library
   build-tool-depends:
       proto-lens-protoc:proto-lens-protoc
   build-depends:
-      base >=4.11 && <4.19
-    , bytestring >=0.10 && <0.12
-    , containers >=0.5 && <0.7
+      base >=4.11 && <4.20
+    , bytestring >=0.10 && <0.13
+    , containers >=0.5 && <0.8
     , contravariant >=1.3 && <1.6
     , discrimination >=0.3 && <0.6
     , discrimination-ieee754 ==0.1.*
@@ -79,9 +79,9 @@ test-suite discrimination_test
   build-depends:
       HUnit >=1.3 && <1.7
     , QuickCheck >=2.8 && <2.15
-    , base >=4.11 && <4.19
-    , bytestring >=0.10 && <0.12
-    , containers >=0.5 && <0.7
+    , base >=4.11 && <4.20
+    , bytestring >=0.10 && <0.13
+    , containers >=0.5 && <0.8
     , contravariant >=1.3 && <1.6
     , discrimination >=0.3 && <0.6
     , discrimination-ieee754 ==0.1.*

--- a/proto-lens-optparse/proto-lens-optparse.cabal
+++ b/proto-lens-optparse/proto-lens-optparse.cabal
@@ -33,7 +33,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.10 && <4.19
+      base >=4.10 && <4.20
     , optparse-applicative >=0.13 && <0.19
     , proto-lens >=0.1 && <0.8
     , text >=1.2 && <2.2

--- a/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
+++ b/proto-lens-protobuf-types/proto-lens-protobuf-types.cabal
@@ -40,7 +40,7 @@ source-repository head
 custom-setup
   setup-depends:
       Cabal >=3 && <3.12
-    , base >=4.10 && <4.19
+    , base >=4.10 && <4.20
     , proto-lens-setup ==0.4.*
 
 library
@@ -101,7 +101,7 @@ library
   build-tool-depends:
       proto-lens-protoc:proto-lens-protoc
   build-depends:
-      base >=4.10 && <4.19
+      base >=4.10 && <4.20
     , lens-family >=1.2 && <2.2
     , proto-lens ==0.7.*
     , proto-lens-runtime ==0.7.*

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -34,7 +34,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.10 && <4.19
+      base >=4.10 && <4.20
     , filepath >=1.4 && <1.6
   default-language: Haskell2010
 
@@ -55,11 +55,11 @@ executable proto-lens-protoc
   hs-source-dirs:
       app
   build-depends:
-      base >=4.10 && <4.19
-    , bytestring >=0.10 && <0.12
-    , containers >=0.5 && <0.7
+      base >=4.10 && <4.20
+    , bytestring >=0.10 && <0.13
+    , containers >=0.5 && <0.8
     , filepath >=1.4 && <1.6
-    , ghc >=8.2 && <9.8
+    , ghc >=8.2 && <9.9
     , ghc-paths ==0.1.*
     , ghc-source-gen ==0.4.*
     , lens-family >=1.2 && <2.2

--- a/proto-lens-runtime/proto-lens-runtime.cabal
+++ b/proto-lens-runtime/proto-lens-runtime.cabal
@@ -53,10 +53,10 @@ library
     , Lens.Family2.Unchecked as Data.ProtoLens.Runtime.Lens.Family2.Unchecked
     , Text.Read as Data.ProtoLens.Runtime.Text.Read
   build-depends:
-      base >=4.10 && <4.19
-    , bytestring >=0.10 && <0.12
-    , containers >=0.5 && <0.7
-    , deepseq ==1.4.*
+      base >=4.10 && <4.20
+    , bytestring >=0.10 && <0.13
+    , containers >=0.5 && <0.8
+    , deepseq >= 1.4 && <1.6
     , filepath >=1.4 && <1.6
     , lens-family >=1.2 && <2.2
     , proto-lens ==0.7.*

--- a/proto-lens-setup/proto-lens-setup.cabal
+++ b/proto-lens-setup/proto-lens-setup.cabal
@@ -69,10 +69,10 @@ library
       src
   build-depends:
       Cabal >=2.0 && <3.12
-    , base >=4.10 && <4.19
-    , bytestring >=0.10 && <0.12
-    , containers >=0.5 && <0.7
-    , deepseq ==1.4.*
+    , base >=4.10 && <4.20
+    , bytestring >=0.10 && <0.13
+    , containers >=0.5 && <0.8
+    , deepseq >=1.4 && <1.6
     , directory >=1.2 && <1.4
     , filepath >=1.4 && <1.6
     , process >=1.2 && <1.7

--- a/proto-lens/proto-lens.cabal
+++ b/proto-lens/proto-lens.cabal
@@ -58,11 +58,11 @@ library
   hs-source-dirs:
       src
   build-depends:
-      base >=4.10 && <4.19
-    , bytestring >=0.10 && <0.12
-    , containers >=0.5 && <0.7
-    , deepseq ==1.4.*
-    , ghc-prim >=0.4 && <0.11
+      base >=4.10 && <4.20
+    , bytestring >=0.10 && <0.13
+    , containers >=0.5 && <0.8
+    , deepseq >=1.4 && <1.6
+    , ghc-prim >=0.4 && <0.12
     , lens-family >=1.2 && <2.2
     , parsec ==3.1.*
     , pretty ==1.1.*


### PR DESCRIPTION
`proto-lens` and `proto-lens-runtime` are compatible with

* `base` 4.19 (ghc 9.8.2 comes with 4.19.1.0)
* `bytestring` 0.12 (ghc 9.8.2 comes with 0.12.1.0)
* `containers` 0.7
* `deepseq` 1.5 (ghc 9.8.2 comes with 1.5.0.0)
* `ghc-prim` 0.11 (ghc 9.8.2 comes with 0.11.0)
* `primitive` 0.9

Closes #459.
Closes #461.