### PR TITLE
Expand support to Protobuf Editions 2024.

### DIFF
--- a/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Defaults.hs
+++ b/proto-lens-protoc/app/Data/ProtoLens/Compiler/Editions/Defaults.hs
@@ -29,15 +29,15 @@ nativeDefaults
 
 {-| Serialized 'FeatureSetDefaults' message containing feature defaults.
 
-This contains the defaults from editions @LEGACY@ to @EDITION_2023@
+This contains the defaults from editions @PROTO2@ to @EDITION_2024@
 for the native features defined by @google.protobuf.FeatureSet@.
 The message was generated with @protoc@ and translated into a Haskell string:
 
-> $ protoc --edition_defaults_out=defaults.binpb --edition_defaults_minimum=PROTO2 --edition_defaults_maximum=2023 google/protobuf/descriptor.proto
+> $ protoc --edition_defaults_out=defaults.binpb --edition_defaults_minimum=PROTO2 --edition_defaults_maximum=2024 google/protobuf/descriptor.proto
 > $ ghci
 > ghci> import Data.ByteString as B
 > ghci> B.readFile "defaults.binpb" >>= print . show
 
 -}
 serializedNativeDefaults :: ByteString
-serializedNativeDefaults = read "\"\\n\\DC3\\CAN\\132\\a\\\"\\NUL*\\f\\b\\SOH\\DLE\\STX\\CAN\\STX \\ETX(\\SOH0\\STX\\n\\DC3\\CAN\\231\\a\\\"\\NUL*\\f\\b\\STX\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH\\n\\DC3\\CAN\\232\\a\\\"\\f\\b\\SOH\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH*\\NUL \\230\\a(\\232\\a\""
+serializedNativeDefaults = read "\"\\n\\DC3\\CAN\\132\\a\\\"\\NUL*\\f\\b\\SOH\\DLE\\STX\\CAN\\STX \\ETX(\\SOH0\\STX\\n\\DC3\\CAN\\231\\a\\\"\\NUL*\\f\\b\\STX\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH\\n\\DC3\\CAN\\232\\a\\\"\\f\\b\\SOH\\DLE\\SOH\\CAN\\SOH \\STX(\\SOH0\\SOH*\\NUL \\230\\a(\\233\\a\""

--- a/proto-lens-protoc/app/protoc-gen-haskell.hs
+++ b/proto-lens-protoc/app/protoc-gen-haskell.hs
@@ -76,7 +76,7 @@ makeResponse dflags prog request = let
                  foldl (.|.) zeroBits (fmap (toEnum . fromEnum) features)
                -- Do not process actual Protobuf Editions files yet.
                & #minimumEdition .~ fromIntegral (fromEnum EDITION_PROTO2)
-               & #maximumEdition .~ fromIntegral (fromEnum EDITION_2023)
+               & #maximumEdition .~ fromIntegral (fromEnum EDITION_2024)
     in case outputFiles of
          Right fs -> preamble & #file .~
            [ defMessage


### PR DESCRIPTION
Protobuf Editions 2024 has [no new generic features](https://github.com/protocolbuffers/protobuf/blob/15487415e4077066d5ebdd4357d045cfaa1771b2/src/google/protobuf/descriptor.proto#L964-L1087), so there is no reason not to accept such files for Haskell.  Editions 2024 is useful for specifying the introduction of language-specific features, and non-Haskell features are not useful to us.