### PR TITLE
Update package.yaml files to catch up with cabal files

### DIFF
--- a/discrimination-ieee754/package.yaml
+++ b/discrimination-ieee754/package.yaml
@@ -12,7 +12,7 @@ license: BSD3
 github: google/proto-lens/discrimination-ieee754
 
 dependencies:
-  - base >= 4.10 && < 4.22
+  - base >= 4.10 && < 4.23
   - data-binary-ieee754 >= 0.4 && < 0.5
   - contravariant >= 1.3 && < 1.6
   - discrimination >= 0.3 && < 0.6

--- a/proto-lens-arbitrary/package.yaml
+++ b/proto-lens-arbitrary/package.yaml
@@ -15,12 +15,12 @@ extra-source-files:
 
 dependencies:
   - proto-lens >= 0.4 && < 0.8
-  - base >= 4.10 && < 4.22
+  - base >= 4.10 && < 4.23
   - bytestring >= 0.10 && < 0.13
   - containers >= 0.5 && < 0.9
   - text >= 1.2 && < 2.2
   - lens-family >= 1.2 && < 2.2
-  - QuickCheck >= 2.8 && < 2.18
+  - QuickCheck >= 2.8 && < 2.19
 
 library:
   source-dirs: src

--- a/proto-lens-arbitrary/proto-lens-arbitrary.cabal
+++ b/proto-lens-arbitrary/proto-lens-arbitrary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.3.
 --
 -- see: https://github.com/sol/hpack
 
@@ -38,6 +38,6 @@ library
     , bytestring >=0.10 && <0.13
     , containers >=0.5 && <0.9
     , lens-family >=1.2 && <2.2
-    , proto-lens >=0.4 && <0.9
+    , proto-lens >=0.4 && <0.8
     , text >=1.2 && <2.2
   default-language: Haskell2010

--- a/proto-lens-discrimination/package.yaml
+++ b/proto-lens-discrimination/package.yaml
@@ -15,14 +15,14 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.10 && < 4.22
+    - base >= 4.10 && < 4.23
     - Cabal
     - proto-lens-setup >= 0.4 && < 0.5
 
 build-tools: proto-lens-protoc:proto-lens-protoc
 
 dependencies:
-  - base >= 4.11 && < 4.22
+  - base >= 4.11 && < 4.23
   - bytestring >= 0.10 && < 0.13
   - contravariant >= 1.3 && < 1.6
   - containers >= 0.5 && < 0.9
@@ -46,7 +46,7 @@ tests:
     source-dirs: tests
     dependencies:
       - HUnit >= 1.3 && < 1.7
-      - QuickCheck >= 2.8 && < 2.18
+      - QuickCheck >= 2.8 && < 2.19
       - proto-lens-arbitrary >= 0.1 && < 0.2
       - proto-lens-discrimination
       - proto-lens-runtime >= 0.6 && < 0.8

--- a/proto-lens-discrimination/proto-lens-discrimination.cabal
+++ b/proto-lens-discrimination/proto-lens-discrimination.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.3.
 --
 -- see: https://github.com/sol/hpack
 
@@ -53,7 +53,7 @@ library
     , discrimination >=0.3 && <0.6
     , discrimination-ieee754 ==0.1.*
     , lens-family >=1.2 && <2.2
-    , proto-lens >=0.6 && <0.9
+    , proto-lens >=0.6 && <0.8
     , text >=1.2 && <2.2
   default-language: Haskell2010
 
@@ -86,10 +86,10 @@ test-suite discrimination_test
     , discrimination >=0.3 && <0.6
     , discrimination-ieee754 ==0.1.*
     , lens-family >=1.2 && <2.2
-    , proto-lens >=0.6 && <0.9
+    , proto-lens >=0.6 && <0.8
     , proto-lens-arbitrary ==0.1.*
     , proto-lens-discrimination
-    , proto-lens-runtime >=0.6 && <0.9
+    , proto-lens-runtime >=0.6 && <0.8
     , test-framework ==0.8.*
     , test-framework-hunit ==0.3.*
     , test-framework-quickcheck2 ==0.3.*

--- a/proto-lens-optparse/package.yaml
+++ b/proto-lens-optparse/package.yaml
@@ -16,7 +16,7 @@ extra-source-files:
 
 dependencies:
   - proto-lens >= 0.1 && < 0.8
-  - base >= 4.10 && < 4.22
+  - base >= 4.10 && < 4.23
   - optparse-applicative >= 0.13 && < 0.20
   - text >= 1.2 && < 2.2
 

--- a/proto-lens-optparse/proto-lens-optparse.cabal
+++ b/proto-lens-optparse/proto-lens-optparse.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.37.0.
+-- This file has been generated from package.yaml by hpack version 0.39.3.
 --
 -- see: https://github.com/sol/hpack
 
@@ -35,6 +35,6 @@ library
   build-depends:
       base >=4.10 && <4.23
     , optparse-applicative >=0.13 && <0.20
-    , proto-lens >=0.1 && <0.9
+    , proto-lens >=0.1 && <0.8
     , text >=1.2 && <2.2
   default-language: Haskell2010

--- a/proto-lens-protobuf-types/package.yaml
+++ b/proto-lens-protobuf-types/package.yaml
@@ -27,14 +27,14 @@ extra-source-files:
 
 custom-setup:
   dependencies:
-    - base >= 4.10 && < 4.22
+    - base >= 4.10 && < 4.23
     - Cabal >= 3 && < 3.17
     - proto-lens-setup == 0.4.*
 
 build-tools: proto-lens-protoc:proto-lens-protoc
 
 dependencies:
-  - base >= 4.10 && < 4.22
+  - base >= 4.10 && < 4.23
   - lens-family >= 1.2 && < 2.2
   - proto-lens == 0.7.*
   - proto-lens-runtime == 0.7.*

--- a/proto-lens-protoc/package.yaml
+++ b/proto-lens-protoc/package.yaml
@@ -6,7 +6,7 @@ description: >
   can be used with the proto-lens package.
  
   The library component of this package contains compiler code (namely
-  Data.ProtoLens.Compiler.*) is not guaranteed to have stable APIs.'
+  Data.ProtoLens.Compiler.*) is not guaranteed to have stable APIs.
 category: Data
 author: Judah Jacobson
 maintainer: proto-lens@googlegroups.com
@@ -17,7 +17,7 @@ extra-source-files:
   - Changelog.md
 
 dependencies:
-  - base >= 4.10 && < 4.22
+  - base >= 4.10 && < 4.23
   - filepath >= 1.4 && < 1.6
 
 library:
@@ -32,7 +32,7 @@ executables:
     dependencies:
       - bytestring >= 0.10 && < 0.13
       - containers >= 0.5 && < 0.9
-      - ghc >= 8.2 && < 9.13
+      - ghc >= 8.2 && < 9.15
       - ghc-paths == 0.1.*
       - ghc-source-gen >= 0.4 && < 0.5
       - lens-family >= 1.2 && < 2.2

--- a/proto-lens-protoc/proto-lens-protoc.cabal
+++ b/proto-lens-protoc/proto-lens-protoc.cabal
@@ -8,7 +8,7 @@ name:           proto-lens-protoc
 version:        0.9.0.0
 synopsis:       Protocol buffer compiler for the proto-lens library.
 description:    Turn protocol buffer files (.proto) into Haskell files (.hs) which can be used with the proto-lens package.
-                The library component of this package contains compiler code (namely Data.ProtoLens.Compiler.*) is not guaranteed to have stable APIs.'
+                The library component of this package contains compiler code (namely Data.ProtoLens.Compiler.*) is not guaranteed to have stable APIs.
 category:       Data
 homepage:       https://github.com/google/proto-lens#readme
 bug-reports:    https://github.com/google/proto-lens/issues

--- a/proto-lens-runtime/package.yaml
+++ b/proto-lens-runtime/package.yaml
@@ -16,7 +16,7 @@ extra-source-files:
 
 library:
   dependencies:
-    - base >= 4.10 && < 4.22
+    - base >= 4.10 && < 4.23
     - bytestring >= 0.10 && < 0.13
     - containers >= 0.5 && < 0.9
     - deepseq >= 1.4 && <1.6

--- a/proto-lens-setup/package.yaml
+++ b/proto-lens-setup/package.yaml
@@ -50,7 +50,7 @@ extra-source-files:
 library:
   source-dirs: src
   dependencies:
-    - base >= 4.10 && < 4.22
+    - base >= 4.10 && < 4.23
     - bytestring >= 0.10 && < 0.13
     - containers >= 0.5 && < 0.9
     - Cabal >= 3 && < 3.17

--- a/proto-lens/package.yaml
+++ b/proto-lens/package.yaml
@@ -34,7 +34,7 @@ library:
     - Data.ProtoLens.Encoding.Parser.Internal
     - Data.ProtoLens.TextFormat.Parser
   dependencies:
-    - base >= 4.10 && < 4.22
+    - base >= 4.10 && < 4.23
     - bytestring >= 0.10 && < 0.13
     - containers >= 0.5 && < 0.9
     - deepseq >=1.4 && <1.6

--- a/proto-lens/proto-lens.cabal
+++ b/proto-lens/proto-lens.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.39.1.
+-- This file has been generated from package.yaml by hpack version 0.39.3.
 --
 -- see: https://github.com/sol/hpack
 
@@ -59,7 +59,7 @@ library
       src
   build-depends:
       base >=4.10 && <4.23
-    , bytestring >=0.10 && <0.14
+    , bytestring >=0.10 && <0.13
     , containers >=0.5 && <0.9
     , deepseq >=1.4 && <1.6
     , ghc-prim >=0.4 && <0.14

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-resolver: nightly-2024-04-06
+resolver: nightly-2026-02-17
 
 packages:
 - discrimination-ieee754
@@ -23,6 +23,6 @@ packages:
 ghc-options:
   "$locals": -Wall -Werror
 
-# Remove once the version is in stackage.
+# Required for older version lts builds.
 extra-deps:
 - ghc-source-gen-0.4.7.0


### PR DESCRIPTION
They happened to stay behind in recent updates. Fixed up inter-package inconsistencies in proto-lens version limits. There's no 0.8 version of the packages so < 0.9 was a mistake.

Updated the resolver in stack.yaml.