### PR TITLE
Check out protoc v28.x during Stack continuous integration.

### DIFF
--- a/.github/workflows/stack-ci.yml
+++ b/.github/workflows/stack-ci.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
-          version: '3.x'
+          version: '28.x'
 
       # Install Stack without GHC first, so we have an opportunity to cache the
       # Pantry package index.

--- a/.github/workflows/stack-ci.yml
+++ b/.github/workflows/stack-ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       # Installs the recent protoc, for now unpinned to gain some experience
       - name: Install Protoc
-        uses: arduino/setup-protoc@v1
+        uses: arduino/setup-protoc@v3
         with:
           version: '28.x'
 


### PR DESCRIPTION
We will need to use a much more recent version of `protoc` if we wish to test Protobuf Editions files.  Old `protoc` versions will not be able to parse new syntax.  For example, a newer version is required for the tests in https://github.com/chungyc/proto-lens/pull/8 to pass.