### PR TITLE
Don't import IsLabels instance in Data.ProtoLens.Any

### DIFF
--- a/proto-lens-protobuf-types/src/Data/ProtoLens/Any.hs
+++ b/proto-lens-protobuf-types/src/Data/ProtoLens/Any.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -24,10 +23,10 @@ import Data.ProtoLens
     , encodeMessage
     , Message(..)
     )
-import Data.ProtoLens.Labels ()
 import Data.Proxy (Proxy(..))
 import Lens.Family2 ((&), (.~), (^.))
 import Proto.Google.Protobuf.Any
+import Proto.Google.Protobuf.Any_Fields (typeUrl, value)
 
 -- | Packs the given message into an 'Any' using the default type URL prefix
 -- "type.googleapis.com".
@@ -41,8 +40,8 @@ googleApisPrefix = "type.googleapis.com"
 packWithPrefix :: forall a . Message a => Text -> a -> Any
 packWithPrefix prefix x =
     defMessage
-        & #typeUrl .~ (prefix <> "/" <> name)
-        & #value .~ encodeMessage x
+        & typeUrl .~ (prefix <> "/" <> name)
+        & value .~ encodeMessage x
   where
     name = messageName (Proxy @a)
 
@@ -64,12 +63,12 @@ instance Exception UnpackError
 -- Ignores the type URL prefix.
 unpack :: forall a . Message a => Any -> Either UnpackError a
 unpack a
-    | expectedName /= snd (Text.breakOnEnd "/" $ a ^. #typeUrl)
+    | expectedName /= snd (Text.breakOnEnd "/" $ a ^. typeUrl)
         = Left DifferentType
               { expectedMessageType = expectedName
-              , actualUrl = a ^. #typeUrl
+              , actualUrl = a ^. typeUrl
               }
-    | otherwise = case decodeMessage (a ^. #value) of
+    | otherwise = case decodeMessage (a ^. value) of
         Left e -> Left $ DecodingError $ Text.pack e
         Right x -> Right x
   where


### PR DESCRIPTION
It infects all users of library with IsLabels instance from Data.ProtoLens.Labels, making usage of other IsLabels instance like generic-lens impossible with #field syntax