### PR TITLE
Switch from haskell/actions/setup to haskell-actions/setup.

### DIFF
--- a/.github/workflows/cabal-ci.yml
+++ b/.github/workflows/cabal-ci.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4.2.0
         with:
           submodules: true
-      - uses: haskell/actions/setup@v2
+      - uses: haskell-actions/setup@dd344bc1cec854a369df8814ce17ef337d6e6170 # v2.7.6
         with:
           ghc-version: '9.6.3'
           cabal-version: '3.10.2.0'

--- a/.github/workflows/stack-ci.yml
+++ b/.github/workflows/stack-ci.yml
@@ -83,7 +83,7 @@ jobs:
       # Install Stack without GHC first, so we have an opportunity to cache the
       # Pantry package index.
       - name: Install Stack
-        uses: haskell/actions/setup@b9d18eaf11de66db1ef1be9ae11830120e7810a0
+        uses: haskell-actions/setup@dd344bc1cec854a369df8814ce17ef337d6e6170 # v2.7.6
         id: setup-stack
         with:
           enable-stack: true


### PR DESCRIPTION
haskell/actions/setup is deprecated because it ran afoul of the best practice of having only one action per repository.  See https://github.com/haskell/actions.