### PR TITLE
Override features defined in enclosed scopes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ will generate the haskell files `Proto/Project/{Foo,Bar}.hs`.
 - Unknown proto2 enum values cause a decoding error, instead of being preserved
   round-trip.
 
+## Protobuf Editions
+
+- `features.utf8_validation = NONE` does not disable UTF-8 validation.
+
+- If more than one field sharing the same message type are
+  in a single message type, and if one of the fields has
+  `features.message_encoding = DELIMITED`, then all of these
+  fields will use `DELIMITED` encoding.
+
 # Troubleshooting
 
 ## Rebuilding

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
@@ -129,9 +129,9 @@ This includes the file-scope options which override
 the feature defaults for an edition.
 -}
 fileFeatures :: FileDescriptorProto -> Either Text FeatureSet
-fileFeatures f =
+fileFeatures f = do
   edition <- fileEdition f
-  features <- featuresForEdition
+  features <- featuresForEdition edition
   return $ case f ^. #options . #maybe'features of
              Just overrides -> overrides `mergedInto` features
              Nothing -> features

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
@@ -659,6 +659,7 @@ enumDef features protoPrefix hsPrefix d = let
     mkHsName n = fromString $ hsPrefix ++ case hsName n of
       ('_':xs) -> 'X':xs
       xs       -> xs
+    -- Include enum-scope feature overrides.
     features' = case d ^. #options . #maybe'features of
       Just overrides -> overrides `mergedInto` features
       Nothing -> features

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Definitions.hs
@@ -72,8 +72,9 @@ import Proto.Google.Protobuf.Descriptor
     , EnumDescriptorProto
     , EnumValueDescriptorProto
     , FeatureSet
-    , FeatureSet'FieldPresence(..)
     , FeatureSet'EnumType(..)
+    , FeatureSet'FieldPresence(..)
+    , FeatureSet'MessageEncoding(..)
     , FeatureSet'RepeatedFieldEncoding(..)
     , FieldDescriptorProto
     , FieldDescriptorProto'Label(..)
@@ -453,8 +454,10 @@ collectGroupFields :: [FieldDescriptorProto] -> GroupMap
 collectGroupFields fs = Map.fromList
     [ (f ^. #typeName, f ^. #number)
     | f <- fs
-    , f ^. #type' == FieldDescriptorProto'TYPE_GROUP
-      ]
+    , (f ^. #type' == FieldDescriptorProto'TYPE_GROUP) ||
+      -- Message fields with DELIMITED encoding are the same as proto2 groups.
+      (f ^. #options . #features . #messageEncoding == FeatureSet'DELIMITED)
+    ]
 
 fieldInfo :: String -> FieldDescriptorProto -> FieldInfo
 fieldInfo hsPrefix f = FieldInfo

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Defaults.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Defaults.hs
@@ -35,11 +35,11 @@ This contains the defaults from editions @LEGACY@ to @EDITION_2023@
 for the native features defined by @google.protobuf.FeatureSet@.
 The message was generated with @protoc@ and translated into a Haskell string:
 
-> $ protoc --edition_defaults_out=defaults.binpb --edition_defaults_minimum=LEGACY --edition_defaults_maximum=2023 google/protobuf/descriptor.proto
+> $ protoc --edition_defaults_out=defaults.binpb --edition_defaults_minimum=PROTO2 --edition_defaults_maximum=2023 google/protobuf/descriptor.proto
 > $ ghci
 > ghci> import Data.ByteString as B
 > ghci> B.readFile "defaults.binpb" >>= print . show
 
 -}
 serializedNativeDefaults :: ByteString
-serializedNativeDefaults = read "\"\\n\\DC3\\CAN\\132\\a\\\"\\NUL*\\f\\b\\SOH\\DLE\\STX\\CAN\\STX \\ETX(\\SOH0\\STX\\n\\DC3\\CAN\\231\\a\\\"\\NUL*\\f\\b\\STX\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH\\n\\DC3\\CAN\\232\\a\\\"\\f\\b\\SOH\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH*\\NUL \\132\\a(\\232\\a\""
+serializedNativeDefaults = read "\"\\n\\DC3\\CAN\\132\\a\\\"\\NUL*\\f\\b\\SOH\\DLE\\STX\\CAN\\STX \\ETX(\\SOH0\\STX\\n\\DC3\\CAN\\231\\a\\\"\\NUL*\\f\\b\\STX\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH\\n\\DC3\\CAN\\232\\a\\\"\\f\\b\\SOH\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH*\\NUL \\230\\a(\\232\\a\""

--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -76,8 +76,8 @@ makeResponse dflags prog request = let
                & #supportedFeatures .~
                  (foldl (.|.) zeroBits $ fmap (toEnum . fromEnum) features)
                -- Do not process actual Protobuf Editions files yet.
-               & #minimumEdition .~ fromIntegral (fromEnum EDITION_LEGACY)
-               & #maximumEdition .~ fromIntegral (fromEnum EDITION_LEGACY)
+               & #minimumEdition .~ fromIntegral (fromEnum EDITION_PROTO2)
+               & #maximumEdition .~ fromIntegral (fromEnum EDITION_2023)
     in case outputFiles of
          Right fs -> preamble & #file .~
            [ defMessage

--- a/proto-lens-tests/package.yaml
+++ b/proto-lens-tests/package.yaml
@@ -56,6 +56,17 @@ tests:
       - Proto.Canonical
       - Proto.Canonical_Fields
 
+  edition2023_test:
+    main: edition2023_test.hs
+    source-dirs: tests
+    dependencies:
+      - proto-lens-tests
+    generated-other-modules:
+      - Proto.Edition2023
+      - Proto.Edition2023_Fields
+      - Proto.Edition2023Fileoptions
+      - Proto.Edition2023Fileoptions_Fields
+
   group_test:
     main: group_test.hs
     source-dirs: tests

--- a/proto-lens-tests/proto-lens-tests.cabal
+++ b/proto-lens-tests/proto-lens-tests.cabal
@@ -234,6 +234,41 @@ test-suite descriptor_test
     , text
   default-language: Haskell2010
 
+test-suite edition2023_test
+  type: exitcode-stdio-1.0
+  main-is: edition2023_test.hs
+  other-modules:
+      Paths_proto_lens_tests
+      Proto.Edition2023
+      Proto.Edition2023_Fields
+      Proto.Edition2023Fileoptions
+      Proto.Edition2023Fileoptions_Fields
+  autogen-modules:
+      Paths_proto_lens_tests
+      Proto.Edition2023
+      Proto.Edition2023_Fields
+      Proto.Edition2023Fileoptions
+      Proto.Edition2023Fileoptions_Fields
+  hs-source-dirs:
+      tests
+  build-tool-depends:
+      proto-lens-protoc:proto-lens-protoc
+  build-depends:
+      QuickCheck
+    , base
+    , bytestring
+    , lens-family
+    , pretty
+    , proto-lens
+    , proto-lens-arbitrary
+    , proto-lens-runtime
+    , proto-lens-tests
+    , tasty
+    , tasty-hunit
+    , tasty-quickcheck
+    , text
+  default-language: Haskell2010
+
 test-suite enum_test
   type: exitcode-stdio-1.0
   main-is: enum_test.hs

--- a/proto-lens-tests/tests/edition2023.proto
+++ b/proto-lens-tests/tests/edition2023.proto
@@ -1,0 +1,74 @@
+edition = "2023";
+
+package edition2023;
+
+// For testing whether the feature defaults are as expected for edition 2023.
+message Defaults {
+  int32 field_presence = 1;  // EXPLICIT
+
+  enum Alternative {
+    ALT_ZERO = 0;
+    ALT_FIRST = 1;
+    ALT_SECOND = 2;
+  }
+  Alternative enum_type = 2;  // OPEN
+
+  repeated int64 repeated_field_encoding = 3;  // PACKED
+
+  string utf8_validation = 4;  // VERIFY
+
+  message Sub {
+    int32 foo = 1;
+  }
+  Sub message_encoding = 5;  // LENGTH_PREFIXED
+}
+
+// For testing explicitly specified features.
+message Features {
+  int32 field_presence_explicit = 1 [features.field_presence = EXPLICIT];
+  int32 field_presence_implicit = 2 [features.field_presence = IMPLICIT];
+
+  message WithRequiredField {
+    int32 field_presence_required = 1 [features.field_presence = LEGACY_REQUIRED];
+    int32 ignored_field = 2;
+  }
+
+  enum Mood {
+    option features.enum_type = CLOSED;
+    MOOD_NEUTRAL = 0;
+    MOOD_HAPPY = 1;
+    MOOD_SAD = 2;
+  }
+  Mood enum_type_closed = 4;
+
+  enum Level {
+    option features.enum_type = OPEN;
+    LEVEL_LOW = 0;
+    LEVEL_MID = 1;
+    LEVEL_HIGH = 2;
+  }
+  Level enum_type_open = 5;
+
+  repeated int64 repeated_field_expanded = 6 [features.repeated_field_encoding = EXPANDED];
+  repeated int64 repeated_field_packed = 7 [features.repeated_field_encoding = PACKED];
+
+  string utf8_validation_none = 8 [features.utf8_validation = NONE];
+  string utf8_validation_verify = 9 [features.utf8_validation = VERIFY];
+
+  message Sub {
+    int32 foo = 1;
+  }
+  Sub message_encoding_delimited = 10 [features.message_encoding = DELIMITED];
+  Sub message_encoding_length_prefixed = 11 [features.message_encoding = LENGTH_PREFIXED];
+
+  // Message encoding is supposed to be determined by field, but proto-lens
+  // currently does it by message type, so the previous LENGTH_PREFIXED field
+  // is still encoded like a group, i.e., with a DELIMITED encoding.
+  // Until this is changed, the following is for a working test where
+  // LENGTH_PREFIXED encoding is explicitly specified.
+  message LengthPrefixedSub {
+    int32 foo = 1;
+  }
+  LengthPrefixedSub message_encoding_length_prefixed_separate = 12
+      [features.message_encoding = LENGTH_PREFIXED];
+}

--- a/proto-lens-tests/tests/edition2023_fileoptions.proto
+++ b/proto-lens-tests/tests/edition2023_fileoptions.proto
@@ -5,10 +5,10 @@ edition = "2023";
 package edition2023_fileoptions;
 
 // In edition 2023, the default for field presence is EXPLICIT.
-option features.field_presence = EXPLICIT;
+option features.field_presence = IMPLICIT;
 
 message FeatureOverrides {
-  // This inherit the EXPLICIT file option.
+  // This inherits the IMPLICIT file option.
   int32 field_presence = 1;
 
   message Sub {

--- a/proto-lens-tests/tests/edition2023_fileoptions.proto
+++ b/proto-lens-tests/tests/edition2023_fileoptions.proto
@@ -1,0 +1,19 @@
+// This is used for testing that file-scope options are passed down.
+
+edition = "2023";
+
+package edition2023_fileoptions;
+
+// In edition 2023, the default for field presence is EXPLICIT.
+option features.field_presence = EXPLICIT;
+
+message FeatureOverrides {
+  // This inherit the EXPLICIT file option.
+  int32 field_presence = 1;
+
+  message Sub {
+    // The option should be passed down through nested message types as well.
+    int32 field_presence = 2;
+  }
+  Sub sub = 3;
+}

--- a/proto-lens-tests/tests/edition2023_test.hs
+++ b/proto-lens-tests/tests/edition2023_test.hs
@@ -1,0 +1,199 @@
+-- Copyright 2024 Google LLC. All Rights Reserved.
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+-- Edition 2023 is a union of proto2 and proto3 features, just with different
+-- defaults and feature specification mechanism.  These tests focus on
+-- these aspects; other tests can comprehensively test the features themselves.
+--
+-- If we trust the feature set defaults for each edition that protoc generates,
+-- then tests for future editions can be limited to testing new features independent
+-- from any edition, and that the new feature is indeed supported by the new edition.
+-- We would not have to comprehensively test all features in every edition.
+
+{-# LANGUAGE OverloadedStrings #-}
+module Main where
+
+import Control.Exception (ErrorCall(..), handle)
+import Data.ProtoLens
+import Lens.Family2 ((&), (.~), (^.))
+import qualified Data.ByteString.Builder as Builder
+import Test.Tasty (testGroup)
+import Test.Tasty.HUnit (assertFailure, testCase, (@=?))
+
+import Proto.Edition2023
+    ( Defaults
+    , Features
+    , Features'WithRequiredField
+    )
+import Proto.Edition2023_Fields
+    ( enumType
+    , enumTypeClosed
+    , enumTypeOpen
+    , foo
+    , fieldPresence
+    , fieldPresenceImplicit
+    , messageEncoding
+    , messageEncodingDelimited
+    , messageEncodingLengthPrefixed
+    , messageEncodingLengthPrefixedSeparate
+    , repeatedFieldEncoding
+    , repeatedFieldExpanded
+    , repeatedFieldPacked
+    , utf8ValidationNone
+    , maybe'fieldPresence
+    , maybe'fieldPresenceExplicit
+    )
+import Proto.Edition2023Fileoptions (FeatureOverrides)
+import qualified Proto.Edition2023Fileoptions_Fields as O
+
+import Data.ProtoLens.TestUtil
+
+defDefaults :: Defaults
+defDefaults = defMessage
+
+defFeatures :: Features
+defFeatures = defMessage
+
+main :: IO ()
+main = testMain
+  [ testGroup "Default features"
+    [ testGroup "field_presence (EXPLICIT)"
+      [ testCase "unset" $
+        Nothing @=? (defDefaults ^. maybe'fieldPresence)
+      , testCase "set" $
+        Just 0 @=? ((defDefaults & fieldPresence .~ 0) ^. maybe'fieldPresence)
+      ]
+
+    , deserializeFrom "enum_type (OPEN)"
+        (Just $ defDefaults & enumType .~ toEnum 5)
+        (tagged 2 $ VarInt 5)
+
+    , serializeTo "repeated_field_encoding (PACKED)"
+        (defDefaults & repeatedFieldEncoding .~ [1,2,3])
+        (vcat [keyedInt "repeated_field_encoding" x | x <- [1,2,3]])
+        (tagged 3 $ Lengthy $ mconcat $ [varInt x | x <- [1,2,3]])
+
+    , deserializeFrom "utf8_validation (VERIFY)"
+        (Nothing :: Maybe Defaults)
+        (tagged 4 $ Lengthy invalidUtf8)
+
+    , serializeTo "message_encoding (LENGTH_PREFIXED)"
+        (defDefaults & messageEncoding .~ (defMessage & foo .~ 42))
+        (braced "message_encoding" $ keyedInt "foo" 42)
+        (tagged 5 $ Lengthy $ tagged 1 $ VarInt 42)
+    ]
+
+  , testGroup "Explicitly specified features"
+    [ testGroup "field_presence"
+      [ testCase "EXPLICIT" $
+        (defFeatures ^. maybe'fieldPresenceExplicit) @=? Nothing
+
+      , testCase "IMPLICIT" $
+        defFeatures @=? (defFeatures & fieldPresenceImplicit .~ 0)
+
+      , deserializeFrom "LEGACY_REQUIRED"
+          (Nothing :: Maybe Features'WithRequiredField)
+          (tagged 2 $ VarInt 10)
+          -- Should not decode if required field with tag 1 is missing.
+      ]
+
+    , testGroup "enum_type"
+      [ testCase "CLOSED" $ do
+          -- Input with an invalid value for the Mood enum.
+          let input = toStrictByteString $ tagged 4 $ VarInt 11
+          -- The message should still be successfully decoded.
+          -- However, the enum will raise an error when actually evaluated.
+          let msg = decodeMessage input :: Either String Features
+          -- There should be an error raised when strictly evaluating the enum.
+          -- This does not match the specification for CLOSED enum types,
+          -- which specifies that the value be an unset default value,
+          -- but this is the current implementation for proto-lens.
+          handle (\(ErrorCallWithLocation _ _) -> return ()) $
+            case msg of
+              -- The decoding should still have succeeded.
+              Left e -> assertFailure $ "failed to decode: " ++ show e
+              -- If the strict evaluation of the invalid enum value calls
+              -- the 'error' function as expected, it will be caught
+              -- as an ErrorCall and the test will pass.
+              --
+              -- If no error is thrown during the strict evaluation,
+              -- then an HUnitFailure will be thrown by assertFailure,
+              -- and the test will fail.
+              Right m -> assertFailure $! show $ m ^. enumTypeClosed
+
+      , deserializeFrom "OPEN"
+          (Just $ defFeatures & enumTypeOpen .~ toEnum 11)
+          (tagged 5 $ VarInt 11)
+      ]
+
+    , testGroup "repeated_field_encoding"
+      [ serializeTo "EXPANDED"
+          (defFeatures & repeatedFieldExpanded .~ [1,2,3])
+          (vcat [keyedInt "repeated_field_expanded" x | x <- [1,2,3]])
+          (mconcat $ [tagged 6 $ VarInt x | x <- [1,2,3]])
+
+      , serializeTo "PACKED"
+          (defFeatures & repeatedFieldPacked .~ [1,2,3])
+          (vcat [keyedInt "repeated_field_packed" x | x <- [1,2,3]])
+          (tagged 7 $ Lengthy $ mconcat [varInt x | x <- [1,2,3]])
+      ]
+
+    , testGroup "utf8_validation"
+      [ const (testCase "NONE (skipped)" (pure ())) $
+        -- We actually cannot disable validation of UTF-8 in strings.
+        -- This could be done by passing down the verification mode
+        -- to the code generator and using decodeUtf8Lenient instead
+        -- when verification is disabled.  This may not be worth it;
+        -- the content with a string containing invalid UTF-8 is undefined,
+        -- and changing it to a bytes field would be a straightforward fix.
+        --
+        -- If this was done, we would stop ignoring this test case.
+        deserializeFrom "NONE"
+          (Just $ defFeatures & utf8ValidationNone .~ "depends on decoding")
+          (tagged 8 $ Lengthy invalidUtf8)
+
+      , deserializeFrom "VERIFY"
+          (Nothing :: Maybe Features)
+          (tagged 9 $ Lengthy invalidUtf8)
+      ]
+
+    , testGroup "message_encoding"
+      [ serializeTo "DELIMITED"
+          (defFeatures & messageEncodingDelimited . foo .~ 7)
+          (braced "message_encoding_delimited" $ keyedInt "foo" 7)
+          (tagged 10 GroupStart <> tagged 1 (VarInt 7) <> tagged 10 GroupEnd)
+
+      , const (testCase "LENGTH_PREFIXED (skipped)" (pure ())) $
+        -- proto-lens sets DELIMITED encoding by message type, not field.
+        -- Full compatability with Protobuf Editions would require it to be
+        -- by field.  However, given the usual use case for DELIMITED encoding,
+        -- where it is to support legacy proto2 groups in which message types
+        -- and fields are tied toggether, this may not be worth fixing.
+        --
+        -- If this was done, we would stop ignoring this test case.
+        serializeTo "LENGTH_PREFIXED"
+          (defFeatures & messageEncodingLengthPrefixed . foo .~ 21)
+          (braced "message_encoding_length_prefixed" $ keyedInt "foo" 21)
+          (tagged 11 $ Lengthy $ tagged 1 $ VarInt 21)
+
+      , serializeTo "LENGTH_PREFIXED (separate message type)"
+          (defFeatures & messageEncodingLengthPrefixedSeparate . foo .~ 31)
+          (braced "message_encoding_length_prefixed_separate" $ keyedInt "foo" 31)
+          (tagged 12 $ Lengthy $ tagged 1 $ VarInt 31)
+      ]
+    ]
+
+  , testGroup "Feature overrides from file options"
+    [ testCase "EXPLICIT field presence passed to field" $
+        ((defMessage :: FeatureOverrides) ^. O.maybe'fieldPresence) @=? Nothing
+
+    , testCase "EXPLICIT field presence passed through nested message type" $
+        ((defMessage :: FeatureOverrides) ^. O.sub . O.maybe'fieldPresence) @=? Nothing
+    ]
+  ]
+
+invalidUtf8 :: Builder.Builder
+invalidUtf8 = Builder.word8 0xc3 <> Builder.word8 0x28

--- a/proto-lens-tests/tests/edition2023_test.hs
+++ b/proto-lens-tests/tests/edition2023_test.hs
@@ -21,7 +21,7 @@ import Data.ProtoLens
 import Lens.Family2 ((&), (.~), (^.))
 import qualified Data.ByteString.Builder as Builder
 import Test.Tasty (testGroup)
-import Test.Tasty.HUnit (assertFailure, testCase, (@=?))
+import Test.Tasty.HUnit (assertFailure, testCase, (@=?), (@?=))
 
 import Proto.Edition2023
     ( Defaults
@@ -89,7 +89,7 @@ main = testMain
   , testGroup "Explicitly specified features"
     [ testGroup "field_presence"
       [ testCase "EXPLICIT" $
-        (defFeatures ^. maybe'fieldPresenceExplicit) @=? Nothing
+        (defFeatures ^. maybe'fieldPresenceExplicit) @?= Nothing
 
       , testCase "IMPLICIT" $
         defFeatures @=? (defFeatures & fieldPresenceImplicit .~ 0)
@@ -187,11 +187,12 @@ main = testMain
     ]
 
   , testGroup "Feature overrides from file options"
-    [ testCase "EXPLICIT field presence passed to field" $
-        ((defMessage :: FeatureOverrides) ^. O.maybe'fieldPresence) @=? Nothing
+    [ testCase "IMPLICIT field presence passed to field" $
+        ((defMessage :: FeatureOverrides) & O.fieldPresence .~ 0) @?= defMessage
 
-    , testCase "EXPLICIT field presence passed through nested message type" $
-        ((defMessage :: FeatureOverrides) ^. O.sub . O.maybe'fieldPresence) @=? Nothing
+    , testCase "IMPLICIT field presence passed through nested message type" $
+        ((defMessage :: FeatureOverrides) & O.sub . O.fieldPresence .~ 0) @?=
+        (defMessage & O.sub .~ defMessage)
     ]
   ]
 


### PR DESCRIPTION
This completes support of Protobuf Editions to the same level that proto-lens supports proto2 and proto3 except for the following, which I do not think are critical bugs:

* `features.utf8_validation = NONE` does not disable UTF-8 validation.

* If more than one field sharing the same message type are in a single message type, and if one of the fields has `features.message_encoding = DELIMITED`, then all of these fields will use `DELIMITED` encoding.

Unevaluated tests are intentionally included despite warnings by HLint so that they are still built and can be easily enabled later if the above are fixed.

Resolves https://github.com/google/proto-lens/issues/468.