### PR TITLE
Remove ghc-source-gen pin and include the tests into the plan

### DIFF
--- a/ghc9.10.1.cabal.project
+++ b/ghc9.10.1.cabal.project
@@ -1,10 +1,6 @@
- packages:
+packages:
    proto-lens
    proto-lens-runtime
    proto-lens-optparse
 
-source-repository-package
-  type: git
-  location: https://github.com/google/ghc-source-gen
-  tag: 1f0ccfc5a236e349cd48c372deda373121cd9734
-
+tests: True


### PR DESCRIPTION
This fixes the broken build of master:
https://github.com/google/proto-lens/actions/runs/12943350675/job/36173525348