### PR TITLE
Add HLint workflow.

### DIFF
--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -1,0 +1,12 @@
+name: HLint
+on: [push, pull_request]
+
+jobs:
+  hlint:
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload results to GitHub code scanning.
+      security-events: write
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - uses: haskell-actions/hlint-scan@c81f3176108e60bbce2d5a223e9297a8406deb92 # v1.1.0

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,34 @@
+# HLint configuration file
+# https://github.com/ndmitchell/hlint
+##########################
+
+
+# Ignore generated files.
+- ignore: {within: Proto.Google.Protobuf.Descriptor}
+- ignore: {within: Proto.Google.Protobuf.Descriptor_Fields}
+- ignore: {within: Proto.Google.Protobuf.Compiler.Plugin}
+- ignore: {within: Proto.Google.Protobuf.Compiler.Plugin_Fields}
+
+
+# Warnings currently triggered by existing code.
+- ignore: {name: "Avoid lambda"} # 1 hint
+- ignore: {name: "Eta reduce"} # 1 hint
+- ignore: {name: "Fuse foldr/map"} # 1 hint
+- ignore: {name: "Move brackets to avoid $"} # 8 hints
+- ignore: {name: "Redundant $"} # 23 hints
+- ignore: {name: "Redundant ^."} # 2 hints
+- ignore: {name: "Redundant bracket"} # 13 hints
+- ignore: {name: "Unused LANGUAGE pragma"} # 11 hints
+- ignore: {name: "Use :"} # 2 hints
+- ignore: {name: "Use <$"} # 1 hint
+- ignore: {name: "Use <$>"} # 1 hint
+- ignore: {name: "Use ?~"} # 5 hints
+- ignore: {name: "Use camelCase"} # 3 hints
+- ignore: {name: "Use concatMap"} # 1 hint
+- ignore: {name: "Use fewer imports"} # 2 hints
+- ignore: {name: "Use fmap"} # 10 hints
+- ignore: {name: "Use lambda-case"} # 3 hints
+- ignore: {name: "Use maybe"} # 1 hint
+- ignore: {name: "Use newtype instead of data"} # 1 hint
+- ignore: {name: "Use replicate"} # 1 hint
+- ignore: {name: "Use unless"} # 1 hint


### PR DESCRIPTION
Adds a code scanning workflow using HLint.  Suggestions and warnings are included inline for pull requests and the code scanning dashboard in the security tab.  See https://github.com/haskell-actions/hlint-scan#examples for an example.

This sets up HLint to ignore warnings that would be triggered by the existing code.  We would likely want to enable some of them, for example, `Redundant $` to remove unnecessary `$` operators.  Others could be marked as permanently disabled.  This could be done in future changes.

Resolves #279.