### PR TITLE
Use per-edition feature defaults instead of syntax type to control behavior.

### DIFF
--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
@@ -106,9 +106,9 @@ respectively, which will map to the equivalent feature set compatible with
 proto2 and proto3.
 
 >>> fileEdition $ defMessage & #syntax .~ "proto2"
-EDITION_PROTO2
+Right EDITION_PROTO2
 >>> fileEdition $ defMessage & #syntax .~ "proto3"
-EDITION_PROTO3
+Right EDITION_PROTO3
 
 -}
 fileEdition :: FileDescriptorProto -> Either Text Edition

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Features.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Features.hs
@@ -48,7 +48,7 @@ for a particular edition.
 featuresForEditionFromDefaults :: FeatureSetDefaults -> Edition -> FeatureSet
 featuresForEditionFromDefaults defaults edition
   | (d : _) <- candidates = (d ^. #overridableFeatures) `mergedInto` (d ^. #fixedFeatures)
-  | otherwise = defMessage
+  | otherwise = error $ "Unsupported edition with tag number: " ++ show (fromEnum edition)
   where
     candidates = dropWhile (\d -> d ^. #edition > edition) recentFirst
 


### PR DESCRIPTION
This basically replaces `SyntaxType` distinguishing between proto2 and proto3 with `FeatureSet` controlling individual features in Protobuf Editions.  For example, instead of checking whether the syntax is proto3 when determining whether repeated fields should use packed encoding by default, we check whether `features.repeated_field_encoding` is `PACKED`.  The default feature set [compatible with proto2 and proto3](https://protobuf.dev/editions/features/#preserving) are provided by `protoc` and included in `Data.ProtoLens.Compiler.Defaults`.  The existing tests continue to pass, showing that the features have been determined correctly.

This does not complete support for Protobuf Editions.  This requires the ability to override options in certain scopes, e.g., file scope or field scope, which will be added in https://github.com/chungyc/proto-lens/pull/8.

This is the second to last change required for https://github.com/google/proto-lens/issues/468.