### PR TITLE
Enable more hints for HLint.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -17,5 +17,4 @@
 - ignore: {name: "Use <$>"} # 1 hint
 - ignore: {name: "Use ?~"} # 5 hints
 - ignore: {name: "Use lambda-case"} # 3 hints
-- ignore: {name: "Use newtype instead of data"} # 1 hint
 - ignore: {name: "Use replicate"} # 1 hint

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -16,4 +16,5 @@
 - ignore: {name: "Use <$"} # 1 hint
 - ignore: {name: "Use <$>"} # 1 hint
 - ignore: {name: "Use ?~"} # 5 hints
+- ignore: {name: "Use fmap"} # 10 hints
 - ignore: {name: "Use lambda-case"} # 3 hints

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -17,6 +17,5 @@
 - ignore: {name: "Use <$>"} # 1 hint
 - ignore: {name: "Use ?~"} # 5 hints
 - ignore: {name: "Use lambda-case"} # 3 hints
-- ignore: {name: "Use maybe"} # 1 hint
 - ignore: {name: "Use newtype instead of data"} # 1 hint
 - ignore: {name: "Use replicate"} # 1 hint

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -16,7 +16,6 @@
 - ignore: {name: "Use <$"} # 1 hint
 - ignore: {name: "Use <$>"} # 1 hint
 - ignore: {name: "Use ?~"} # 5 hints
-- ignore: {name: "Use concatMap"} # 1 hint
 - ignore: {name: "Use fmap"} # 10 hints
 - ignore: {name: "Use lambda-case"} # 3 hints
 - ignore: {name: "Use maybe"} # 1 hint

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -17,4 +17,3 @@
 - ignore: {name: "Use <$>"} # 1 hint
 - ignore: {name: "Use ?~"} # 5 hints
 - ignore: {name: "Use lambda-case"} # 3 hints
-- ignore: {name: "Use replicate"} # 1 hint

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -13,7 +13,6 @@
 # Warnings currently triggered by existing code.
 - ignore: {name: "Avoid lambda"} # 1 hint
 - ignore: {name: "Eta reduce"} # 1 hint
-- ignore: {name: "Use :"} # 2 hints
 - ignore: {name: "Use <$"} # 1 hint
 - ignore: {name: "Use <$>"} # 1 hint
 - ignore: {name: "Use ?~"} # 5 hints

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -16,7 +16,6 @@
 - ignore: {name: "Use <$"} # 1 hint
 - ignore: {name: "Use <$>"} # 1 hint
 - ignore: {name: "Use ?~"} # 5 hints
-- ignore: {name: "Use camelCase"} # 3 hints
 - ignore: {name: "Use concatMap"} # 1 hint
 - ignore: {name: "Use fmap"} # 10 hints
 - ignore: {name: "Use lambda-case"} # 3 hints

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -16,7 +16,6 @@
 - ignore: {name: "Use <$"} # 1 hint
 - ignore: {name: "Use <$>"} # 1 hint
 - ignore: {name: "Use ?~"} # 5 hints
-- ignore: {name: "Use fmap"} # 10 hints
 - ignore: {name: "Use lambda-case"} # 3 hints
 - ignore: {name: "Use maybe"} # 1 hint
 - ignore: {name: "Use newtype instead of data"} # 1 hint

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -13,7 +13,6 @@
 # Warnings currently triggered by existing code.
 - ignore: {name: "Avoid lambda"} # 1 hint
 - ignore: {name: "Eta reduce"} # 1 hint
-- ignore: {name: "Fuse foldr/map"} # 1 hint
 - ignore: {name: "Use :"} # 2 hints
 - ignore: {name: "Use <$"} # 1 hint
 - ignore: {name: "Use <$>"} # 1 hint

--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Generate/Commented.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Generate/Commented.hs
@@ -2,7 +2,6 @@
 -- | Enables pretty-printing Haddock comments along with top-level declarations.
 module Data.ProtoLens.Compiler.Generate.Commented where
 
-import Data.Maybe (fromMaybe)
 import GHC.SourceGen
 #if MIN_VERSION_ghc(9,0,0)
 import GHC.Utils.Outputable (Outputable(..), SDoc, (<+>), ($+$), vcat, empty, text)
@@ -47,8 +46,10 @@ data CommentedModule = CommentedModule
 
 getModuleName :: CommentedModule -> ModuleName
 getModuleName m =
-    fromMaybe (error "getModuleName: No explicit name")
-        $ fmap unLoc $ hsmodName $ moduleHeader m
+    maybe
+        (error "getModuleName: No explicit name")
+        unLoc
+        (hsmodName $ moduleHeader m)
 
 instance Outputable CommentedModule where
     ppr m =

--- a/proto-lens-setup/src/Data/ProtoLens/Setup.hs
+++ b/proto-lens-setup/src/Data/ProtoLens/Setup.hs
@@ -240,7 +240,7 @@ generateSources root l files = withSystemTempDirectory "protoc-out" $ \tmpDir ->
     -- Generate .hs files for all active components into a single temporary
     -- directory.
     let activeModules = collectActiveModules l
-    let allModules = Set.fromList . concat . map snd $ activeModules
+    let allModules = Set.fromList . concatMap snd $ activeModules
     let usedInComponent f = ModuleName.fromString (protoModuleName f)
                           `Set.member` allModules
     generateProtosWithImports (root : importDirs) tmpDir

--- a/proto-lens-tests/tests/decode_delimited_test.hs
+++ b/proto-lens-tests/tests/decode_delimited_test.hs
@@ -16,8 +16,8 @@ import Proto.DecodeDelimited_Fields
 import System.IO (openBinaryFile, hClose, IOMode(ReadMode))
 import System.IO.Temp (withSystemTempFile)
 
-filename_template :: String
-filename_template = "test_decode_delimited"
+filenameTemplate :: String
+filenameTemplate = "test_decode_delimited"
 
 main :: IO ()
 main = testMain
@@ -28,13 +28,13 @@ main = testMain
     foo1 = defMessage & a .~ 42 & b .~ "hello" :: Foo
     foo2 = defMessage
         & a .~ 43
-        & b .~ (T.pack . take 300 . repeat $ 'x') :: Foo
+        & b .~ (T.pack . replicate 300 $ 'x') :: Foo
 
 testWithMessage :: (Eq msg, Show msg, Message msg) => msg -> IO ()
 testWithMessage msg =
   let bs = runBuilder . buildMessageDelimited $ msg
   in
-    withSystemTempFile filename_template $ \fname h -> do
+    withSystemTempFile filenameTemplate $ \fname h -> do
         B.hPut h bs
         hClose h
         h' <- openBinaryFile fname ReadMode

--- a/proto-lens-tests/tests/proto3_optional_test.hs
+++ b/proto-lens-tests/tests/proto3_optional_test.hs
@@ -117,6 +117,10 @@ instance HasField Foo "maybe'_nonsynth" (Maybe ()) where
     fieldOf _ = lens (const Nothing) const
 #endif
 
+-- Ignore lint suggestions which test generated type names.
+{- HLINT ignore Foo'_tracked -}
+{- HLINT ignore Foo'_nonsynth -}
+
 -- We should not generate a data type or constructor for the synthetic oneof.
 data Foo'_tracked = Foo'Tracked Int32
 #if 0


### PR DESCRIPTION
The specific hints that are enabled are `Fuse foldr/map`, `Use :`, `Use camelCase`, `Use concatMap`, `Use maybe`, `Use newtype instead of data`, and `Use replicate`.

These are the last of the hints I will be enabling, which seem uncontroversial enough.  The rest range from those that I am ambivalent about (e.g., `Eta reduce`; point-free style is fine, but I don't feel that we need to strive to be point-free as much as possible) to those I think are a bad idea (e.g., `Use <$`; it's a generally obscure enough operator that isn't used enough in this code base for it to become naturally familiar with).