### PR TITLE
Custom options for the code generator without extension support (proof of concept)

### DIFF
--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -52,6 +52,7 @@ library:
     - Data.Vector as Data.ProtoLens.Runtime.Data.Vector
     - Data.Vector.Generic as Data.ProtoLens.Runtime.Data.Vector.Generic
     - Data.Vector.Unboxed as Data.ProtoLens.Runtime.Data.Vector.Unboxed
+    - GHC.Generics as Data.ProtoLens.Runtime.GHC.Generics
     - Lens.Family2 as Data.ProtoLens.Runtime.Lens.Family2
     - Lens.Family2.Unchecked as Data.ProtoLens.Runtime.Lens.Family2.Unchecked
     - Text.Read as Data.ProtoLens.Runtime.Text.Read

--- a/proto-lens-runtime/proto-lens-runtime.cabal
+++ b/proto-lens-runtime/proto-lens-runtime.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.22
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -49,6 +49,7 @@ library
     , Data.Vector as Data.ProtoLens.Runtime.Data.Vector
     , Data.Vector.Generic as Data.ProtoLens.Runtime.Data.Vector.Generic
     , Data.Vector.Unboxed as Data.ProtoLens.Runtime.Data.Vector.Unboxed
+    , GHC.Generics as Data.ProtoLens.Runtime.GHC.Generics
     , Lens.Family2 as Data.ProtoLens.Runtime.Lens.Family2
     , Lens.Family2.Unchecked as Data.ProtoLens.Runtime.Lens.Family2.Unchecked
     , Text.Read as Data.ProtoLens.Runtime.Text.Read

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -174,6 +174,18 @@ tests:
       - Proto.Packed
       - Proto.Packed_Fields
 
+  protoc_options_test:
+    main: protoc_options_test.hs
+    source-dirs: tests
+    dependencies:
+      - proto-lens-protobuf-types
+      - proto-lens-tests
+    generated-other-modules:
+      - Proto.HaskellMessageOptions
+      - Proto.HaskellMessageOptions_Fields
+      - Proto.ProtocOptions
+      - Proto.ProtocOptions_Fields
+
   raw_fields_test:
     main: raw_fields_test.hs
     source-dirs: tests

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -706,6 +706,42 @@ test-suite proto3_test
     , pretty
     , proto-lens
     , proto-lens-arbitrary
+    , proto-lens-runtime
+    , proto-lens-tests
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+  default-language: Haskell2010
+
+test-suite protoc_options_test
+  type: exitcode-stdio-1.0
+  main-is: protoc_options_test.hs
+  other-modules:
+      Paths_proto_lens_tests
+      Proto.HaskellMessageOptions
+      Proto.HaskellMessageOptions_Fields
+      Proto.ProtocOptions
+      Proto.ProtocOptions_Fields
+  autogen-modules:
+      Paths_proto_lens_tests
+      Proto.HaskellMessageOptions
+      Proto.HaskellMessageOptions_Fields
+      Proto.ProtocOptions
+      Proto.ProtocOptions_Fields
+  hs-source-dirs:
+      tests
+  build-tool-depends:
+      proto-lens-protoc:proto-lens-protoc
+  build-depends:
+      QuickCheck
+    , base
+    , bytestring
+    , lens-family
+    , pretty
+    , proto-lens
+    , proto-lens-arbitrary
+    , proto-lens-protobuf-types
     , proto-lens-runtime
     , proto-lens-tests
     , tasty

--- a/proto-lens-tests/tests/haskell_message_options.proto
+++ b/proto-lens-tests/tests/haskell_message_options.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+import "google/protobuf/descriptor.proto";
+
+package pb;
+
+extend google.protobuf.MessageOptions {
+  // TODO: Get a real tag number.
+  optional HaskellMessageOptions haskell = 50000;
+}
+
+message HaskellMessageOptions {
+  // stock derived: Eq, Ord
+  // instance: Show, NFData
+  optional string deriving = 1;
+}

--- a/proto-lens-tests/tests/protoc_options.proto
+++ b/proto-lens-tests/tests/protoc_options.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+import "haskell_message_options.proto";
+
+message GenericMessage {
+  option (pb.haskell).deriving = "GHC.Generics.Generic";
+  int32 foo = 1;
+}

--- a/proto-lens-tests/tests/protoc_options_test.hs
+++ b/proto-lens-tests/tests/protoc_options_test.hs
@@ -13,5 +13,5 @@ main = testMain [testNames]
 
 testNames :: TestTree
 testNames = testCase "testNoPackage" $ do
-    (defMessage :: GenericMessage) @=? defMessage
+    -- This will not compile if Generic was not derived.
     ((to . from) (defMessage :: GenericMessage)) @=? (defMessage :: GenericMessage)

--- a/proto-lens-tests/tests/protoc_options_test.hs
+++ b/proto-lens-tests/tests/protoc_options_test.hs
@@ -1,0 +1,17 @@
+module Main where
+
+import Data.ProtoLens
+import GHC.Generics
+import Test.Tasty.HUnit (testCase, (@=?))
+
+import Data.ProtoLens.TestUtil
+
+import Proto.ProtocOptions
+
+main :: IO ()
+main = testMain [testNames]
+
+testNames :: TestTree
+testNames = testCase "testNoPackage" $ do
+    (defMessage :: GenericMessage) @=? defMessage
+    ((to . from) (defMessage :: GenericMessage)) @=? (defMessage :: GenericMessage)


### PR DESCRIPTION
Custom options for the code generator would have to be defined as extensions, but I had an epiphany that we do not actually need to [support extensions] to read extensions.  Let's say we wanted to support custom options like the following:

```proto
message GenericMessage {
  option (pb.haskell).deriving = "Generic";
  int32 foo = 1;
}
```

[support extensions]: https://github.com/google/proto-lens/issues/27

The code generator would already know the extension tag number and type for any custom option it would use.  This is enough to read the contents of relevant extensions from the unknown fields in option messages.  This pull request is a proof of concept of doing this for https://github.com/google/proto-lens/issues/167, which adds a type class to the `deriving` clause.[^not-for-merging] This is to illustrate it could be done for anyone interested, and not intended for eventual merging into the main branch.

[^not-for-merging]: This is extremely limited.  It will only use the option if it is the _only_ option specified for a message type, and it pre-enables extensions and module imports to allow `deriving` for `Generic` to work.  A real implementation would not be so restricted in what other options or unknown fields there may be.  It would also have to decide how to deal with necessary extensions and module imports.  (Automatically based on a built-in list of stock derivations?  Manually by requiring extra extensions and module imports to be specified in other options?  Go crazy and even include the ability to specify derivation strategies?)

For a real implementation of custom options, the probable steps would be:

1. [Grab an extension number] for use by extension fields for Haskell.

2. Implement helper functions to make it easier to extract known types with known tag numbers.

3. Define an appropriate message type for the type of options.  There would be separate message types for file options, message options, [features], etc., which would be extensions of message types in [`descriptor.proto`].[^proto-location]

[^proto-location]: Where should the proto files for such messages be located?  `proto-lens/proto-lens-imports/proto/haskell`?

4. Control the behavior of the code generator according to the custom option.

[Grab an extension number]: https://github.com/protocolbuffers/protobuf/blob/c87ba1e58784aa2e5be941a5af79e2bc8e24d7b6/src/google/protobuf/descriptor.proto#L417-L427

[features]: https://protobuf.dev/editions/implementation/#feature-definition

[`descriptor.proto`]: https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/descriptor.proto

This approach would be moot with proper support of extensions,[^unwanted-extensions] but if anyone is interested in custom options such as [changing the module name] or [controlling type derivations] without waiting for such support, this could be one way to do it.  I might do something like this one day ...

[^unwanted-extensions]: Although given its status as a remnant feature of proto2, maybe we do not _ever_ want to support extensions as a first-class feature.

[changing the module name]: https://github.com/google/proto-lens/issues/235

[controlling type derivations]: https://github.com/google/proto-lens/issues/167
