### PR TITLE
Include GitHub authentication token while setting up protoc.

### DIFF
--- a/.github/workflows/stack-ci.yml
+++ b/.github/workflows/stack-ci.yml
@@ -14,6 +14,8 @@
 
 name: Stack CI
 
+permissions: read-all
+
 on:
   push:
     branches:
@@ -79,6 +81,7 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           version: '28.x'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Install Stack without GHC first, so we have an opportunity to cache the
       # Pantry package index.


### PR DESCRIPTION
`arduino/setup-protoc` uses the GitHub API to fetch release data.  Unauthenticated requests have a much lower rate limit, so pass on the GitHub token so that it can issue authenticated requests. Unauthenticated requests with the lower rate limit may cause builds to fail.

Explicitly set the permissions to be read-only, since the workflow does not need write access to the repository, so that accidental or malicious changes cannot be made despite having the authentication token.

#### See also

* Failed workflow: https://github.com/google/proto-lens/actions/runs/13092278602/job/36530330732?pr=502.

* Suggestion by `arduino/setup-protoc` to include the token: https://github.com/arduino/setup-protoc#usage